### PR TITLE
Support parametric (polymorphic) types

### DIFF
--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -145,8 +145,7 @@ let variant ~loc ~config constrs =
 
 let value_name_pattern ~loc type_name = ppat_var ~loc { txt = type_name ^ "_jsonschema"; loc }
 
-let create_value ~loc name value =
-  [%stri let[@warning "-32-39"] (* rec *) [%p value_name_pattern ~loc name (* : [< `Assoc of _ list ] *)] = [%e value]]
+let create_value ~loc name value = [%stri let[@warning "-32-39"] [%p value_name_pattern ~loc name] = [%e value]]
 
 let is_optional_type core_type =
   match core_type with
@@ -169,9 +168,10 @@ let rec type_of_core ~config core_type =
     Schema.array_ ~loc t
   | _ ->
   match core_type.ptyp_desc with
-  | Ptyp_constr (id, []) ->
-    (* todo: support using references with [type_ref ~loc type_name] instead of inlining everything *)
-    type_constr_conv ~loc id ~f:(fun s -> s ^ "_jsonschema") []
+  | Ptyp_var name -> evar ~loc ("_" ^ name ^ "_jsonschema")
+  | Ptyp_constr (id, args) ->
+    let args = List.map (type_of_core ~config) args in
+    type_constr_conv ~loc id ~f:(fun s -> s ^ "_jsonschema") args
   | Ptyp_tuple types ->
     let ts = List.map (type_of_core ~config) types in
     Schema.tuple ~loc ts
@@ -251,6 +251,28 @@ let object_ ~loc ~config fields allow_extra_fields =
         "additionalProperties", `Bool [%e ebool ~loc allow_extra_fields];
       ]]
 
+let expr_has_free_var name expr =
+  let found = ref false in
+  let iter =
+    object
+      inherit Ast_traverse.iter as super
+
+      method! expression e =
+        (match e.pexp_desc with
+        | Pexp_ident { txt = Lident n; _ } when String.equal n name -> found := true
+        | _ -> ());
+        super#expression e
+    end
+  in
+  iter#expression expr;
+  !found
+
+let wrap_type_params ~loc params body =
+  let used_params = List.filter (fun param -> expr_has_free_var ("_" ^ param ^ "_jsonschema") body) params in
+  List.fold_right
+    (fun param body -> [%expr fun [%p ppat_var ~loc { txt = "_" ^ param ^ "_jsonschema"; loc }] -> [%e body]])
+    used_params body
+
 let derive_jsonschema ~ctxt ast flag_variant_as_string flag_polymorphic_variant_tuple =
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
   let allow_extra_fields =
@@ -262,7 +284,8 @@ let derive_jsonschema ~ctxt ast flag_variant_as_string flag_polymorphic_variant_
     { variant_as_string = flag_variant_as_string; polymorphic_variant_tuple = flag_polymorphic_variant_tuple }
   in
   match ast with
-  | _, [ { ptype_name = { txt = type_name; _ }; ptype_kind = Ptype_variant variants; _ } ] ->
+  | _, [ ({ ptype_name = { txt = type_name; _ }; ptype_kind = Ptype_variant variants; _ } as td) ] ->
+    let params = List.map (fun tp -> (get_type_param_name tp).txt) td.ptype_params in
     let variants =
       List.map
         (fun ({ pcd_args; pcd_name = { txt = name; _ }; _ } as var) ->
@@ -282,22 +305,26 @@ let derive_jsonschema ~ctxt ast flag_variant_as_string flag_polymorphic_variant_
         variants
     in
     let v =
-      (* todo: raise an error if encoding is as string and constructor has a payload *)
       match config.variant_as_string with
       | true -> variant_as_string ~loc variants
       | false -> variant_as_array ~loc variants
     in
-    let jsonschema_expr = create_value ~loc type_name v in
+    let jsonschema_expr = create_value ~loc type_name (wrap_type_params ~loc params v) in
     [ jsonschema_expr ]
-  | _, [ { ptype_name = { txt = type_name; _ }; ptype_kind = Ptype_record label_declarations; _ } ] ->
-    let jsonschema_expr = create_value ~loc type_name (object_ ~loc ~config label_declarations allow_extra_fields) in
+  | _, [ ({ ptype_name = { txt = type_name; _ }; ptype_kind = Ptype_record label_declarations; _ } as td) ] ->
+    let params = List.map (fun tp -> (get_type_param_name tp).txt) td.ptype_params in
+    let body = object_ ~loc ~config label_declarations allow_extra_fields in
+    let jsonschema_expr = create_value ~loc type_name (wrap_type_params ~loc params body) in
     [ jsonschema_expr ]
-  | _, [ { ptype_name = { txt = type_name; _ }; ptype_kind = Ptype_abstract; ptype_manifest = Some core_type; _ } ] ->
-    let jsonschema_expr = create_value ~loc type_name (type_of_core ~config core_type) in
+  | ( _,
+      [
+        ({ ptype_name = { txt = type_name; _ }; ptype_kind = Ptype_abstract; ptype_manifest = Some core_type; _ } as td);
+      ] ) ->
+    let params = List.map (fun tp -> (get_type_param_name tp).txt) td.ptype_params in
+    let body = type_of_core ~config core_type in
+    let jsonschema_expr = create_value ~loc type_name (wrap_type_params ~loc params body) in
     [ jsonschema_expr ]
-  | _, _ast ->
-    (* Format.printf "unsuported type: %a\n======\n" Format.(pp_print_list Astlib.Pprintast.type_declaration) ast; *)
-    [%str [%ocaml.error "ppx_deriving_jsonschema: unsupported type"]]
+  | _, _ast -> [%str [%ocaml.error "ppx_deriving_jsonschema: unsupported type"]]
 
 let generator () = Deriving.Generator.V2.make ~attributes (args ()) derive_jsonschema
 (* let generator () = Deriving.Generator.V2.make_noarg derive_jsonschema *)

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -4,6 +4,9 @@ let print_schema ?definitions  ?id  ?title  ?description  s =
     Ppx_deriving_jsonschema_runtime.json_schema ?definitions ?id ?title
       ?description s in
   let () = print_endline (Yojson.Basic.pretty_to_string s) in ()
+let string_jsonschema = `Assoc [("type", (`String "string"))]
+let int_jsonschema = `Assoc [("type", (`String "integer"))]
+let bool_jsonschema = `Assoc [("type", (`String "boolean"))]
 module Mod1 =
   struct
     type m_1 =
