### PR TITLE
allow additional properties flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,16 +209,7 @@ Records are converted to `{ "type": "object", "properties": {...}, "required": [
 
 The fields of type `option` are not included in the `required` list.
 
-By default, additional properties are not allowed in objects. To allow additional properties, you can use either of these attribute annotations:
-
-```ocaml
-type person = {
-  name : string;
-  age : int;
-}
-[@@deriving jsonschema]
-[@@allow_additional_fields]
-```
+By default, additionalProperties are not allowed in objects. To allow additionalProperties, use the `allow_extra_fields` attribute:
 
 ```ocaml
 type company = {
@@ -226,10 +217,10 @@ type company = {
   employees : int;
 }
 [@@deriving jsonschema]
-[@@jsonschema.allow_additional_fields]
+[@@jsonschema.allow_extra_fields]
 ```
 
-Both annotations will generate a schema with `"additionalProperties": true`, allowing for additional fields not defined in the record:
+This annotation will generate a schema with `"additionalProperties": true`, allowing for additional fields not defined in the record:
 
 ```json
 {
@@ -253,7 +244,7 @@ type t = {
 [@@deriving jsonschema]
 ```
 
-### Inline Records in Variants
+#### Inline Records in Variants
 
 You can use the `[@jsonschema.allow_extra_fields]` attribute on a constructor with an inline record to allow additional fields in that record:
 
@@ -306,7 +297,7 @@ This will generate a schema that allows additional fields for the `User` variant
 }
 ```
 
-### References
+#### References
 
 Rather than inlining the definition of a type it is possible to use a [json schema `$ref`](https://json-schema.org/understanding-json-schema/structuring#dollarref) using the `[@ref "name"]` attribute. In such a case, the type definition must be passed to `Ppx_deriving_jsonschema_runtime.json_schema` as a parameter.
 

--- a/README.md
+++ b/README.md
@@ -205,9 +205,43 @@ type t =
 
 #### Records
 
-Records are converted to `{ "type": "object", "properties": {...}, "required": [...] }`.
+Records are converted to `{ "type": "object", "properties": {...}, "required": [...], "additionalProperties": false }`.
 
 The fields of type `option` are not included in the `required` list.
+
+By default, additional properties are not allowed in objects. To allow additional properties, you can use either of these attribute annotations:
+
+```ocaml
+type person = {
+  name : string;
+  age : int;
+}
+[@@deriving jsonschema]
+[@@allow_additional_fields]
+```
+
+```ocaml
+type company = {
+  name : string;
+  employees : int;
+}
+[@@deriving jsonschema]
+[@@jsonschema.allow_additional_fields]
+```
+
+Both annotations will generate a schema with `"additionalProperties": true`, allowing for additional fields not defined in the record:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "age": { "type": "integer" }
+  },
+  "required": [ "name", "age" ],
+  "additionalProperties": true
+}
+```
 
 When the JSON object keys differ from the ocaml field names, users can specify the corresponding JSON key implicitly using `[@key "field"]`, for example:
 

--- a/dune-project
+++ b/dune-project
@@ -30,6 +30,8 @@
   dune
   (ppxlib
    (>= "0.24.0"))
+  (melange-json :with-test)
+  (melange-json-native :with-test)
   (yojson :with-test)
   (ppx_expect :with-test)
   (ocamlformat :with-dev-setup)

--- a/ppx_deriving_jsonschema.opam
+++ b/ppx_deriving_jsonschema.opam
@@ -18,6 +18,8 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "3.16"}
   "ppxlib" {>= "0.24.0"}
+  "melange-json" {with-test}
+  "melange-json-native" {with-test}
   "yojson" {with-test}
   "ppx_expect" {with-test}
   "ocamlformat" {with-dev-setup}

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -9,6 +9,7 @@ type config = {
   polymorphic_variant_tuple : bool;
     (** Preserve the implicit tuple in a polymorphic variant.
         This option breaks compatibility with yojson derivers. *)
+  allow_additional_properties : bool;  (** annotate objects with additioanlProperties:true field *)
 }
 
 let deriver_name = "jsonschema"
@@ -42,7 +43,7 @@ let attributes =
   ]
 
 (* let args () = Deriving.Args.(empty) *)
-let args () = Deriving.Args.(empty +> flag "variant_as_string" +> flag "polymorphic_variant_tuple")
+let args () = Deriving.Args.(empty +> flag "variant_as_string" +> flag "polymorphic_variant_tuple" +> flag "allow_additional_properties")
 
 let deps = []
 
@@ -236,12 +237,17 @@ let object_ ~loc ~config fields =
         "type", `String "object";
         "properties", `Assoc [%e elist ~loc fields];
         "required", `List [%e elist ~loc required];
+        "additionalProperties", `Bool [%e ebool ~loc config.allow_additional_properties]
       ]]
 
-let derive_jsonschema ~ctxt ast flag_variant_as_string flag_polymorphic_variant_tuple =
+let derive_jsonschema ~ctxt ast flag_variant_as_string flag_polymorphic_variant_tuple flag_additional_properties =
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
   let config =
-    { variant_as_string = flag_variant_as_string; polymorphic_variant_tuple = flag_polymorphic_variant_tuple }
+    {
+      variant_as_string = flag_variant_as_string;
+      polymorphic_variant_tuple = flag_polymorphic_variant_tuple;
+      allow_additional_properties = flag_additional_properties;
+    }
   in
   match ast with
   | _, [ { ptype_name = { txt = type_name; _ }; ptype_kind = Ptype_variant variants; _ } ] ->

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -43,7 +43,9 @@ let attributes =
   ]
 
 (* let args () = Deriving.Args.(empty) *)
-let args () = Deriving.Args.(empty +> flag "variant_as_string" +> flag "polymorphic_variant_tuple" +> flag "allow_additional_properties")
+let args () =
+  Deriving.Args.(
+    empty +> flag "variant_as_string" +> flag "polymorphic_variant_tuple" +> flag "allow_additional_properties")
 
 let deps = []
 
@@ -237,7 +239,7 @@ let object_ ~loc ~config fields =
         "type", `String "object";
         "properties", `Assoc [%e elist ~loc fields];
         "required", `List [%e elist ~loc required];
-        "additionalProperties", `Bool [%e ebool ~loc config.allow_additional_properties]
+        "additionalProperties", `Bool [%e ebool ~loc config.allow_additional_properties];
       ]]
 
 let derive_jsonschema ~ctxt ast flag_variant_as_string flag_polymorphic_variant_tuple flag_additional_properties =

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -259,10 +259,7 @@ let derive_jsonschema ~ctxt ast flag_variant_as_string flag_polymorphic_variant_
     | _ -> false
   in
   let config =