@@ -2383,3 +2386,153 @@ include
     print_schema x_without_extra_jsonschema;
     [%expect
       "\n {\n   \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n   \"type\": \"object\",\n   \"properties\": { \"x\": { \"type\": \"integer\" } },\n   \"required\": [ \"x\" ],\n   \"additionalProperties\": true\n }\n "]]
+type 'url generic_link_traffic = {
+  title: string option ;
+  url: 'url }[@@deriving jsonschema]
+include
+  struct
+    let generic_link_traffic_jsonschema _url_jsonschema =
+      `Assoc
+        [("type", (`String "object"));
+        ("properties",
+          (`Assoc
+             [("url", _url_jsonschema);
+             ("title", (`Assoc [("type", (`String "string"))]))]));
+        ("required", (`List [`String "url"]));
+        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "parameterized_record" =
+    print_schema (generic_link_traffic_jsonschema string_jsonschema);
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "url": { "type": "string" },
+        "title": { "type": "string" }
+      },
+      "required": [ "url" ],
+      "additionalProperties": false
+    } |}]]
+type string_link_traffic = string generic_link_traffic[@@deriving jsonschema]
+include
+  struct
+    let string_link_traffic_jsonschema =
+      generic_link_traffic_jsonschema (`Assoc [("type", (`String "string"))])
+      [@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "instantiated_parameterized_record" =
+    print_schema string_link_traffic_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "url": { "type": "string" },
+        "title": { "type": "string" }
+      },
+      "required": [ "url" ],
+      "additionalProperties": false
+    } |}]]
+type 'a poly_variant =
+  | A 
+  | B of 'a [@@deriving jsonschema]
+include
+  struct
+    let poly_variant_jsonschema _a_jsonschema =
+      `Assoc
+        [("anyOf",
+           (`List
+              [`Assoc
+                 [("type", (`String "array"));
+                 ("prefixItems", (`List [`Assoc [("const", (`String "A"))]]));
+                 ("unevaluatedItems", (`Bool false));
+                 ("minItems", (`Int 1));
+                 ("maxItems", (`Int 1))];
+              `Assoc
+                [("type", (`String "array"));
+                ("prefixItems",
+                  (`List [`Assoc [("const", (`String "B"))]; _a_jsonschema]));
+                ("unevaluatedItems", (`Bool false));
+                ("minItems", (`Int 2));
+                ("maxItems", (`Int 2))]]))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "parameterized_variant" =
+    print_schema (poly_variant_jsonschema int_jsonschema);
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "A" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "B" }, { "type": "integer" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    } |}]]
+type ('a, 'b) multi_param = {
+  first: 'a ;
+  second: 'b ;
+  label: string }[@@deriving jsonschema]
+include
+  struct
+    let multi_param_jsonschema _a_jsonschema _b_jsonschema =
+      `Assoc
+        [("type", (`String "object"));
+        ("properties",
+          (`Assoc
+             [("label", (`Assoc [("type", (`String "string"))]));
+             ("second", _b_jsonschema);
+             ("first", _a_jsonschema)]));
+        ("required",
+          (`List [`String "label"; `String "second"; `String "first"]));
+        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "multi_param" =
+    print_schema (multi_param_jsonschema int_jsonschema bool_jsonschema);
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "label": { "type": "string" },
+        "second": { "type": "boolean" },
+        "first": { "type": "integer" }
+      },
+      "required": [ "label", "second", "first" ],
+      "additionalProperties": false
+    } |}]]
+type 'a param_list = 'a list[@@deriving jsonschema]
+include
+  struct
+    let param_list_jsonschema _a_jsonschema =
+      `Assoc [("type", (`String "array")); ("items", _a_jsonschema)][@@warning
+                                                                    "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "parameterized_abstract" =
+    print_schema (param_list_jsonschema string_jsonschema);
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "items": { "type": "string" }
+    } |}]]