-    {
-      variant_as_string = flag_variant_as_string;
-      polymorphic_variant_tuple = flag_polymorphic_variant_tuple;
-    }
+    { variant_as_string = flag_variant_as_string; polymorphic_variant_tuple = flag_polymorphic_variant_tuple }
   in
   match ast with
   | _, [ { ptype_name = { txt = type_name; _ }; ptype_kind = Ptype_variant variants; _ } ] ->
@@ -276,8 +273,8 @@ let derive_jsonschema ~ctxt ast flag_variant_as_string flag_polymorphic_variant_
           in
           match pcd_args with
           | Pcstr_record label_declarations ->
-            let allow_extra_fields =  Attribute.get cd_jsonschema_allow_extra_fields var |> Option.is_some in
-            let typs = [ object_ ~loc ~config label_declarations allow_extra_fields] in
+            let allow_extra_fields = Attribute.get cd_jsonschema_allow_extra_fields var |> Option.is_some in
+            let typs = [ object_ ~loc ~config label_declarations allow_extra_fields ] in
             `Tag (name, typs)
           | Pcstr_tuple typs ->
             let types = List.map (type_of_core ~config) typs in

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -279,11 +279,8 @@ let derive_jsonschema ~ctxt ast flag_variant_as_string flag_polymorphic_variant_
           match pcd_args with
           | Pcstr_record label_declarations ->
             let has_allow_extra_fields = Attribute.get constructor_allow_extra_fields var |> Option.is_some in
-            let inline_config = 
-              if has_allow_extra_fields then
-                { config with allow_extra_properties = true }
-              else
-                config
+            let inline_config =
+              if has_allow_extra_fields then { config with allow_extra_properties = true } else config
             in
             let typs = [ object_ ~loc ~config:inline_config label_declarations ] in
             `Tag (name, typs)

--- a/test/dune
+++ b/test/dune
@@ -19,10 +19,10 @@
 (library
  (name test)
  (modules test)
- (libraries yojson)
+ (libraries yojson melange-json)
  (inline_tests)
  (preprocess
-  (pps ppx_deriving_jsonschema ppx_expect)))
+  (pps ppx_deriving_jsonschema ppx_expect melange-json-native.ppx)))
 
 (executable
  (name generate_schemas)

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -119,8 +119,8 @@ include
         ("properties",
           (`Assoc
              [("m2", Mod1.Mod2.m_2_jsonschema); ("m", Mod1.m_1_jsonschema)]));
-        ("required", (`List [`String "m2"; `String "m"]))][@@warning
-                                                            "-32-39"]
+        ("required", (`List [`String "m2"; `String "m"]));
+        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "with_modules" =
@@ -624,7 +624,8 @@ include
              `String "a";
              `String "comment";
              `String "kind_f";
-             `String "date"]))][@@warning "-32-39"]
+             `String "date"]));
+        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "event" =
@@ -1308,7 +1309,8 @@ include
       `Assoc
         [("type", (`String "object"));
         ("properties", (`Assoc [("m", Mod1.m_1_jsonschema)]));
-        ("required", (`List [`String "m"]))][@@warning "-32-39"]
+        ("required", (`List [`String "m"]));
+        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "using_m" =
@@ -1437,8 +1439,8 @@ include
              [("scores_ref",
                 (`Assoc [("$ref", (`String "#/$defs/numbers"))]));
              ("player", (`Assoc [("type", (`String "string"))]))]));
-        ("required", (`List [`String "scores_ref"; `String "player"]))]
-      [@@warning "-32-39"]
+        ("required", (`List [`String "scores_ref"; `String "player"]));
+        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "player_scores" =
@@ -1475,8 +1477,8 @@ include
              ("city", (`Assoc [("type", (`String "string"))]));
              ("street", (`Assoc [("type", (`String "string"))]))]));
         ("required",
-          (`List [`String "zip"; `String "city"; `String "street"]))]
-      [@@warning "-32-39"]
+          (`List [`String "zip"; `String "city"; `String "street"]));
+        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type t = {
   name: string ;
@@ -1495,8 +1497,8 @@ include
              ("age", (`Assoc [("type", (`String "integer"))]));
              ("name", (`Assoc [("type", (`String "string"))]))]));
         ("required",
-          (`List [`String "address"; `String "age"; `String "name"]))]
-      [@@warning "-32-39"]
+          (`List [`String "address"; `String "age"; `String "name"]));
+        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "t" =
@@ -1552,7 +1554,8 @@ include
              `String "work_address";
              `String "home_address";
              `String "age";
-             `String "name"]))][@@warning "-32-39"]
+             `String "name"]));
+        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "tt" =

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -1650,6 +1650,97 @@ include
       "anyOf": [ { "const": "A" }, { "const": "B" } ]
     }
     |}]]
+type inline_record_with_extra_fields =
+  | User of {
+  name: string ;
+  email: string } [@jsonschema.allow_extra_fields ]
+  | Guest of {
+  ip: string } [@@deriving jsonschema]
+include
+  struct
+    let inline_record_with_extra_fields_jsonschema =
+      `Assoc
+        [("anyOf",
+           (`List
+              [`Assoc
+                 [("type", (`String "array"));
+                 ("prefixItems",
+                   (`List
+                      [`Assoc [("const", (`String "User"))];
+                      `Assoc
+                        [("type", (`String "object"));
+                        ("properties",
+                          (`Assoc
+                             [("email",
+                                (`Assoc [("type", (`String "string"))]));
+                             ("name",
+                               (`Assoc [("type", (`String "string"))]))]));
+                        ("required",
+                          (`List [`String "email"; `String "name"]));
+                        ("additionalProperties", (`Bool true))]]));
+                 ("unevaluatedItems", (`Bool false));
+                 ("minItems", (`Int 2));
+                 ("maxItems", (`Int 2))];
+              `Assoc
+                [("type", (`String "array"));
+                ("prefixItems",
+                  (`List
+                     [`Assoc [("const", (`String "Guest"))];
+                     `Assoc
+                       [("type", (`String "object"));
+                       ("properties",
+                         (`Assoc
+                            [("ip", (`Assoc [("type", (`String "string"))]))]));
+                       ("required", (`List [`String "ip"]));
+                       ("additionalProperties", (`Bool false))]]));
+                ("unevaluatedItems", (`Bool false));
+                ("minItems", (`Int 2));
+                ("maxItems", (`Int 2))]]))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "inline_record_with_extra_fields" =
+    print_schema inline_record_with_extra_fields_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "User" },
+            {
+              "type": "object",
+              "properties": {
+                "email": { "type": "string" },
+                "name": { "type": "string" }
+              },
+              "required": [ "email", "name" ],
+              "additionalProperties": true
+            }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        },
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "Guest" },
+            {
+              "type": "object",
+              "properties": { "ip": { "type": "string" } },
+              "required": [ "ip" ],
+              "additionalProperties": false
+            }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    }
+    |}]]
 type variant_with_payload =
   | A of int 
   | B 
@@ -2242,7 +2333,7 @@ include
               "type": "object",
               "properties": { "x": { "type": "integer" } },
               "required": [ "x" ],
-              "additionalProperties": false
+              "additionalProperties": true
             }
           },
           "required": [ "obj2" ],

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -168,7 +168,8 @@ include
           ]
         }
       },
-      "required": [ "m2", "m" ]
+      "required": [ "m2", "m" ],
+      "additionalProperties": false
     }
     |}]]
 type kind =
@@ -700,7 +701,8 @@ include
       "required": [
         "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l", "a",
         "comment", "kind_f", "date"
-      ]
+      ],
+      "additionalProperties": false
     }
     |}]]
 type events = event list[@@deriving jsonschema]
@@ -785,7 +787,8 @@ include
         "required": [
           "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l",
           "a", "comment", "kind_f", "date"
-        ]
+        ],
+        "additionalProperties": false
       }
     }
     |}]]
@@ -876,7 +879,8 @@ include
           "required": [
             "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l",
             "a", "comment", "kind_f", "date"
-          ]
+          ],
+          "additionalProperties": false
         }
       }
     }
@@ -969,7 +973,8 @@ include
           "required": [
             "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l",
             "a", "comment", "kind_f", "date"
-          ]
+          ],
+          "additionalProperties": false
         },
         { "type": "string" }
       ],
@@ -1064,7 +1069,8 @@ include
             "required": [
               "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
               "l", "a", "comment", "kind_f", "date"
-            ]
+            ],
+            "additionalProperties": false
           },
           { "type": "string" }
         ],
@@ -1168,7 +1174,8 @@ include
             "required": [
               "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
               "l", "a", "comment", "kind_f", "date"
-            ]
+            ],
+            "additionalProperties": false
           },
           { "type": "integer" }
         ],
@@ -1262,7 +1269,8 @@ include
           "required": [
             "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l",
             "a", "comment", "kind_f", "date"
-          ]
+          ],
+          "additionalProperties": false
         }
       }
     }
@@ -1340,7 +1348,8 @@ include
           ]
         }
       },
-      "required": [ "m" ]
+      "required": [ "m" ],
+      "additionalProperties": false
     }
     |}]]
 type 'param2 poly2 =
@@ -1460,8 +1469,10 @@ include
         "scores_ref": { "$ref": "#/$defs/numbers" },
         "player": { "type": "string" }
       },
-      "required": [ "scores_ref", "player" ]
-    } |}]]
+      "required": [ "scores_ref", "player" ],
+      "additionalProperties": false
+    }
+    |}]]
 type address = {
   street: string ;
   city: string ;
@@ -1516,14 +1527,17 @@ include
             "city": { "type": "string" },
             "street": { "type": "string" }
           },
-          "required": [ "zip", "city", "street" ]
+          "required": [ "zip", "city", "street" ],
+          "additionalProperties": false
         },
         "email": { "type": "string" },
         "age": { "type": "integer" },
         "name": { "type": "string" }
       },
-      "required": [ "address", "age", "name" ]
-    } |}]]
+      "required": [ "address", "age", "name" ],
+      "additionalProperties": false
+    }
+    |}]]
 type tt =
   {
   name: string ;
@@ -1573,7 +1587,8 @@ include
             "city": { "type": "string" },
             "street": { "type": "string" }
           },
-          "required": [ "zip", "city", "street" ]
+          "required": [ "zip", "city", "street" ],
+          "additionalProperties": false
         }
       },
       "type": "object",
@@ -1587,8 +1602,10 @@ include
       },
       "required": [
         "retreat_address", "work_address", "home_address", "age", "name"
-      ]
-    } |}]]
+      ],
+      "additionalProperties": false
+    }
+    |}]]
 type c = char[@@deriving jsonschema]
 include
   struct
@@ -2173,5 +2190,81 @@ include
           "maxItems": 2
         }
       ]
+    }
+    |}]]
+type allow_additional_properties = {
+  allow: bool }[@@deriving jsonschema ~allow_additional_properties]
+include
+  struct
+    let allow_additional_properties_jsonschema =
+      `Assoc
+        [("type", (`String "object"));
+        ("properties",
+          (`Assoc [("allow", (`Assoc [("type", (`String "boolean"))]))]));
+        ("required", (`List [`String "allow"]));
+        ("additionalProperties", (`Bool true))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "allow_additional_properties" =
+    print_schema allow_additional_properties_jsonschema; [%expect {||}]]
+type obj2 = {
+  x: int }[@@deriving jsonschema]
+include
+  struct
+    let obj2_jsonschema =
+      `Assoc
+        [("type", (`String "object"));
+        ("properties",
+          (`Assoc [("x", (`Assoc [("type", (`String "integer"))]))]));
+        ("required", (`List [`String "x"]));
+        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type obj1 = {
+  obj2: obj2 }[@@deriving jsonschema]
+include
+  struct
+    let obj1_jsonschema =
+      `Assoc
+        [("type", (`String "object"));
+        ("properties", (`Assoc [("obj2", obj2_jsonschema)]));
+        ("required", (`List [`String "obj2"]));
+        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type nested_obj = {
+  obj1: obj1 }[@@deriving jsonschema]
+include
+  struct
+    let nested_obj_jsonschema =
+      `Assoc
+        [("type", (`String "object"));
+        ("properties", (`Assoc [("obj1", obj1_jsonschema)]));
+        ("required", (`List [`String "obj1"]));
+        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "nested_obj" =
+    print_schema nested_obj_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "obj1": {
+          "type": "object",
+          "properties": {
+            "obj2": {
+              "type": "object",
+              "properties": { "x": { "type": "integer" } },
+              "required": [ "x" ],
+              "additionalProperties": false
+            }
+          },
+          "required": [ "obj2" ],
+          "additionalProperties": false
+        }
+      },
+      "required": [ "obj1" ],
+      "additionalProperties": false
     }
     |}]]

--- a/test/test.ml
+++ b/test/test.ml
@@ -1253,7 +1253,10 @@ let%expect_test "variant_inline_record" =
     |}]
 
 type inline_record_with_extra_fields =
-  | User of { name : string; email : string } [@jsonschema.allow_extra_fields]
+  | User of {
+      name : string;
+      email : string;
+    } [@jsonschema.allow_extra_fields]
   | Guest of { ip : string }
 [@@deriving jsonschema]
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -1252,6 +1252,55 @@ let%expect_test "variant_inline_record" =
     }
     |}]
 
+type inline_record_with_extra_fields =
+  | User of { name : string; email : string } [@jsonschema.allow_extra_fields]
+  | Guest of { ip : string }
+[@@deriving jsonschema]
+
+let%expect_test "inline_record_with_extra_fields" =
+  print_schema inline_record_with_extra_fields_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "User" },
+            {
+              "type": "object",
+              "properties": {
+                "email": { "type": "string" },
+                "name": { "type": "string" }
+              },
+              "required": [ "email", "name" ],
+              "additionalProperties": true
+            }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        },
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "Guest" },
+            {
+              "type": "object",
+              "properties": { "ip": { "type": "string" } },
+              "required": [ "ip" ],
+              "additionalProperties": false
+            }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    }
+    |}]
+
 type variant_with_payload =
   | A of int
   | B