--- a/test/test.ml
+++ b/test/test.ml
@@ -5,6 +5,10 @@ let print_schema ?definitions ?id ?title ?description s =
   let () = print_endline (Yojson.Basic.pretty_to_string s) in
   ()
 
+let string_jsonschema = `Assoc [ "type", `String "string" ]
+let int_jsonschema = `Assoc [ "type", `String "integer" ]
+let bool_jsonschema = `Assoc [ "type", `String "boolean" ]
+
 module Mod1 = struct
   type m_1 =
     | A
@@ -1675,3 +1679,105 @@ let%expect_test "extra_fields" =
     \   \"additionalProperties\": true\n\
     \ }\n\
     \ "]
+
+type 'url generic_link_traffic = {
+  title : string option;
+  url : 'url;
+}
+[@@deriving jsonschema]
+
+let%expect_test "parameterized_record" =
+  print_schema (generic_link_traffic_jsonschema string_jsonschema);
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "url": { "type": "string" },
+        "title": { "type": "string" }
+      },
+      "required": [ "url" ],
+      "additionalProperties": false
+    } |}]
+
+type string_link_traffic = string generic_link_traffic [@@deriving jsonschema]
+
+let%expect_test "instantiated_parameterized_record" =
+  print_schema string_link_traffic_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "url": { "type": "string" },
+        "title": { "type": "string" }
+      },
+      "required": [ "url" ],
+      "additionalProperties": false
+    } |}]
+
+type 'a poly_variant =
+  | A
+  | B of 'a
+[@@deriving jsonschema]
+
+let%expect_test "parameterized_variant" =
+  print_schema (poly_variant_jsonschema int_jsonschema);
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "A" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "B" }, { "type": "integer" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    } |}]
+
+type ('a, 'b) multi_param = {
+  first : 'a;
+  second : 'b;
+  label : string;
+}
+[@@deriving jsonschema]
+
+let%expect_test "multi_param" =
+  print_schema (multi_param_jsonschema int_jsonschema bool_jsonschema);
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "label": { "type": "string" },
+        "second": { "type": "boolean" },
+        "first": { "type": "integer" }
+      },
+      "required": [ "label", "second", "first" ],
+      "additionalProperties": false
+    } |}]
+
+type 'a param_list = 'a list [@@deriving jsonschema]
+
+let%expect_test "parameterized_abstract" =
+  print_schema (param_list_jsonschema string_jsonschema);
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "items": { "type": "string" }
+    } |}]


### PR DESCRIPTION
## Summary

- Add support for parameterized types (e.g. `type 'a t = ...`) in `[@@deriving jsonschema]`. The generated `t_jsonschema` becomes a function taking the schema for each type parameter as an argument.
- At usage sites like `type u = string t`, the PPX resolves the type argument and passes its schema automatically (e.g. `t_jsonschema (string_schema_expr)`).
- Type parameters unused in the generated body (e.g. when `~variant_as_string` discards payloads) are omitted from the function signature entirely, avoiding unused-variable warnings without suppression.

## Examples

```ocaml
type 'url generic_link_traffic = {
  title : string option;
  url : 'url;
} [@@deriving jsonschema]
(* generates: let generic_link_traffic_jsonschema _url_jsonschema = ... *)

type string_link_traffic = string generic_link_traffic [@@deriving jsonschema]
(* generates: let string_link_traffic_jsonschema = generic_link_traffic_jsonschema (`Assoc [("type", `String "string")]) *)
```

## Test plan

- [x] Parameterized record type (`'url generic_link_traffic`)
- [x] Instantiation via type alias (`string generic_link_traffic`)
- [x] Parameterized variant type (`'a poly_variant`)
- [x] Multi-parameter type (`('a, 'b) multi_param`)
- [x] Parameterized abstract type (`'a param_list = 'a list`)
- [x] Unused param omission (`'param2 poly2` with `~variant_as_string`)
- [x] All existing tests continue to pass

Made with [Cursor](https://cursor.com)