--- a/test/test.ml
+++ b/test/test.ml
@@ -1569,3 +1569,49 @@ let%expect_test "t11" =
       ]
     }
     |}]
+
+type allow_additional_properties = { allow : bool } [@@deriving jsonschema ~allow_additional_properties]
+
+let%expect_test "allow_additional_properties" =
+  print_schema allow_additional_properties_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": { "allow": { "type": "boolean" } },
+      "required": [ "allow" ],
+      "additionalProperties": true
+    }
+    |}]
+
+type obj2 = { x : int } [@@deriving jsonschema]
+type obj1 = { obj2 : obj2 } [@@deriving jsonschema]
+type nested_obj = { obj1 : obj1 } [@@deriving jsonschema]
+
+let%expect_test "nested_obj" =
+  print_schema nested_obj_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "obj1": {
+          "type": "object",
+          "properties": {
+            "obj2": {
+              "type": "object",
+              "properties": { "x": { "type": "integer" } },
+              "required": [ "x" ],
+              "additionalProperties": false
+            }
+          },
+          "required": [ "obj2" ],
+          "additionalProperties": false
+        }
+      },
+      "required": [ "obj1" ],
+      "additionalProperties": false
+    }
+    |}]

--- a/test/test.ml
+++ b/test/test.ml
@@ -120,7 +120,8 @@ let%expect_test "with_modules" =
           ]
         }
       },
-      "required": [ "m2", "m" ]
+      "required": [ "m2", "m" ],
+      "additionalProperties": false
     }
     |}]
 
@@ -462,7 +463,8 @@ let%expect_test "event" =
       "required": [
         "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l", "a",
         "comment", "kind_f", "date"
-      ]
+      ],
+      "additionalProperties": false
     }
     |}]
 
@@ -557,7 +559,8 @@ let%expect_test "events" =
         "required": [
           "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l",
           "a", "comment", "kind_f", "date"
-        ]
+        ],
+        "additionalProperties": false
       }
     }
     |}]
@@ -640,7 +643,8 @@ let%expect_test "eventss" =
           "required": [
             "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l",
             "a", "comment", "kind_f", "date"
-          ]
+          ],
+          "additionalProperties": false
         }
       }
     }
@@ -723,7 +727,8 @@ let%expect_test "event_comment" =
           "required": [
             "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l",
             "a", "comment", "kind_f", "date"
-          ]
+          ],
+          "additionalProperties": false
         },
         { "type": "string" }
       ],
@@ -812,7 +817,8 @@ let%expect_test "event_comments'" =
             "required": [
               "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
               "l", "a", "comment", "kind_f", "date"
-            ]
+            ],
+            "additionalProperties": false
           },
           { "type": "string" }
         ],
@@ -902,7 +908,8 @@ let%expect_test "event_n" =
             "required": [
               "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
               "l", "a", "comment", "kind_f", "date"
-            ]
+            ],
+            "additionalProperties": false
           },
           { "type": "integer" }
         ],
@@ -991,7 +998,8 @@ let%expect_test "events_array" =
           "required": [
             "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l",
             "a", "comment", "kind_f", "date"
-          ]
+          ],
+          "additionalProperties": false
         }
       }
     }
@@ -1048,7 +1056,8 @@ let%expect_test "using_m" =
           ]
         }
       },
-      "required": [ "m" ]
+      "required": [ "m" ],
+      "additionalProperties": false
     }
     |}]
 
@@ -1124,8 +1133,10 @@ let%expect_test "player_scores" =
         "scores_ref": { "$ref": "#/$defs/numbers" },
         "player": { "type": "string" }
       },
-      "required": [ "scores_ref", "player" ]
-    } |}]
+      "required": [ "scores_ref", "player" ],
+      "additionalProperties": false
+    }
+    |}]
 
 type address = {
   street : string;
@@ -1157,14 +1168,17 @@ let%expect_test "t" =
             "city": { "type": "string" },
             "street": { "type": "string" }
           },
-          "required": [ "zip", "city", "street" ]
+          "required": [ "zip", "city", "street" ],
+          "additionalProperties": false
         },
         "email": { "type": "string" },
         "age": { "type": "integer" },
         "name": { "type": "string" }
       },
-      "required": [ "address", "age", "name" ]
-    } |}]
+      "required": [ "address", "age", "name" ],
+      "additionalProperties": false
+    }
+    |}]
 
 type tt = {
   name : string;
@@ -1190,7 +1204,8 @@ let%expect_test "tt" =
             "city": { "type": "string" },
             "street": { "type": "string" }
           },
-          "required": [ "zip", "city", "street" ]
+          "required": [ "zip", "city", "street" ],
+          "additionalProperties": false
         }
       },
       "type": "object",
@@ -1204,8 +1219,10 @@ let%expect_test "tt" =
       },
       "required": [
         "retreat_address", "work_address", "home_address", "age", "name"
-      ]
-    } |}]
+      ],
+      "additionalProperties": false
+    }
+    |}]
 
 type c = char [@@deriving jsonschema]
 

--- a/test/test_schemas.expected.json
+++ b/test/test_schemas.expected.json
@@ -42,7 +42,8 @@
           ]
         }
       },
-      "required": [ "m2", "m" ]
+      "required": [ "m2", "m" ],
+      "additionalProperties": false
     },
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -262,7 +263,8 @@
       "required": [
         "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l",
         "a", "comment", "kind_f", "date"
-      ]
+      ],
+      "additionalProperties": false
     },
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -334,7 +336,8 @@
         "required": [
           "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
           "l", "a", "comment", "kind_f", "date"
-        ]
+        ],
+        "additionalProperties": false
       }
     },
     {
@@ -409,7 +412,8 @@
           "required": [
             "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
             "l", "a", "comment", "kind_f", "date"
-          ]
+          ],
+          "additionalProperties": false
         }
       }
     },
@@ -484,7 +488,8 @@
           "required": [
             "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
             "l", "a", "comment", "kind_f", "date"
-          ]
+          ],
+          "additionalProperties": false
         },
         { "type": "string" }
       ],
@@ -565,7 +570,8 @@
             "required": [
               "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
               "l", "a", "comment", "kind_f", "date"
-            ]
+            ],
+            "additionalProperties": false
           },
           { "type": "string" }
         ],
@@ -647,7 +653,8 @@
             "required": [
               "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
               "l", "a", "comment", "kind_f", "date"
-            ]
+            ],
+            "additionalProperties": false
           },
           { "type": "integer" }
         ],
@@ -728,7 +735,8 @@
           "required": [
             "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
             "l", "a", "comment", "kind_f", "date"
-          ]
+          ],
+          "additionalProperties": false
         }
       }
     },
@@ -764,7 +772,8 @@
           ]
         }
       },
-      "required": [ "m" ]
+      "required": [ "m" ],
+      "additionalProperties": false
     },
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -811,7 +820,8 @@
         "scores_ref": { "$ref": "#/$defs/numbers" },
         "player": { "type": "string" }
       },
-      "required": [ "scores_ref", "player" ]
+      "required": [ "scores_ref", "player" ],
+      "additionalProperties": false
     },
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -824,13 +834,15 @@
             "city": { "type": "string" },
             "street": { "type": "string" }
           },
-          "required": [ "zip", "city", "street" ]
+          "required": [ "zip", "city", "street" ],
+          "additionalProperties": false
         },
         "email": { "type": "string" },
         "age": { "type": "integer" },
         "name": { "type": "string" }
       },
-      "required": [ "address", "age", "name" ]
+      "required": [ "address", "age", "name" ],
+      "additionalProperties": false
     },
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -842,7 +854,8 @@
             "city": { "type": "string" },
             "street": { "type": "string" }
           },
-          "required": [ "zip", "city", "street" ]
+          "required": [ "zip", "city", "street" ],
+          "additionalProperties": false
         }
       },
       "type": "object",
@@ -856,7 +869,8 @@
       },
       "required": [
         "retreat_address", "work_address", "home_address", "age", "name"
-      ]
+      ],
+      "additionalProperties": false
     },
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",


### PR DESCRIPTION
https://platform.openai.com/docs/guides/structured-outputs#additionalproperties-false-must-always-be-set-in-objects

We can set this to be the default but the openai jsonschema is opinionated and will fail if one of the objects is missing this `additionalProperties:false` field. I considered creating a new ppx library which removes the option of changing these settings but some things still can't be enforced well in the PPX like making sure the root json object cannot be `anyOf`