### PR TITLE
Fix schema generation for parametric recursive types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Next release
 - make option types nullable in generated JSON Schema (e.g. `int option` → `{"type":["integer","null"]}`); add `[@@jsonschema.option]` attribute to opt a field out of `required` without making its type nullable
+- fix schema generation for parametric recursive types (e.g. `type 'a t = ... | B of 'a t`)
+- fix broken `$ref` scoping when a recursive type uses a parametric recursive type with itself as a type argument (e.g. `type t = ... | N of t wrapper` where `wrapper` is also recursive); inner `$defs` are now hoisted into the root schema's `$defs` namespace
 
 # 0.0.6
 - update jsonschema derivation to use t instead of Yojson.Basic for type signatures

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -133,7 +133,7 @@ module Schema = struct
       `Assoc
         [
           "$id", `String [%e estring ~loc ("urn:jsonschema:" ^ type_name)];
-          "$defs", `Assoc (([%e estring ~loc type_name], _ppx_body) :: ! [%e extra_defs_var]);
+          "$defs", `Assoc (([%e estring ~loc type_name], _ppx_body) :: ![%e extra_defs_var]);
           "$ref", `String [%e estring ~loc ("#/$defs/" ^ type_name)];
         ]]
 
@@ -145,24 +145,23 @@ module Schema = struct
     let indexed = List.mapi (fun i (name, schema) -> i, name, schema) defs in
     let body_vars = List.map (fun (i, name, _) -> name, Printf.sprintf "_ppx_body_%d" i) indexed in
     let pairs_expr =
-      elist ~loc
-        (List.map
-           (fun (name, vname) -> [%expr [%e estring ~loc name], [%e evar ~loc vname]])
-           body_vars)
+      elist ~loc (List.map (fun (name, vname) -> [%expr [%e estring ~loc name], [%e evar ~loc vname]]) body_vars)
     in
     let base_expr =
       [%expr
         `Assoc
           [
             "$id", `String [%e estring ~loc id];
-            "$defs", `Assoc ([%e pairs_expr] @ ! [%e extra_defs_var]);
+            "$defs", `Assoc ([%e pairs_expr] @ ![%e extra_defs_var]);
             "$ref", `String [%e estring ~loc ("#/$defs/" ^ primary_type)];
           ]]
     in
     List.fold_right
       (fun (i, _name, schema) acc ->
         let vname = Printf.sprintf "_ppx_body_%d" i in
-        [%expr let [%p ppat_var ~loc { txt = vname; loc }] = [%e schema] in [%e acc]])
+        [%expr
+          let [%p ppat_var ~loc { txt = vname; loc }] = [%e schema] in
+          [%e acc]])
       indexed base_expr
 end
 
@@ -241,12 +240,10 @@ let rec type_of_core ~config ?(recursive_types = []) ?extra_defs_var core_type =
            "#/$defs/outer" would resolve against the inner $id — wrong.
            Fix: hoist the inner $defs into the outer type's _ppx_eds accumulator
            with unique suffixed names, and return just a renamed $ref. *)
-        let suffix =
-          estring ~loc (Printf.sprintf "%d_%d" loc.loc_start.pos_lnum loc.loc_start.pos_cnum)
-        in
+        let suffix = estring ~loc (Printf.sprintf "%d_%d" loc.loc_start.pos_lnum loc.loc_start.pos_cnum) in
         ( [%expr
             let _ppx_sub = [%e schema] in
-            (match _ppx_sub with
+            match _ppx_sub with
             | `Assoc _ppx_pairs when List.mem_assoc "$defs" _ppx_pairs ->
               let _ppx_inner_defs =
                 match List.assoc_opt "$defs" _ppx_pairs with
@@ -263,12 +260,17 @@ let rec type_of_core ~config ?(recursive_types = []) ?extra_defs_var core_type =
                     (List.map
                        (fun (k, v) ->
                          let v' =
-                           if k = "$ref" then
+                           if k = "$ref" then (
                              match v with
                              | `String r when String.length r > 8 && String.sub r 0 8 = "#/$defs/" ->
                                let n = String.sub r 8 (String.length r - 8) in
-                               `String ("#/$defs/" ^ (match List.assoc_opt n _ppx_rmap with Some m -> m | None -> n))
-                             | _ -> v
+                               `String
+                                 ("#/$defs/"
+                                 ^
+                                 match List.assoc_opt n _ppx_rmap with
+                                 | Some m -> m
+                                 | None -> n)
+                             | _ -> v)
                            else _ppx_ren v
                          in
                          k, v')
@@ -276,25 +278,22 @@ let rec type_of_core ~config ?(recursive_types = []) ?extra_defs_var core_type =
                 | `List xs -> `List (List.map _ppx_ren xs)
                 | other -> other
               in
-              let _ppx_hoisted =
-                List.map (fun (n, b) -> _ppx_mk n, _ppx_ren b) _ppx_inner_defs
-              in
-              [%e edv] := ! [%e edv] @ _ppx_hoisted;
+              let _ppx_hoisted = List.map (fun (n, b) -> _ppx_mk n, _ppx_ren b) _ppx_inner_defs in
+              [%e edv] := ![%e edv] @ _ppx_hoisted;
               (match List.assoc_opt "$ref" _ppx_pairs with
-              | Some (`String _ppx_r)
-                when String.length _ppx_r > 8 && String.sub _ppx_r 0 8 = "#/$defs/" ->
+              | Some (`String _ppx_r) when String.length _ppx_r > 8 && String.sub _ppx_r 0 8 = "#/$defs/" ->
                 let _ppx_n = String.sub _ppx_r 8 (String.length _ppx_r - 8) in
                 `Assoc [ "$ref", `String ("#/$defs/" ^ _ppx_mk _ppx_n) ]
               | _ -> `Assoc (List.filter (fun (k, _) -> k <> "$id") _ppx_pairs))
-            | _ppx_other -> _ppx_other)],
+            | _ppx_other -> _ppx_other],
           true )
       | _ ->
         (* Non-recursive arg (or no accumulator): add a location-based $id to mark
            the resource boundary so that any internal $defs refs resolve correctly. *)
         let unique_id =
           estring ~loc
-            (Printf.sprintf "urn:jsonschema:%s:%d:%d"
-               loc.loc_start.pos_fname loc.loc_start.pos_lnum loc.loc_start.pos_cnum)
+            (Printf.sprintf "urn:jsonschema:%s:%d:%d" loc.loc_start.pos_fname loc.loc_start.pos_lnum
+               loc.loc_start.pos_cnum)
         in
         ( [%expr
             match [%e schema] with
@@ -373,11 +372,11 @@ let object_ ~loc ~config ?(recursive_types = []) ?extra_defs_var fields allow_ex
           match Attribute.get jsonschema_ref field with
           | Some def -> Schema.type_ref ~loc def.txt, false
           | None ->
-            (match pld_type with
-            | [%type: [%t? inner] option] ->
-              let s, r = type_of_core ~config ~recursive_types ?extra_defs_var inner in
-              Schema.nullable ~loc s, r
-            | _ -> type_of_core ~config ~recursive_types ?extra_defs_var pld_type)
+          match pld_type with
+          | [%type: [%t? inner] option] ->
+            let s, r = type_of_core ~config ~recursive_types ?extra_defs_var inner in
+            Schema.nullable ~loc s, r
+          | _ -> type_of_core ~config ~recursive_types ?extra_defs_var pld_type
         in
         ( [%expr [%e estring ~loc name], [%e type_def]] :: fields,
           (if drop_required then required else { txt = name; loc } :: required),
@@ -442,9 +441,7 @@ let derive_single_type ~loc ~config ~recursive_types ?extra_defs_var type_decl =
     in
     type_name, schema, is_rec, params, params_prefix
   | Ptype_record label_declarations ->
-    let schema, is_rec =
-      object_ ~loc ~config ~recursive_types ?extra_defs_var label_declarations allow_extra_fields
-    in
+    let schema, is_rec = object_ ~loc ~config ~recursive_types ?extra_defs_var label_declarations allow_extra_fields in
     type_name, schema, is_rec, params, ""
   | Ptype_abstract ->
     (match type_decl.ptype_manifest with
@@ -469,21 +466,17 @@ let derive_jsonschema ~ctxt ast flag_variant_as_string flag_polymorphic_variant_
     let type_name = type_decl.ptype_name.txt in
     let recursive_types = [ type_name ] in
     (* First pass: determine whether the type is recursive *)
-    let _, raw_schema, is_rec, params, params_prefix =
-      derive_single_type ~loc ~config ~recursive_types type_decl
-    in
+    let _, raw_schema, is_rec, params, params_prefix = derive_single_type ~loc ~config ~recursive_types type_decl in
     (* Apply with_defs before wrap_type_params so params wrap the full schema.
        For recursive types, do a second pass with extra_defs_var so hoisting
        code referencing _ppx_eds is generated in the body expression. *)
     let schema =
-      if is_rec then
+      if is_rec then (
         let edv = evar ~loc "_ppx_eds" in
-        let _, raw_schema2, _, _, _ =
-          derive_single_type ~loc ~config ~recursive_types ~extra_defs_var:edv type_decl
-        in
+        let _, raw_schema2, _, _, _ = derive_single_type ~loc ~config ~recursive_types ~extra_defs_var:edv type_decl in
         [%expr
           let _ppx_eds = ref [] in
-          [%e Schema.with_defs ~loc type_name ~extra_defs_var:edv raw_schema2]]
+          [%e Schema.with_defs ~loc type_name ~extra_defs_var:edv raw_schema2]])
       else raw_schema
     in
     let schema = wrap_type_params ~loc ~prefix:params_prefix params schema in
@@ -495,25 +488,19 @@ let derive_jsonschema ~ctxt ast flag_variant_as_string flag_polymorphic_variant_
     let primary_type = List.hd recursive_types in
     (* Collect raw schemas without wrapping type params yet — $defs must contain
        the raw bodies so that parametric types remain valid OCaml expressions. *)
-    let raw_results =
-      List.map (fun td -> derive_single_type ~loc ~config ~recursive_types td) type_decls
-    in
+    let raw_results = List.map (fun td -> derive_single_type ~loc ~config ~recursive_types td) type_decls in
     let any_recursive = List.exists (fun (_, _, is_rec, _, _) -> is_rec) raw_results in
     if any_recursive then (
       (* Second pass: regenerate with extra_defs_var so hoisting code is emitted *)
       let edv = evar ~loc "_ppx_eds" in
       let raw_results2 =
-        List.map
-          (fun td -> derive_single_type ~loc ~config ~recursive_types ~extra_defs_var:edv td)
-          type_decls
+        List.map (fun td -> derive_single_type ~loc ~config ~recursive_types ~extra_defs_var:edv td) type_decls
       in
       let defs2 = List.map (fun (name, raw, _, _, _) -> name, raw) raw_results2 in
       (* Build $defs from raw schemas, then wrap the combined schema with type params.
          Each binding gets its own _ppx_eds ref so hoisted defs don't leak across. *)
       let primary_value =
-        let _, _, _, params, prefix =
-          List.find (fun (name, _, _, _, _) -> name = primary_type) raw_results2
-        in
+        let _, _, _, params, prefix = List.find (fun (name, _, _, _, _) -> name = primary_type) raw_results2 in
         let schema_inner = Schema.with_multi_defs ~loc ~primary_type ~extra_defs_var:edv defs2 in
         let schema =
           wrap_type_params ~loc ~prefix params
@@ -527,25 +514,22 @@ let derive_jsonschema ~ctxt ast flag_variant_as_string flag_polymorphic_variant_
         List.filter_map
           (fun (name, _, _, params, prefix) ->
             if name = primary_type then None
-            else
-              let schema_inner =
-                Schema.with_multi_defs ~loc ~primary_type:name ~extra_defs_var:edv defs2
-              in
+            else (
+              let schema_inner = Schema.with_multi_defs ~loc ~primary_type:name ~extra_defs_var:edv defs2 in
               let schema =
                 wrap_type_params ~loc ~prefix params
                   [%expr
                     let _ppx_eds = ref [] in
                     [%e schema_inner]]
               in
-              Some (create_value ~loc name schema))
+              Some (create_value ~loc name schema)))
           raw_results2
       in
       primary_value :: other_values)
     else
       (* No recursion detected - wrap params and generate independent schemas *)
       List.map
-        (fun (name, raw, _, params, prefix) ->
-          create_value ~loc name (wrap_type_params ~loc ~prefix params raw))
+        (fun (name, raw, _, params, prefix) -> create_value ~loc name (wrap_type_params ~loc ~prefix params raw))
         raw_results
   | _, _ -> [%str [%ocaml.error "ppx_deriving_jsonschema: unsupported type"]]
 

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -127,18 +127,43 @@ module Schema = struct
       | `Assoc [ ("type", `String t) ] -> `Assoc [ "type", `List [ `String t; `String "null" ] ]
       | s -> `Assoc [ "anyOf", `List [ s; `Assoc [ "type", `String "null" ] ] ]]
 
-  let with_defs ~loc type_name schema =
+  let with_defs ~loc type_name ~extra_defs_var schema =
     [%expr
+      let _ppx_body = [%e schema] in
       `Assoc
         [
-          "$defs", `Assoc [ [%e estring ~loc type_name], [%e schema] ];
+          "$id", `String [%e estring ~loc ("urn:jsonschema:" ^ type_name)];
+          "$defs", `Assoc (([%e estring ~loc type_name], _ppx_body) :: ! [%e extra_defs_var]);
           "$ref", `String [%e estring ~loc ("#/$defs/" ^ type_name)];
         ]]
 
-  (* For mutually recursive types: multiple definitions, ref to first type *)
-  let with_multi_defs ~loc ~primary_type defs =
-    let defs_expr = elist ~loc (List.map (fun (name, schema) -> [%expr [%e estring ~loc name], [%e schema]]) defs) in
-    [%expr `Assoc [ "$defs", `Assoc [%e defs_expr]; "$ref", `String [%e estring ~loc ("#/$defs/" ^ primary_type)] ]]
+  (* For mutually recursive types: multiple definitions, ref to first type.
+     Schemas are bound to _ppx_body_N variables so they execute before !extra_defs_var
+     is read — this ensures any hoisted $defs accumulate into extra_defs_var first. *)
+  let with_multi_defs ~loc ~primary_type ~extra_defs_var defs =
+    let id = "urn:jsonschema:" ^ primary_type in
+    let indexed = List.mapi (fun i (name, schema) -> i, name, schema) defs in
+    let body_vars = List.map (fun (i, name, _) -> name, Printf.sprintf "_ppx_body_%d" i) indexed in
+    let pairs_expr =
+      elist ~loc
+        (List.map
+           (fun (name, vname) -> [%expr [%e estring ~loc name], [%e evar ~loc vname]])
+           body_vars)
+    in
+    let base_expr =
+      [%expr
+        `Assoc
+          [
+            "$id", `String [%e estring ~loc id];
+            "$defs", `Assoc ([%e pairs_expr] @ ! [%e extra_defs_var]);
+            "$ref", `String [%e estring ~loc ("#/$defs/" ^ primary_type)];
+          ]]
+    in
+    List.fold_right
+      (fun (i, _name, schema) acc ->
+        let vname = Printf.sprintf "_ppx_body_%d" i in
+        [%expr let [%p ppat_var ~loc { txt = vname; loc }] = [%e schema] in [%e acc]])
+      indexed base_expr
 end
 
 let variant_as_string ~loc constrs =
@@ -173,8 +198,10 @@ let value_name_pattern ~loc type_name = ppat_var ~loc { txt = type_name ^ "_json
 let create_value ~loc name value = [%stri let[@warning "-32-39"] [%p value_name_pattern ~loc name] = [%e value]]
 
 (* Returns (schema_expression, is_recursive)
-   recursive_types: list of type names in a mutually recursive group *)
-let rec type_of_core ~config ?(recursive_types = []) core_type =
+   recursive_types: list of type names in a mutually recursive group
+   extra_defs_var: when Some edv, edv is an expression for a (string * t) list ref that
+     accumulates hoisted $defs from parametric recursive sub-schemas *)
+let rec type_of_core ~config ?(recursive_types = []) ?extra_defs_var core_type =
   let loc = core_type.ptyp_loc in
   match core_type with
   | [%type: int] | [%type: int32] | [%type: int64] | [%type: nativeint] -> Schema.type_def ~loc "integer", false
@@ -184,26 +211,99 @@ let rec type_of_core ~config ?(recursive_types = []) core_type =
   | [%type: char] -> Schema.char ~loc, false
   | [%type: unit] -> Schema.null ~loc, false
   | [%type: [%t? t] option] ->
-    let s, is_rec = type_of_core ~config ~recursive_types t in
+    let s, is_rec = type_of_core ~config ~recursive_types ?extra_defs_var t in
     Schema.nullable ~loc s, is_rec
-  | [%type: [%t? t] ref] -> type_of_core ~config ~recursive_types t
+  | [%type: [%t? t] ref] -> type_of_core ~config ~recursive_types ?extra_defs_var t
   | [%type: [%t? t] list] | [%type: [%t? t] array] ->
-    let t, is_rec = type_of_core ~config ~recursive_types t in
+    let t, is_rec = type_of_core ~config ~recursive_types ?extra_defs_var t in
     Schema.array_ ~loc t, is_rec
   | _ ->
   match core_type.ptyp_desc with
   | Ptyp_var name -> evar ~loc name, false
-  | Ptyp_constr (id, []) ->
-    (match id.txt with
-    | Lident name when List.mem name recursive_types -> Schema.type_ref ~loc name, true
-    | _ -> type_constr_conv ~loc id ~f:(fun s -> s ^ "_jsonschema") [], false)
   | Ptyp_constr (id, args) ->
-    let results = List.map (type_of_core ~config ~recursive_types) args in
-    let args = List.map fst results in
-    let is_rec = List.exists snd results in
-    type_constr_conv ~loc id ~f:(fun s -> s ^ "_jsonschema") args, is_rec
+    (match id.txt with
+    | Lident name when List.mem name recursive_types ->
+      (* Recursive reference: emit $ref regardless of type arguments.
+         The $defs entry for this type is the canonical definition; inlining
+         its schema here (with concrete args) would produce the wrong schema
+         and lose the self-reference structure. *)
+      Schema.type_ref ~loc name, true
+    | _ ->
+      let results = List.map (type_of_core ~config ~recursive_types ?extra_defs_var) args in
+      let args = List.map fst results in
+      let is_rec = List.exists snd results in
+      let schema = type_constr_conv ~loc id ~f:(fun s -> s ^ "_jsonschema") args in
+      (match is_rec, extra_defs_var with
+      | true, Some edv ->
+        (* A recursive $ref was passed as an arg to a parametric type.
+           The parametric type's schema will have {$id, $defs, $ref}; the $id
+           creates a JSON Schema resource boundary so internal $refs like
+           "#/$defs/outer" would resolve against the inner $id — wrong.
+           Fix: hoist the inner $defs into the outer type's _ppx_eds accumulator
+           with unique suffixed names, and return just a renamed $ref. *)
+        let suffix =
+          estring ~loc (Printf.sprintf "%d_%d" loc.loc_start.pos_lnum loc.loc_start.pos_cnum)
+        in
+        ( [%expr
+            let _ppx_sub = [%e schema] in
+            (match _ppx_sub with
+            | `Assoc _ppx_pairs when List.mem_assoc "$defs" _ppx_pairs ->
+              let _ppx_inner_defs =
+                match List.assoc_opt "$defs" _ppx_pairs with
+                | Some (`Assoc d) -> d
+                | _ -> []
+              in
+              let _ppx_suffix = [%e suffix] in
+              let _ppx_mk n = n ^ "__" ^ _ppx_suffix in
+              let _ppx_rmap = List.map (fun (n, _) -> n, _ppx_mk n) _ppx_inner_defs in
+              let rec _ppx_ren t =
+                match t with
+                | `Assoc pairs ->
+                  `Assoc
+                    (List.map
+                       (fun (k, v) ->
+                         let v' =
+                           if k = "$ref" then
+                             match v with
+                             | `String r when String.length r > 8 && String.sub r 0 8 = "#/$defs/" ->
+                               let n = String.sub r 8 (String.length r - 8) in
+                               `String ("#/$defs/" ^ (match List.assoc_opt n _ppx_rmap with Some m -> m | None -> n))
+                             | _ -> v
+                           else _ppx_ren v
+                         in
+                         k, v')
+                       pairs)
+                | `List xs -> `List (List.map _ppx_ren xs)
+                | other -> other
+              in
+              let _ppx_hoisted =
+                List.map (fun (n, b) -> _ppx_mk n, _ppx_ren b) _ppx_inner_defs
+              in
+              [%e edv] := ! [%e edv] @ _ppx_hoisted;
+              (match List.assoc_opt "$ref" _ppx_pairs with
+              | Some (`String _ppx_r)
+                when String.length _ppx_r > 8 && String.sub _ppx_r 0 8 = "#/$defs/" ->
+                let _ppx_n = String.sub _ppx_r 8 (String.length _ppx_r - 8) in
+                `Assoc [ "$ref", `String ("#/$defs/" ^ _ppx_mk _ppx_n) ]
+              | _ -> `Assoc (List.filter (fun (k, _) -> k <> "$id") _ppx_pairs))
+            | _ppx_other -> _ppx_other)],
+          true )
+      | _ ->
+        (* Non-recursive arg (or no accumulator): add a location-based $id to mark
+           the resource boundary so that any internal $defs refs resolve correctly. *)
+        let unique_id =
+          estring ~loc
+            (Printf.sprintf "urn:jsonschema:%s:%d:%d"
+               loc.loc_start.pos_fname loc.loc_start.pos_lnum loc.loc_start.pos_cnum)
+        in
+        ( [%expr
+            match [%e schema] with
+            | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+              `Assoc (("$id", `String [%e unique_id]) :: List.filter (fun (k, _) -> k <> "$id") pairs)
+            | other -> other],
+          is_rec )))
   | Ptyp_tuple types ->
-    let results = List.map (type_of_core ~config ~recursive_types) types in
+    let results = List.map (type_of_core ~config ~recursive_types ?extra_defs_var) types in
     let ts = List.map fst results in
     let is_rec = List.exists snd results in
     Schema.tuple ~loc ts, is_rec
@@ -233,14 +333,14 @@ let rec type_of_core ~config ?(recursive_types = []) core_type =
               | Ptyp_tuple tps -> tps
               | _ -> [ typ ]
             in
-            let results = List.map (type_of_core ~config ~recursive_types) raw_typs in
+            let results = List.map (type_of_core ~config ~recursive_types ?extra_defs_var) raw_typs in
             let typs = List.map fst results in
             let typs_rec = List.exists snd results in
             `Tag (name, typs) :: constrs, is_rec || typs_rec
           | Rtag (_, true, [ _ ]) | Rtag (_, _, _ :: _ :: _) ->
             Location.raise_errorf ~loc "ppx_deriving_jsonschema: polymorphic_variant/Rtag/&"
           | Rinherit core_type ->
-            let typ, typ_rec = type_of_core ~config ~recursive_types core_type in
+            let typ, typ_rec = type_of_core ~config ~recursive_types ?extra_defs_var core_type in
             `Inherit typ :: constrs, is_rec || typ_rec
           (* impossible?*)
           | Rtag (_, false, []) -> assert false)
@@ -259,7 +359,7 @@ let rec type_of_core ~config ?(recursive_types = []) core_type =
     [%expr [%ocaml.error [%e estring ~loc msg]]], false
 
 (* Returns (schema_expression, is_recursive) *)
-let object_ ~loc ~config ?(recursive_types = []) fields allow_extra_fields =
+let object_ ~loc ~config ?(recursive_types = []) ?extra_defs_var fields allow_extra_fields =
   let fields, required, is_rec =
     List.fold_left
       (fun (fields, required, is_rec) ({ pld_name; pld_type; pld_loc = _loc; _ } as field) ->
@@ -273,11 +373,11 @@ let object_ ~loc ~config ?(recursive_types = []) fields allow_extra_fields =
           match Attribute.get jsonschema_ref field with
           | Some def -> Schema.type_ref ~loc def.txt, false
           | None ->
-          match pld_type with
-          | [%type: [%t? inner] option] ->
-            let s, r = type_of_core ~config ~recursive_types inner in
-            Schema.nullable ~loc s, r
-          | _ -> type_of_core ~config ~recursive_types pld_type
+            (match pld_type with
+            | [%type: [%t? inner] option] ->
+              let s, r = type_of_core ~config ~recursive_types ?extra_defs_var inner in
+              Schema.nullable ~loc s, r
+            | _ -> type_of_core ~config ~recursive_types ?extra_defs_var pld_type)
         in
         ( [%expr [%e estring ~loc name], [%e type_def]] :: fields,
           (if drop_required then required else { txt = name; loc } :: required),
@@ -305,7 +405,7 @@ let wrap_type_params ~loc ?(prefix = "") params body =
     params body
 
 (* Generate schema for a single type declaration, given the recursive type group *)
-let derive_single_type ~loc ~config ~recursive_types type_decl =
+let derive_single_type ~loc ~config ~recursive_types ?extra_defs_var type_decl =
   let type_name = type_decl.ptype_name.txt in
   let allow_extra_fields = Attribute.get jsonschema_td_allow_extra_fields type_decl |> Option.is_some in
   let params = List.map (fun tp -> (get_type_param_name tp).txt) type_decl.ptype_params in
@@ -322,10 +422,12 @@ let derive_single_type ~loc ~config ~recursive_types type_decl =
           match pcd_args with
           | Pcstr_record label_declarations ->
             let allow_extra_fields = Attribute.get jsonschema_cd_allow_extra_fields var |> Option.is_some in
-            let obj_schema, obj_rec = object_ ~loc ~config ~recursive_types label_declarations allow_extra_fields in
+            let obj_schema, obj_rec =
+              object_ ~loc ~config ~recursive_types ?extra_defs_var label_declarations allow_extra_fields
+            in
             `Tag (name, [ obj_schema ]) :: variants, is_rec || obj_rec
           | Pcstr_tuple typs ->
-            let results = List.map (type_of_core ~config ~recursive_types) typs in
+            let results = List.map (type_of_core ~config ~recursive_types ?extra_defs_var) typs in
             let types = List.map fst results in
             let typs_rec = List.exists snd results in
             `Tag (name, types) :: variants, is_rec || typs_rec)
@@ -338,21 +440,23 @@ let derive_single_type ~loc ~config ~recursive_types type_decl =
       | true -> variant_as_string ~loc variants, "_"
       | false -> variant_as_array ~loc variants, ""
     in
-    type_name, wrap_type_params ~loc ~prefix:params_prefix params schema, is_rec
+    type_name, schema, is_rec, params, params_prefix
   | Ptype_record label_declarations ->
-    let schema, is_rec = object_ ~loc ~config ~recursive_types label_declarations allow_extra_fields in
-    type_name, wrap_type_params ~loc params schema, is_rec
+    let schema, is_rec =
+      object_ ~loc ~config ~recursive_types ?extra_defs_var label_declarations allow_extra_fields
+    in
+    type_name, schema, is_rec, params, ""
   | Ptype_abstract ->
     (match type_decl.ptype_manifest with
     | Some core_type ->
-      let schema, is_rec = type_of_core ~config ~recursive_types core_type in
-      type_name, wrap_type_params ~loc params schema, is_rec
+      let schema, is_rec = type_of_core ~config ~recursive_types ?extra_defs_var core_type in
+      type_name, schema, is_rec, params, ""
     | None ->
       let msg = "ppx_deriving_jsonschema: abstract type without manifest" in
-      type_name, [%expr [%ocaml.error [%e estring ~loc msg]]], false)
+      type_name, [%expr [%ocaml.error [%e estring ~loc msg]]], false, params, "")
   | Ptype_open ->
     let msg = "ppx_deriving_jsonschema: open types not supported" in
-    type_name, [%expr [%ocaml.error [%e estring ~loc msg]]], false
+    type_name, [%expr [%ocaml.error [%e estring ~loc msg]]], false, params, ""
 
 let derive_jsonschema ~ctxt ast flag_variant_as_string flag_polymorphic_variant_tuple =
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
@@ -364,34 +468,85 @@ let derive_jsonschema ~ctxt ast flag_variant_as_string flag_polymorphic_variant_
   | _, [ type_decl ] ->
     let type_name = type_decl.ptype_name.txt in
     let recursive_types = [ type_name ] in
-    let _, schema, is_rec = derive_single_type ~loc ~config ~recursive_types type_decl in
-    let schema = if is_rec then Schema.with_defs ~loc type_name schema else schema in
+    (* First pass: determine whether the type is recursive *)
+    let _, raw_schema, is_rec, params, params_prefix =
+      derive_single_type ~loc ~config ~recursive_types type_decl
+    in
+    (* Apply with_defs before wrap_type_params so params wrap the full schema.
+       For recursive types, do a second pass with extra_defs_var so hoisting
+       code referencing _ppx_eds is generated in the body expression. *)
+    let schema =
+      if is_rec then
+        let edv = evar ~loc "_ppx_eds" in
+        let _, raw_schema2, _, _, _ =
+          derive_single_type ~loc ~config ~recursive_types ~extra_defs_var:edv type_decl
+        in
+        [%expr
+          let _ppx_eds = ref [] in
+          [%e Schema.with_defs ~loc type_name ~extra_defs_var:edv raw_schema2]]
+      else raw_schema
+    in
+    let schema = wrap_type_params ~loc ~prefix:params_prefix params schema in
     [ create_value ~loc type_name schema ]
   (* Multiple type declarations (mutually recursive types) *)
   | _, type_decls when List.length type_decls > 1 ->
     (* Collect all type names in the recursive group *)
     let recursive_types = List.map (fun td -> td.ptype_name.txt) type_decls in
     let primary_type = List.hd recursive_types in
-    (* Generate schemas for all types *)
-    let results = List.map (derive_single_type ~loc ~config ~recursive_types) type_decls in
-    let any_recursive = List.exists (fun (_, _, is_rec) -> is_rec) results in
+    (* Collect raw schemas without wrapping type params yet — $defs must contain
+       the raw bodies so that parametric types remain valid OCaml expressions. *)
+    let raw_results =
+      List.map (fun td -> derive_single_type ~loc ~config ~recursive_types td) type_decls
+    in
+    let any_recursive = List.exists (fun (_, _, is_rec, _, _) -> is_rec) raw_results in
     if any_recursive then (
-      (* Generate a single value with $defs containing all types, $ref to first *)
-      let defs = List.map (fun (name, schema, _) -> name, schema) results in
-      let combined_schema = Schema.with_multi_defs ~loc ~primary_type defs in
-      let primary_value = create_value ~loc primary_type combined_schema in
-      (* Generate individual values, each with the full $defs and $ref to their own type *)
+      (* Second pass: regenerate with extra_defs_var so hoisting code is emitted *)
+      let edv = evar ~loc "_ppx_eds" in
+      let raw_results2 =
+        List.map
+          (fun td -> derive_single_type ~loc ~config ~recursive_types ~extra_defs_var:edv td)
+          type_decls
+      in
+      let defs2 = List.map (fun (name, raw, _, _, _) -> name, raw) raw_results2 in
+      (* Build $defs from raw schemas, then wrap the combined schema with type params.
+         Each binding gets its own _ppx_eds ref so hoisted defs don't leak across. *)
+      let primary_value =
+        let _, _, _, params, prefix =
+          List.find (fun (name, _, _, _, _) -> name = primary_type) raw_results2
+        in
+        let schema_inner = Schema.with_multi_defs ~loc ~primary_type ~extra_defs_var:edv defs2 in
+        let schema =
+          wrap_type_params ~loc ~prefix params
+            [%expr
+              let _ppx_eds = ref [] in
+              [%e schema_inner]]
+        in
+        create_value ~loc primary_type schema
+      in
       let other_values =
         List.filter_map
-          (fun (name, _, _) ->
+          (fun (name, _, _, params, prefix) ->
             if name = primary_type then None
-            else Some (create_value ~loc name (Schema.with_multi_defs ~loc ~primary_type:name defs)))
-          results
+            else
+              let schema_inner =
+                Schema.with_multi_defs ~loc ~primary_type:name ~extra_defs_var:edv defs2
+              in
+              let schema =
+                wrap_type_params ~loc ~prefix params
+                  [%expr
+                    let _ppx_eds = ref [] in
+                    [%e schema_inner]]
+              in
+              Some (create_value ~loc name schema))
+          raw_results2
       in
       primary_value :: other_values)
     else
-      (* No recursion detected - generate independent schemas *)
-      List.map (fun (name, schema, _) -> create_value ~loc name schema) results
+      (* No recursion detected - wrap params and generate independent schemas *)
+      List.map
+        (fun (name, raw, _, params, prefix) ->
+          create_value ~loc name (wrap_type_params ~loc ~prefix params raw))
+        raw_results
   | _, _ -> [%str [%ocaml.error "ppx_deriving_jsonschema: unsupported type"]]
 
 let generator () = Deriving.Generator.V2.make ~attributes (args ()) derive_jsonschema

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -121,7 +121,20 @@ include
         [("type", (`String "object"));
         ("properties",
           (`Assoc
-             [("m2", Mod1.Mod2.m_2_jsonschema); ("m", Mod1.m_1_jsonschema)]));
+             [("m2",
+                ((match Mod1.Mod2.m_2_jsonschema with
+                  | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                      `Assoc
+                        (("$id", (`String "urn:jsonschema:test.ml:78:1882"))
+                        :: (List.filter (fun (k, _) -> k <> "$id") pairs))
+                  | other -> other)));
+             ("m",
+               ((match Mod1.m_1_jsonschema with
+                 | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                     `Assoc
+                       (("$id", (`String "urn:jsonschema:test.ml:77:1865"))
+                       :: (List.filter (fun (k, _) -> k <> "$id") pairs))
+                 | other -> other)))]));
         ("required", (`List [`String "m2"; `String "m"]));
         ("additionalProperties", (`Bool false))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
@@ -467,7 +480,12 @@ include
                 ("unevaluatedItems", (`Bool false));
                 ("minItems", (`Int 2));
                 ("maxItems", (`Int 2))];
-              poly_kind_jsonschema]))][@@warning "-32-39"]
+              (match poly_kind_jsonschema with
+               | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                   `Assoc
+                     (("$id", (`String "urn:jsonschema:test.ml:305:7119")) ::
+                     (List.filter (fun (k, _) -> k <> "$id") pairs))
+               | other -> other)]))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "poly_inherit" =
@@ -531,7 +549,12 @@ include
            (`List
               [`Assoc [("const", (`String "New_one"))];
               `Assoc [("const", (`String "Second_one"))];
-              poly_kind_as_string_jsonschema]))][@@warning "-32-39"]
+              (match poly_kind_as_string_jsonschema with
+               | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                   `Assoc
+                     (("$id", (`String "urn:jsonschema:test.ml:362:8515")) ::
+                     (List.filter (fun (k, _) -> k <> "$id") pairs))
+               | other -> other)]))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "poly_inherit_as_string" =
@@ -621,7 +644,13 @@ include
                        [("anyOf",
                           (`List [s; `Assoc [("type", (`String "null"))]]))])));
              ("comment", (`Assoc [("type", (`String "string"))]));
-             ("kind_f", kind_jsonschema);
+             ("kind_f",
+               ((match kind_jsonschema with
+                 | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                     `Assoc
+                       (("$id", (`String "urn:jsonschema:test.ml:384:9016"))
+                       :: (List.filter (fun (k, _) -> k <> "$id") pairs))
+                 | other -> other)));
              ("date", (`Assoc [("type", (`String "number"))]))]));
         ("required",
           (`List
@@ -722,24 +751,24 @@ type recursive_record = {
 include
   struct
     let recursive_record_jsonschema =
+      let _ppx_eds = ref [] in
+      let _ppx_body =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("b",
+                  (`Assoc
+                     [("type", (`String "array"));
+                     ("items",
+                       (`Assoc
+                          [("$ref", (`String "#/$defs/recursive_record"))]))]));
+               ("a", (`Assoc [("type", (`String "integer"))]))]));
+          ("required", (`List [`String "b"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
       `Assoc
-        [("$defs",
-           (`Assoc
-              [("recursive_record",
-                 (`Assoc
-                    [("type", (`String "object"));
-                    ("properties",
-                      (`Assoc
-                         [("b",
-                            (`Assoc
-                               [("type", (`String "array"));
-                               ("items",
-                                 (`Assoc
-                                    [("$ref",
-                                       (`String "#/$defs/recursive_record"))]))]));
-                         ("a", (`Assoc [("type", (`String "integer"))]))]));
-                    ("required", (`List [`String "b"; `String "a"]));
-                    ("additionalProperties", (`Bool false))]))]));
+        [("$id", (`String "urn:jsonschema:recursive_record"));
+        ("$defs", (`Assoc (("recursive_record", _ppx_body) :: (!_ppx_eds))));
         ("$ref", (`String "#/$defs/recursive_record"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -749,6 +778,7 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:recursive_record",
       "$defs": {
         "recursive_record": {
           "type": "object",
@@ -772,31 +802,31 @@ type recursive_variant =
 include
   struct
     let recursive_variant_jsonschema =
+      let _ppx_eds = ref [] in
+      let _ppx_body =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        `Assoc
+                          [("$ref", (`String "#/$defs/recursive_variant"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "B"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))]]))] in
       `Assoc
-        [("$defs",
-           (`Assoc
-              [("recursive_variant",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc
-                             [("type", (`String "array"));
-                             ("prefixItems",
-                               (`List
-                                  [`Assoc [("const", (`String "A"))];
-                                  `Assoc
-                                    [("$ref",
-                                       (`String "#/$defs/recursive_variant"))]]));
-                             ("unevaluatedItems", (`Bool false));
-                             ("minItems", (`Int 2));
-                             ("maxItems", (`Int 2))];
-                          `Assoc
-                            [("type", (`String "array"));
-                            ("prefixItems",
-                              (`List [`Assoc [("const", (`String "B"))]]));
-                            ("unevaluatedItems", (`Bool false));
-                            ("minItems", (`Int 1));
-                            ("maxItems", (`Int 1))]]))]))]));
+        [("$id", (`String "urn:jsonschema:recursive_variant"));
+        ("$defs", (`Assoc (("recursive_variant", _ppx_body) :: (!_ppx_eds))));
         ("$ref", (`String "#/$defs/recursive_variant"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -806,6 +836,7 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:recursive_variant",
       "$defs": {
         "recursive_variant": {
           "anyOf": [
@@ -840,49 +871,45 @@ type tree =
 include
   struct
     let tree_jsonschema =
+      let _ppx_eds = ref [] in
+      let _ppx_body =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Leaf"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Node"))];
+                       `Assoc
+                         [("type", (`String "object"));
+                         ("properties",
+                           (`Assoc
+                              [("right",
+                                 (`Assoc [("$ref", (`String "#/$defs/tree"))]));
+                              ("left",
+                                (`Assoc [("$ref", (`String "#/$defs/tree"))]));
+                              ("value",
+                                (`Assoc [("type", (`String "integer"))]))]));
+                         ("required",
+                           (`List
+                              [`String "right";
+                              `String "left";
+                              `String "value"]));
+                         ("additionalProperties", (`Bool false))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
       `Assoc
-        [("$defs",
-           (`Assoc
-              [("tree",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc
-                             [("type", (`String "array"));
-                             ("prefixItems",
-                               (`List [`Assoc [("const", (`String "Leaf"))]]));
-                             ("unevaluatedItems", (`Bool false));
-                             ("minItems", (`Int 1));
-                             ("maxItems", (`Int 1))];
-                          `Assoc
-                            [("type", (`String "array"));
-                            ("prefixItems",
-                              (`List
-                                 [`Assoc [("const", (`String "Node"))];
-                                 `Assoc
-                                   [("type", (`String "object"));
-                                   ("properties",
-                                     (`Assoc
-                                        [("right",
-                                           (`Assoc
-                                              [("$ref",
-                                                 (`String "#/$defs/tree"))]));
-                                        ("left",
-                                          (`Assoc
-                                             [("$ref",
-                                                (`String "#/$defs/tree"))]));
-                                        ("value",
-                                          (`Assoc
-                                             [("type", (`String "integer"))]))]));
-                                   ("required",
-                                     (`List
-                                        [`String "right";
-                                        `String "left";
-                                        `String "value"]));
-                                   ("additionalProperties", (`Bool false))]]));
-                            ("unevaluatedItems", (`Bool false));
-                            ("minItems", (`Int 2));
-                            ("maxItems", (`Int 2))]]))]))]));
+        [("$id", (`String "urn:jsonschema:tree"));
+        ("$defs", (`Assoc (("tree", _ppx_body) :: (!_ppx_eds))));
         ("$ref", (`String "#/$defs/tree"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -892,6 +919,7 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:tree",
       "$defs": {
         "tree": {
           "anyOf": [
@@ -962,96 +990,84 @@ and bar = {
 include
   struct
     let foo_jsonschema =
+      let _ppx_eds = ref [] in
+      let _ppx_body_0 =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("bar",
+                  ((match `Assoc [("$ref", (`String "#/$defs/bar"))] with
+                    | `Assoc (("type", `String t)::[]) ->
+                        `Assoc
+                          [("type", (`List [`String t; `String "null"]))]
+                    | s ->
+                        `Assoc
+                          [("anyOf",
+                             (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+          ("required", (`List [`String "bar"]));
+          ("additionalProperties", (`Bool false))] in
+      let _ppx_body_1 =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("foo",
+                  ((match `Assoc [("$ref", (`String "#/$defs/foo"))] with
+                    | `Assoc (("type", `String t)::[]) ->
+                        `Assoc
+                          [("type", (`List [`String t; `String "null"]))]
+                    | s ->
+                        `Assoc
+                          [("anyOf",
+                             (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+          ("required", (`List [`String "foo"]));
+          ("additionalProperties", (`Bool false))] in
       `Assoc
-        [("$defs",
-           (`Assoc
-              [("foo",
-                 (`Assoc
-                    [("type", (`String "object"));
-                    ("properties",
-                      (`Assoc
-                         [("bar",
-                            ((match `Assoc
-                                      [("$ref", (`String "#/$defs/bar"))]
-                              with
-                              | `Assoc (("type", `String t)::[]) ->
-                                  `Assoc
-                                    [("type",
-                                       (`List [`String t; `String "null"]))]
-                              | s ->
-                                  `Assoc
-                                    [("anyOf",
-                                       (`List
-                                          [s;
-                                          `Assoc [("type", (`String "null"))]]))])))]));
-                    ("required", (`List [`String "bar"]));
-                    ("additionalProperties", (`Bool false))]));
-              ("bar",
-                (`Assoc
-                   [("type", (`String "object"));
-                   ("properties",
-                     (`Assoc
-                        [("foo",
-                           ((match `Assoc [("$ref", (`String "#/$defs/foo"))]
-                             with
-                             | `Assoc (("type", `String t)::[]) ->
-                                 `Assoc
-                                   [("type",
-                                      (`List [`String t; `String "null"]))]
-                             | s ->
-                                 `Assoc
-                                   [("anyOf",
-                                      (`List
-                                         [s;
-                                         `Assoc [("type", (`String "null"))]]))])))]));
-                   ("required", (`List [`String "foo"]));
-                   ("additionalProperties", (`Bool false))]))]));
+        [("$id", (`String "urn:jsonschema:foo"));
+        ("$defs",
+          (`Assoc
+             ([("foo", _ppx_body_0); ("bar", _ppx_body_1)] @ (!_ppx_eds))));
         ("$ref", (`String "#/$defs/foo"))][@@warning "-32-39"]
     let bar_jsonschema =
+      let _ppx_eds = ref [] in
+      let _ppx_body_0 =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("bar",
+                  ((match `Assoc [("$ref", (`String "#/$defs/bar"))] with
+                    | `Assoc (("type", `String t)::[]) ->
+                        `Assoc
+                          [("type", (`List [`String t; `String "null"]))]
+                    | s ->
+                        `Assoc
+                          [("anyOf",
+                             (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+          ("required", (`List [`String "bar"]));
+          ("additionalProperties", (`Bool false))] in
+      let _ppx_body_1 =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("foo",
+                  ((match `Assoc [("$ref", (`String "#/$defs/foo"))] with
+                    | `Assoc (("type", `String t)::[]) ->
+                        `Assoc
+                          [("type", (`List [`String t; `String "null"]))]
+                    | s ->
+                        `Assoc
+                          [("anyOf",
+                             (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+          ("required", (`List [`String "foo"]));
+          ("additionalProperties", (`Bool false))] in
       `Assoc
-        [("$defs",
-           (`Assoc
-              [("foo",
-                 (`Assoc
-                    [("type", (`String "object"));
-                    ("properties",
-                      (`Assoc
-                         [("bar",
-                            ((match `Assoc
-                                      [("$ref", (`String "#/$defs/bar"))]
-                              with
-                              | `Assoc (("type", `String t)::[]) ->
-                                  `Assoc
-                                    [("type",
-                                       (`List [`String t; `String "null"]))]
-                              | s ->
-                                  `Assoc
-                                    [("anyOf",
-                                       (`List
-                                          [s;
-                                          `Assoc [("type", (`String "null"))]]))])))]));
-                    ("required", (`List [`String "bar"]));
-                    ("additionalProperties", (`Bool false))]));
-              ("bar",
-                (`Assoc
-                   [("type", (`String "object"));
-                   ("properties",
-                     (`Assoc
-                        [("foo",
-                           ((match `Assoc [("$ref", (`String "#/$defs/foo"))]
-                             with
-                             | `Assoc (("type", `String t)::[]) ->
-                                 `Assoc
-                                   [("type",
-                                      (`List [`String t; `String "null"]))]
-                             | s ->
-                                 `Assoc
-                                   [("anyOf",
-                                      (`List
-                                         [s;
-                                         `Assoc [("type", (`String "null"))]]))])))]));
-                   ("required", (`List [`String "foo"]));
-                   ("additionalProperties", (`Bool false))]))]));
+        [("$id", (`String "urn:jsonschema:bar"));
+        ("$defs",
+          (`Assoc
+             ([("foo", _ppx_body_0); ("bar", _ppx_body_1)] @ (!_ppx_eds))));
         ("$ref", (`String "#/$defs/bar"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -1061,6 +1077,7 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:foo",
       "$defs": {
         "foo": {
           "type": "object",
@@ -1089,6 +1106,7 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:bar",
       "$defs": {
         "foo": {
           "type": "object",
@@ -1123,206 +1141,194 @@ and stmt =
 include
   struct
     let expr_jsonschema =
+      let _ppx_eds = ref [] in
+      let _ppx_body_0 =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "Literal"))];
+                        `Assoc [("type", (`String "integer"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Binary"))];
+                       `Assoc [("$ref", (`String "#/$defs/expr"))];
+                       `Assoc [("$ref", (`String "#/$defs/expr"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 3));
+                  ("maxItems", (`Int 3))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Block"))];
+                       `Assoc
+                         [("type", (`String "array"));
+                         ("items",
+                           (`Assoc [("$ref", (`String "#/$defs/stmt"))]))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      let _ppx_body_1 =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "ExprStmt"))];
+                        `Assoc [("$ref", (`String "#/$defs/expr"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "IfStmt"))];
+                       `Assoc
+                         [("type", (`String "object"));
+                         ("properties",
+                           (`Assoc
+                              [("else_",
+                                 ((match `Assoc
+                                           [("$ref",
+                                              (`String "#/$defs/stmt"))]
+                                   with
+                                   | `Assoc (("type", `String t)::[]) ->
+                                       `Assoc
+                                         [("type",
+                                            (`List
+                                               [`String t; `String "null"]))]
+                                   | s ->
+                                       `Assoc
+                                         [("anyOf",
+                                            (`List
+                                               [s;
+                                               `Assoc
+                                                 [("type", (`String "null"))]]))])));
+                              ("then_",
+                                (`Assoc [("$ref", (`String "#/$defs/stmt"))]));
+                              ("cond",
+                                (`Assoc [("$ref", (`String "#/$defs/expr"))]))]));
+                         ("required",
+                           (`List
+                              [`String "else_";
+                              `String "then_";
+                              `String "cond"]));
+                         ("additionalProperties", (`Bool false))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
       `Assoc
-        [("$defs",
-           (`Assoc
-              [("expr",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc
-                             [("type", (`String "array"));
-                             ("prefixItems",
-                               (`List
-                                  [`Assoc [("const", (`String "Literal"))];
-                                  `Assoc [("type", (`String "integer"))]]));
-                             ("unevaluatedItems", (`Bool false));
-                             ("minItems", (`Int 2));
-                             ("maxItems", (`Int 2))];
-                          `Assoc
-                            [("type", (`String "array"));
-                            ("prefixItems",
-                              (`List
-                                 [`Assoc [("const", (`String "Binary"))];
-                                 `Assoc [("$ref", (`String "#/$defs/expr"))];
-                                 `Assoc [("$ref", (`String "#/$defs/expr"))]]));
-                            ("unevaluatedItems", (`Bool false));
-                            ("minItems", (`Int 3));
-                            ("maxItems", (`Int 3))];
-                          `Assoc
-                            [("type", (`String "array"));
-                            ("prefixItems",
-                              (`List
-                                 [`Assoc [("const", (`String "Block"))];
-                                 `Assoc
-                                   [("type", (`String "array"));
-                                   ("items",
-                                     (`Assoc
-                                        [("$ref", (`String "#/$defs/stmt"))]))]]));
-                            ("unevaluatedItems", (`Bool false));
-                            ("minItems", (`Int 2));
-                            ("maxItems", (`Int 2))]]))]));
-              ("stmt",
-                (`Assoc
-                   [("anyOf",
-                      (`List
-                         [`Assoc
-                            [("type", (`String "array"));
-                            ("prefixItems",
-                              (`List
-                                 [`Assoc [("const", (`String "ExprStmt"))];
-                                 `Assoc [("$ref", (`String "#/$defs/expr"))]]));
-                            ("unevaluatedItems", (`Bool false));
-                            ("minItems", (`Int 2));
-                            ("maxItems", (`Int 2))];
-                         `Assoc
-                           [("type", (`String "array"));
-                           ("prefixItems",
-                             (`List
-                                [`Assoc [("const", (`String "IfStmt"))];
-                                `Assoc
-                                  [("type", (`String "object"));
-                                  ("properties",
-                                    (`Assoc
-                                       [("else_",
-                                          ((match `Assoc
-                                                    [("$ref",
-                                                       (`String
-                                                          "#/$defs/stmt"))]
-                                            with
-                                            | `Assoc
-                                                (("type", `String t)::[]) ->
-                                                `Assoc
-                                                  [("type",
-                                                     (`List
-                                                        [`String t;
-                                                        `String "null"]))]
-                                            | s ->
-                                                `Assoc
-                                                  [("anyOf",
-                                                     (`List
-                                                        [s;
-                                                        `Assoc
-                                                          [("type",
-                                                             (`String "null"))]]))])));
-                                       ("then_",
-                                         (`Assoc
-                                            [("$ref",
-                                               (`String "#/$defs/stmt"))]));
-                                       ("cond",
-                                         (`Assoc
-                                            [("$ref",
-                                               (`String "#/$defs/expr"))]))]));
-                                  ("required",
-                                    (`List
-                                       [`String "else_";
-                                       `String "then_";
-                                       `String "cond"]));
-                                  ("additionalProperties", (`Bool false))]]));
-                           ("unevaluatedItems", (`Bool false));
-                           ("minItems", (`Int 2));
-                           ("maxItems", (`Int 2))]]))]))]));
+        [("$id", (`String "urn:jsonschema:expr"));
+        ("$defs",
+          (`Assoc
+             ([("expr", _ppx_body_0); ("stmt", _ppx_body_1)] @ (!_ppx_eds))));
         ("$ref", (`String "#/$defs/expr"))][@@warning "-32-39"]
     let stmt_jsonschema =
+      let _ppx_eds = ref [] in
+      let _ppx_body_0 =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "Literal"))];
+                        `Assoc [("type", (`String "integer"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Binary"))];
+                       `Assoc [("$ref", (`String "#/$defs/expr"))];
+                       `Assoc [("$ref", (`String "#/$defs/expr"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 3));
+                  ("maxItems", (`Int 3))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Block"))];
+                       `Assoc
+                         [("type", (`String "array"));
+                         ("items",
+                           (`Assoc [("$ref", (`String "#/$defs/stmt"))]))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      let _ppx_body_1 =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "ExprStmt"))];
+                        `Assoc [("$ref", (`String "#/$defs/expr"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "IfStmt"))];
+                       `Assoc
+                         [("type", (`String "object"));
+                         ("properties",
+                           (`Assoc
+                              [("else_",
+                                 ((match `Assoc
+                                           [("$ref",
+                                              (`String "#/$defs/stmt"))]
+                                   with
+                                   | `Assoc (("type", `String t)::[]) ->
+                                       `Assoc
+                                         [("type",
+                                            (`List
+                                               [`String t; `String "null"]))]
+                                   | s ->
+                                       `Assoc
+                                         [("anyOf",
+                                            (`List
+                                               [s;
+                                               `Assoc
+                                                 [("type", (`String "null"))]]))])));
+                              ("then_",
+                                (`Assoc [("$ref", (`String "#/$defs/stmt"))]));
+                              ("cond",
+                                (`Assoc [("$ref", (`String "#/$defs/expr"))]))]));
+                         ("required",
+                           (`List
+                              [`String "else_";
+                              `String "then_";
+                              `String "cond"]));
+                         ("additionalProperties", (`Bool false))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
       `Assoc
-        [("$defs",
-           (`Assoc
-              [("expr",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc
-                             [("type", (`String "array"));
-                             ("prefixItems",
-                               (`List
-                                  [`Assoc [("const", (`String "Literal"))];
-                                  `Assoc [("type", (`String "integer"))]]));
-                             ("unevaluatedItems", (`Bool false));
-                             ("minItems", (`Int 2));
-                             ("maxItems", (`Int 2))];
-                          `Assoc
-                            [("type", (`String "array"));
-                            ("prefixItems",
-                              (`List
-                                 [`Assoc [("const", (`String "Binary"))];
-                                 `Assoc [("$ref", (`String "#/$defs/expr"))];
-                                 `Assoc [("$ref", (`String "#/$defs/expr"))]]));
-                            ("unevaluatedItems", (`Bool false));
-                            ("minItems", (`Int 3));
-                            ("maxItems", (`Int 3))];
-                          `Assoc
-                            [("type", (`String "array"));
-                            ("prefixItems",
-                              (`List
-                                 [`Assoc [("const", (`String "Block"))];
-                                 `Assoc
-                                   [("type", (`String "array"));
-                                   ("items",
-                                     (`Assoc
-                                        [("$ref", (`String "#/$defs/stmt"))]))]]));
-                            ("unevaluatedItems", (`Bool false));
-                            ("minItems", (`Int 2));
-                            ("maxItems", (`Int 2))]]))]));
-              ("stmt",
-                (`Assoc
-                   [("anyOf",
-                      (`List
-                         [`Assoc
-                            [("type", (`String "array"));
-                            ("prefixItems",
-                              (`List
-                                 [`Assoc [("const", (`String "ExprStmt"))];
-                                 `Assoc [("$ref", (`String "#/$defs/expr"))]]));
-                            ("unevaluatedItems", (`Bool false));
-                            ("minItems", (`Int 2));
-                            ("maxItems", (`Int 2))];
-                         `Assoc
-                           [("type", (`String "array"));
-                           ("prefixItems",
-                             (`List
-                                [`Assoc [("const", (`String "IfStmt"))];
-                                `Assoc
-                                  [("type", (`String "object"));
-                                  ("properties",
-                                    (`Assoc
-                                       [("else_",
-                                          ((match `Assoc
-                                                    [("$ref",
-                                                       (`String
-                                                          "#/$defs/stmt"))]
-                                            with
-                                            | `Assoc
-                                                (("type", `String t)::[]) ->
-                                                `Assoc
-                                                  [("type",
-                                                     (`List
-                                                        [`String t;
-                                                        `String "null"]))]
-                                            | s ->
-                                                `Assoc
-                                                  [("anyOf",
-                                                     (`List
-                                                        [s;
-                                                        `Assoc
-                                                          [("type",
-                                                             (`String "null"))]]))])));
-                                       ("then_",
-                                         (`Assoc
-                                            [("$ref",
-                                               (`String "#/$defs/stmt"))]));
-                                       ("cond",
-                                         (`Assoc
-                                            [("$ref",
-                                               (`String "#/$defs/expr"))]))]));
-                                  ("required",
-                                    (`List
-                                       [`String "else_";
-                                       `String "then_";
-                                       `String "cond"]));
-                                  ("additionalProperties", (`Bool false))]]));
-                           ("unevaluatedItems", (`Bool false));
-                           ("minItems", (`Int 2));
-                           ("maxItems", (`Int 2))]]))]))]));
+        [("$id", (`String "urn:jsonschema:stmt"));
+        ("$defs",
+          (`Assoc
+             ([("expr", _ppx_body_0); ("stmt", _ppx_body_1)] @ (!_ppx_eds))));
         ("$ref", (`String "#/$defs/stmt"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -1332,6 +1338,7 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:expr",
       "$defs": {
         "expr": {
           "anyOf": [
@@ -1462,334 +1469,250 @@ and node_c = {
 include
   struct
     let node_a_jsonschema =
+      let _ppx_eds = ref [] in
+      let _ppx_body_0 =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("c",
+                  ((match `Assoc [("$ref", (`String "#/$defs/node_c"))] with
+                    | `Assoc (("type", `String t)::[]) ->
+                        `Assoc
+                          [("type", (`List [`String t; `String "null"]))]
+                    | s ->
+                        `Assoc
+                          [("anyOf",
+                             (`List [s; `Assoc [("type", (`String "null"))]]))])));
+               ("b",
+                 ((match `Assoc [("$ref", (`String "#/$defs/node_b"))] with
+                   | `Assoc (("type", `String t)::[]) ->
+                       `Assoc [("type", (`List [`String t; `String "null"]))]
+                   | s ->
+                       `Assoc
+                         [("anyOf",
+                            (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+          ("required", (`List [`String "c"; `String "b"]));
+          ("additionalProperties", (`Bool false))] in
+      let _ppx_body_1 =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("c",
+                  ((match `Assoc [("$ref", (`String "#/$defs/node_c"))] with
+                    | `Assoc (("type", `String t)::[]) ->
+                        `Assoc
+                          [("type", (`List [`String t; `String "null"]))]
+                    | s ->
+                        `Assoc
+                          [("anyOf",
+                             (`List [s; `Assoc [("type", (`String "null"))]]))])));
+               ("a",
+                 ((match `Assoc [("$ref", (`String "#/$defs/node_a"))] with
+                   | `Assoc (("type", `String t)::[]) ->
+                       `Assoc [("type", (`List [`String t; `String "null"]))]
+                   | s ->
+                       `Assoc
+                         [("anyOf",
+                            (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+          ("required", (`List [`String "c"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
+      let _ppx_body_2 =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("b",
+                  ((match `Assoc [("$ref", (`String "#/$defs/node_b"))] with
+                    | `Assoc (("type", `String t)::[]) ->
+                        `Assoc
+                          [("type", (`List [`String t; `String "null"]))]
+                    | s ->
+                        `Assoc
+                          [("anyOf",
+                             (`List [s; `Assoc [("type", (`String "null"))]]))])));
+               ("a",
+                 ((match `Assoc [("$ref", (`String "#/$defs/node_a"))] with
+                   | `Assoc (("type", `String t)::[]) ->
+                       `Assoc [("type", (`List [`String t; `String "null"]))]
+                   | s ->
+                       `Assoc
+                         [("anyOf",
+                            (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+          ("required", (`List [`String "b"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
       `Assoc
-        [("$defs",
-           (`Assoc
-              [("node_a",
-                 (`Assoc
-                    [("type", (`String "object"));
-                    ("properties",
-                      (`Assoc
-                         [("c",
-                            ((match `Assoc
-                                      [("$ref", (`String "#/$defs/node_c"))]
-                              with
-                              | `Assoc (("type", `String t)::[]) ->
-                                  `Assoc
-                                    [("type",
-                                       (`List [`String t; `String "null"]))]
-                              | s ->
-                                  `Assoc
-                                    [("anyOf",
-                                       (`List
-                                          [s;
-                                          `Assoc [("type", (`String "null"))]]))])));
-                         ("b",
-                           ((match `Assoc
-                                     [("$ref", (`String "#/$defs/node_b"))]
-                             with
-                             | `Assoc (("type", `String t)::[]) ->
-                                 `Assoc
-                                   [("type",
-                                      (`List [`String t; `String "null"]))]
-                             | s ->
-                                 `Assoc
-                                   [("anyOf",
-                                      (`List
-                                         [s;
-                                         `Assoc [("type", (`String "null"))]]))])))]));
-                    ("required", (`List [`String "c"; `String "b"]));
-                    ("additionalProperties", (`Bool false))]));
-              ("node_b",
-                (`Assoc
-                   [("type", (`String "object"));
-                   ("properties",
-                     (`Assoc
-                        [("c",
-                           ((match `Assoc
-                                     [("$ref", (`String "#/$defs/node_c"))]
-                             with
-                             | `Assoc (("type", `String t)::[]) ->
-                                 `Assoc
-                                   [("type",
-                                      (`List [`String t; `String "null"]))]
-                             | s ->
-                                 `Assoc
-                                   [("anyOf",
-                                      (`List
-                                         [s;
-                                         `Assoc [("type", (`String "null"))]]))])));
-                        ("a",
-                          ((match `Assoc
-                                    [("$ref", (`String "#/$defs/node_a"))]
-                            with
-                            | `Assoc (("type", `String t)::[]) ->
-                                `Assoc
-                                  [("type",
-                                     (`List [`String t; `String "null"]))]
-                            | s ->
-                                `Assoc
-                                  [("anyOf",
-                                     (`List
-                                        [s;
-                                        `Assoc [("type", (`String "null"))]]))])))]));
-                   ("required", (`List [`String "c"; `String "a"]));
-                   ("additionalProperties", (`Bool false))]));
-              ("node_c",
-                (`Assoc
-                   [("type", (`String "object"));
-                   ("properties",
-                     (`Assoc
-                        [("b",
-                           ((match `Assoc
-                                     [("$ref", (`String "#/$defs/node_b"))]
-                             with
-                             | `Assoc (("type", `String t)::[]) ->
-                                 `Assoc
-                                   [("type",
-                                      (`List [`String t; `String "null"]))]
-                             | s ->
-                                 `Assoc
-                                   [("anyOf",
-                                      (`List
-                                         [s;
-                                         `Assoc [("type", (`String "null"))]]))])));
-                        ("a",
-                          ((match `Assoc
-                                    [("$ref", (`String "#/$defs/node_a"))]
-                            with
-                            | `Assoc (("type", `String t)::[]) ->
-                                `Assoc
-                                  [("type",
-                                     (`List [`String t; `String "null"]))]
-                            | s ->
-                                `Assoc
-                                  [("anyOf",
-                                     (`List
-                                        [s;
-                                        `Assoc [("type", (`String "null"))]]))])))]));
-                   ("required", (`List [`String "b"; `String "a"]));
-                   ("additionalProperties", (`Bool false))]))]));
+        [("$id", (`String "urn:jsonschema:node_a"));
+        ("$defs",
+          (`Assoc
+             ([("node_a", _ppx_body_0);
+              ("node_b", _ppx_body_1);
+              ("node_c", _ppx_body_2)] @ (!_ppx_eds))));
         ("$ref", (`String "#/$defs/node_a"))][@@warning "-32-39"]
     let node_b_jsonschema =
+      let _ppx_eds = ref [] in
+      let _ppx_body_0 =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("c",
+                  ((match `Assoc [("$ref", (`String "#/$defs/node_c"))] with
+                    | `Assoc (("type", `String t)::[]) ->
+                        `Assoc
+                          [("type", (`List [`String t; `String "null"]))]
+                    | s ->
+                        `Assoc
+                          [("anyOf",
+                             (`List [s; `Assoc [("type", (`String "null"))]]))])));
+               ("b",
+                 ((match `Assoc [("$ref", (`String "#/$defs/node_b"))] with
+                   | `Assoc (("type", `String t)::[]) ->
+                       `Assoc [("type", (`List [`String t; `String "null"]))]
+                   | s ->
+                       `Assoc
+                         [("anyOf",
+                            (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+          ("required", (`List [`String "c"; `String "b"]));
+          ("additionalProperties", (`Bool false))] in
+      let _ppx_body_1 =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("c",
+                  ((match `Assoc [("$ref", (`String "#/$defs/node_c"))] with
+                    | `Assoc (("type", `String t)::[]) ->
+                        `Assoc
+                          [("type", (`List [`String t; `String "null"]))]
+                    | s ->
+                        `Assoc
+                          [("anyOf",
+                             (`List [s; `Assoc [("type", (`String "null"))]]))])));
+               ("a",
+                 ((match `Assoc [("$ref", (`String "#/$defs/node_a"))] with
+                   | `Assoc (("type", `String t)::[]) ->
+                       `Assoc [("type", (`List [`String t; `String "null"]))]
+                   | s ->
+                       `Assoc
+                         [("anyOf",
+                            (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+          ("required", (`List [`String "c"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
+      let _ppx_body_2 =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("b",
+                  ((match `Assoc [("$ref", (`String "#/$defs/node_b"))] with
+                    | `Assoc (("type", `String t)::[]) ->
+                        `Assoc
+                          [("type", (`List [`String t; `String "null"]))]
+                    | s ->
+                        `Assoc
+                          [("anyOf",
+                             (`List [s; `Assoc [("type", (`String "null"))]]))])));
+               ("a",
+                 ((match `Assoc [("$ref", (`String "#/$defs/node_a"))] with
+                   | `Assoc (("type", `String t)::[]) ->
+                       `Assoc [("type", (`List [`String t; `String "null"]))]
+                   | s ->
+                       `Assoc
+                         [("anyOf",
+                            (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+          ("required", (`List [`String "b"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
       `Assoc
-        [("$defs",
-           (`Assoc
-              [("node_a",
-                 (`Assoc
-                    [("type", (`String "object"));
-                    ("properties",
-                      (`Assoc
-                         [("c",
-                            ((match `Assoc
-                                      [("$ref", (`String "#/$defs/node_c"))]
-                              with
-                              | `Assoc (("type", `String t)::[]) ->
-                                  `Assoc
-                                    [("type",
-                                       (`List [`String t; `String "null"]))]
-                              | s ->
-                                  `Assoc
-                                    [("anyOf",
-                                       (`List
-                                          [s;
-                                          `Assoc [("type", (`String "null"))]]))])));
-                         ("b",
-                           ((match `Assoc
-                                     [("$ref", (`String "#/$defs/node_b"))]
-                             with
-                             | `Assoc (("type", `String t)::[]) ->
-                                 `Assoc
-                                   [("type",
-                                      (`List [`String t; `String "null"]))]
-                             | s ->
-                                 `Assoc
-                                   [("anyOf",
-                                      (`List
-                                         [s;
-                                         `Assoc [("type", (`String "null"))]]))])))]));
-                    ("required", (`List [`String "c"; `String "b"]));
-                    ("additionalProperties", (`Bool false))]));
-              ("node_b",
-                (`Assoc
-                   [("type", (`String "object"));
-                   ("properties",
-                     (`Assoc
-                        [("c",
-                           ((match `Assoc
-                                     [("$ref", (`String "#/$defs/node_c"))]
-                             with
-                             | `Assoc (("type", `String t)::[]) ->
-                                 `Assoc
-                                   [("type",
-                                      (`List [`String t; `String "null"]))]
-                             | s ->
-                                 `Assoc
-                                   [("anyOf",
-                                      (`List
-                                         [s;
-                                         `Assoc [("type", (`String "null"))]]))])));
-                        ("a",
-                          ((match `Assoc
-                                    [("$ref", (`String "#/$defs/node_a"))]
-                            with
-                            | `Assoc (("type", `String t)::[]) ->
-                                `Assoc
-                                  [("type",
-                                     (`List [`String t; `String "null"]))]
-                            | s ->
-                                `Assoc
-                                  [("anyOf",
-                                     (`List
-                                        [s;
-                                        `Assoc [("type", (`String "null"))]]))])))]));
-                   ("required", (`List [`String "c"; `String "a"]));
-                   ("additionalProperties", (`Bool false))]));
-              ("node_c",
-                (`Assoc
-                   [("type", (`String "object"));
-                   ("properties",
-                     (`Assoc
-                        [("b",
-                           ((match `Assoc
-                                     [("$ref", (`String "#/$defs/node_b"))]
-                             with
-                             | `Assoc (("type", `String t)::[]) ->
-                                 `Assoc
-                                   [("type",
-                                      (`List [`String t; `String "null"]))]
-                             | s ->
-                                 `Assoc
-                                   [("anyOf",
-                                      (`List
-                                         [s;
-                                         `Assoc [("type", (`String "null"))]]))])));
-                        ("a",
-                          ((match `Assoc
-                                    [("$ref", (`String "#/$defs/node_a"))]
-                            with
-                            | `Assoc (("type", `String t)::[]) ->
-                                `Assoc
-                                  [("type",
-                                     (`List [`String t; `String "null"]))]
-                            | s ->
-                                `Assoc
-                                  [("anyOf",
-                                     (`List
-                                        [s;
-                                        `Assoc [("type", (`String "null"))]]))])))]));
-                   ("required", (`List [`String "b"; `String "a"]));
-                   ("additionalProperties", (`Bool false))]))]));
+        [("$id", (`String "urn:jsonschema:node_b"));
+        ("$defs",
+          (`Assoc
+             ([("node_a", _ppx_body_0);
+              ("node_b", _ppx_body_1);
+              ("node_c", _ppx_body_2)] @ (!_ppx_eds))));
         ("$ref", (`String "#/$defs/node_b"))][@@warning "-32-39"]
     let node_c_jsonschema =
+      let _ppx_eds = ref [] in
+      let _ppx_body_0 =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("c",
+                  ((match `Assoc [("$ref", (`String "#/$defs/node_c"))] with
+                    | `Assoc (("type", `String t)::[]) ->
+                        `Assoc
+                          [("type", (`List [`String t; `String "null"]))]
+                    | s ->
+                        `Assoc
+                          [("anyOf",
+                             (`List [s; `Assoc [("type", (`String "null"))]]))])));
+               ("b",
+                 ((match `Assoc [("$ref", (`String "#/$defs/node_b"))] with
+                   | `Assoc (("type", `String t)::[]) ->
+                       `Assoc [("type", (`List [`String t; `String "null"]))]
+                   | s ->
+                       `Assoc
+                         [("anyOf",
+                            (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+          ("required", (`List [`String "c"; `String "b"]));
+          ("additionalProperties", (`Bool false))] in
+      let _ppx_body_1 =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("c",
+                  ((match `Assoc [("$ref", (`String "#/$defs/node_c"))] with
+                    | `Assoc (("type", `String t)::[]) ->
+                        `Assoc
+                          [("type", (`List [`String t; `String "null"]))]
+                    | s ->
+                        `Assoc
+                          [("anyOf",
+                             (`List [s; `Assoc [("type", (`String "null"))]]))])));
+               ("a",
+                 ((match `Assoc [("$ref", (`String "#/$defs/node_a"))] with
+                   | `Assoc (("type", `String t)::[]) ->
+                       `Assoc [("type", (`List [`String t; `String "null"]))]
+                   | s ->
+                       `Assoc
+                         [("anyOf",
+                            (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+          ("required", (`List [`String "c"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
+      let _ppx_body_2 =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("b",
+                  ((match `Assoc [("$ref", (`String "#/$defs/node_b"))] with
+                    | `Assoc (("type", `String t)::[]) ->
+                        `Assoc
+                          [("type", (`List [`String t; `String "null"]))]
+                    | s ->
+                        `Assoc
+                          [("anyOf",
+                             (`List [s; `Assoc [("type", (`String "null"))]]))])));
+               ("a",
+                 ((match `Assoc [("$ref", (`String "#/$defs/node_a"))] with
+                   | `Assoc (("type", `String t)::[]) ->
+                       `Assoc [("type", (`List [`String t; `String "null"]))]
+                   | s ->
+                       `Assoc
+                         [("anyOf",
+                            (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+          ("required", (`List [`String "b"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
       `Assoc
-        [("$defs",
-           (`Assoc
-              [("node_a",
-                 (`Assoc
-                    [("type", (`String "object"));
-                    ("properties",
-                      (`Assoc
-                         [("c",
-                            ((match `Assoc
-                                      [("$ref", (`String "#/$defs/node_c"))]
-                              with
-                              | `Assoc (("type", `String t)::[]) ->
-                                  `Assoc
-                                    [("type",
-                                       (`List [`String t; `String "null"]))]
-                              | s ->
-                                  `Assoc
-                                    [("anyOf",
-                                       (`List
-                                          [s;
-                                          `Assoc [("type", (`String "null"))]]))])));
-                         ("b",
-                           ((match `Assoc
-                                     [("$ref", (`String "#/$defs/node_b"))]
-                             with
-                             | `Assoc (("type", `String t)::[]) ->
-                                 `Assoc
-                                   [("type",
-                                      (`List [`String t; `String "null"]))]
-                             | s ->
-                                 `Assoc
-                                   [("anyOf",
-                                      (`List
-                                         [s;
-                                         `Assoc [("type", (`String "null"))]]))])))]));
-                    ("required", (`List [`String "c"; `String "b"]));
-                    ("additionalProperties", (`Bool false))]));
-              ("node_b",
-                (`Assoc
-                   [("type", (`String "object"));
-                   ("properties",
-                     (`Assoc
-                        [("c",
-                           ((match `Assoc
-                                     [("$ref", (`String "#/$defs/node_c"))]
-                             with
-                             | `Assoc (("type", `String t)::[]) ->
-                                 `Assoc
-                                   [("type",
-                                      (`List [`String t; `String "null"]))]
-                             | s ->
-                                 `Assoc
-                                   [("anyOf",
-                                      (`List
-                                         [s;
-                                         `Assoc [("type", (`String "null"))]]))])));
-                        ("a",
-                          ((match `Assoc
-                                    [("$ref", (`String "#/$defs/node_a"))]
-                            with
-                            | `Assoc (("type", `String t)::[]) ->
-                                `Assoc
-                                  [("type",
-                                     (`List [`String t; `String "null"]))]
-                            | s ->
-                                `Assoc
-                                  [("anyOf",
-                                     (`List
-                                        [s;
-                                        `Assoc [("type", (`String "null"))]]))])))]));
-                   ("required", (`List [`String "c"; `String "a"]));
-                   ("additionalProperties", (`Bool false))]));
-              ("node_c",
-                (`Assoc
-                   [("type", (`String "object"));
-                   ("properties",
-                     (`Assoc
-                        [("b",
-                           ((match `Assoc
-                                     [("$ref", (`String "#/$defs/node_b"))]
-                             with
-                             | `Assoc (("type", `String t)::[]) ->
-                                 `Assoc
-                                   [("type",
-                                      (`List [`String t; `String "null"]))]
-                             | s ->
-                                 `Assoc
-                                   [("anyOf",
-                                      (`List
-                                         [s;
-                                         `Assoc [("type", (`String "null"))]]))])));
-                        ("a",
-                          ((match `Assoc
-                                    [("$ref", (`String "#/$defs/node_a"))]
-                            with
-                            | `Assoc (("type", `String t)::[]) ->
-                                `Assoc
-                                  [("type",
-                                     (`List [`String t; `String "null"]))]
-                            | s ->
-                                `Assoc
-                                  [("anyOf",
-                                     (`List
-                                        [s;
-                                        `Assoc [("type", (`String "null"))]]))])))]));
-                   ("required", (`List [`String "b"; `String "a"]));
-                   ("additionalProperties", (`Bool false))]))]));
+        [("$id", (`String "urn:jsonschema:node_c"));
+        ("$defs",
+          (`Assoc
+             ([("node_a", _ppx_body_0);
+              ("node_b", _ppx_body_1);
+              ("node_c", _ppx_body_2)] @ (!_ppx_eds))));
         ("$ref", (`String "#/$defs/node_c"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -1799,6 +1722,7 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:node_a",
       "$defs": {
         "node_a": {
           "type": "object",
@@ -1849,45 +1773,44 @@ type recursive_tuple =
 include
   struct
     let recursive_tuple_jsonschema =
+      let _ppx_eds = ref [] in
+      let _ppx_body =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "Leaf"))];
+                        `Assoc [("type", (`String "integer"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Branch"))];
+                       `Assoc
+                         [("type", (`String "array"));
+                         ("prefixItems",
+                           (`List
+                              [`Assoc
+                                 [("$ref",
+                                    (`String "#/$defs/recursive_tuple"))];
+                              `Assoc
+                                [("$ref",
+                                   (`String "#/$defs/recursive_tuple"))]]));
+                         ("unevaluatedItems", (`Bool false));
+                         ("minItems", (`Int 2));
+                         ("maxItems", (`Int 2))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
       `Assoc
-        [("$defs",
-           (`Assoc
-              [("recursive_tuple",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc
-                             [("type", (`String "array"));
-                             ("prefixItems",
-                               (`List
-                                  [`Assoc [("const", (`String "Leaf"))];
-                                  `Assoc [("type", (`String "integer"))]]));
-                             ("unevaluatedItems", (`Bool false));
-                             ("minItems", (`Int 2));
-                             ("maxItems", (`Int 2))];
-                          `Assoc
-                            [("type", (`String "array"));
-                            ("prefixItems",
-                              (`List
-                                 [`Assoc [("const", (`String "Branch"))];
-                                 `Assoc
-                                   [("type", (`String "array"));
-                                   ("prefixItems",
-                                     (`List
-                                        [`Assoc
-                                           [("$ref",
-                                              (`String
-                                                 "#/$defs/recursive_tuple"))];
-                                        `Assoc
-                                          [("$ref",
-                                             (`String
-                                                "#/$defs/recursive_tuple"))]]));
-                                   ("unevaluatedItems", (`Bool false));
-                                   ("minItems", (`Int 2));
-                                   ("maxItems", (`Int 2))]]));
-                            ("unevaluatedItems", (`Bool false));
-                            ("minItems", (`Int 2));
-                            ("maxItems", (`Int 2))]]))]))]));
+        [("$id", (`String "urn:jsonschema:recursive_tuple"));
+        ("$defs", (`Assoc (("recursive_tuple", _ppx_body) :: (!_ppx_eds))));
         ("$ref", (`String "#/$defs/recursive_tuple"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -1897,6 +1820,7 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:recursive_tuple",
       "$defs": {
         "recursive_tuple": {
           "anyOf": [
@@ -1934,8 +1858,14 @@ include
     |}]]
 type int_tree = tree[@@deriving jsonschema]
 include
-  struct let int_tree_jsonschema = tree_jsonschema[@@warning "-32-39"] end
-[@@ocaml.doc "@inline"][@@merlin.hide ]
+  struct
+    let int_tree_jsonschema =
+      match tree_jsonschema with
+      | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+          `Assoc (("$id", (`String "urn:jsonschema:test.ml:920:23215")) ::
+            (List.filter (fun (k, _) -> k <> "$id") pairs))
+      | other -> other[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "recursive_abstract_alias" =
     print_schema int_tree_jsonschema;
@@ -1943,6 +1873,7 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:test/test.ml:920:23215",
       "$defs": {
         "tree": {
           "anyOf": [
@@ -1982,8 +1913,14 @@ type events = event list[@@deriving jsonschema]
 include
   struct
     let events_jsonschema =
-      `Assoc [("type", (`String "array")); ("items", event_jsonschema)]
-      [@@warning "-32-39"]
+      `Assoc
+        [("type", (`String "array"));
+        ("items",
+          ((match event_jsonschema with
+            | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                `Assoc (("$id", (`String "urn:jsonschema:test.ml:965:24467"))
+                  :: (List.filter (fun (k, _) -> k <> "$id") pairs))
+            | other -> other)))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "events" =
@@ -2072,8 +2009,16 @@ include
       `Assoc
         [("type", (`String "array"));
         ("items",
-          (`Assoc [("type", (`String "array")); ("items", event_jsonschema)]))]
-      [@@warning "-32-39"]
+          (`Assoc
+             [("type", (`String "array"));
+             ("items",
+               ((match event_jsonschema with
+                 | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                     `Assoc
+                       (("$id",
+                          (`String "urn:jsonschema:test.ml:1047:27015"))
+                       :: (List.filter (fun (k, _) -> k <> "$id") pairs))
+                 | other -> other)))]))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "eventss" =
@@ -2165,7 +2110,14 @@ include
       `Assoc
         [("type", (`String "array"));
         ("prefixItems",
-          (`List [event_jsonschema; `Assoc [("type", (`String "string"))]]));
+          (`List
+             [(match event_jsonschema with
+               | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                   `Assoc
+                     (("$id", (`String "urn:jsonschema:test.ml:1132:29766"))
+                     :: (List.filter (fun (k, _) -> k <> "$id") pairs))
+               | other -> other);
+             `Assoc [("type", (`String "string"))]]));
         ("unevaluatedItems", (`Bool false));
         ("minItems", (`Int 2));
         ("maxItems", (`Int 2))][@@warning "-32-39"]
@@ -2261,8 +2213,14 @@ include
   struct
     let event_comments'_jsonschema =
       `Assoc
-        [("type", (`String "array")); ("items", event_comment_jsonschema)]
-      [@@warning "-32-39"]
+        [("type", (`String "array"));
+        ("items",
+          ((match event_comment_jsonschema with
+            | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                `Assoc
+                  (("$id", (`String "urn:jsonschema:test.ml:1220:32607")) ::
+                  (List.filter (fun (k, _) -> k <> "$id") pairs))
+            | other -> other)))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "event_comments'" =
@@ -2364,7 +2322,14 @@ include
              [("type", (`String "array"));
              ("prefixItems",
                (`List
-                  [event_jsonschema; `Assoc [("type", (`String "integer"))]]));
+                  [(match event_jsonschema with
+                    | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                        `Assoc
+                          (("$id",
+                             (`String "urn:jsonschema:test.ml:1311:35651"))
+                          :: (List.filter (fun (k, _) -> k <> "$id") pairs))
+                    | other -> other);
+                  `Assoc [("type", (`String "integer"))]]));
              ("unevaluatedItems", (`Bool false));
              ("minItems", (`Int 2));
              ("maxItems", (`Int 2))]))][@@warning "-32-39"]
@@ -2462,8 +2427,15 @@ type events_array = events array[@@deriving jsonschema]
 include
   struct
     let events_array_jsonschema =
-      `Assoc [("type", (`String "array")); ("items", events_jsonschema)]
-      [@@warning "-32-39"]
+      `Assoc
+        [("type", (`String "array"));
+        ("items",
+          ((match events_jsonschema with
+            | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                `Assoc
+                  (("$id", (`String "urn:jsonschema:test.ml:1402:38683")) ::
+                  (List.filter (fun (k, _) -> k <> "$id") pairs))
+            | other -> other)))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "events_array" =
@@ -2596,7 +2568,16 @@ include
     let using_m_jsonschema =
       `Assoc
         [("type", (`String "object"));
-        ("properties", (`Assoc [("m", Mod1.m_1_jsonschema)]));
+        ("properties",
+          (`Assoc
+             [("m",
+                ((match Mod1.m_1_jsonschema with
+                  | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                      `Assoc
+                        (("$id",
+                           (`String "urn:jsonschema:test.ml:1511:41955"))
+                        :: (List.filter (fun (k, _) -> k <> "$id") pairs))
+                  | other -> other)))]));
         ("required", (`List [`String "m"]));
         ("additionalProperties", (`Bool false))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
@@ -2783,7 +2764,14 @@ include
         [("type", (`String "object"));
         ("properties",
           (`Assoc
-             [("address", address_jsonschema);
+             [("address",
+                ((match address_jsonschema with
+                  | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                      `Assoc
+                        (("$id",
+                           (`String "urn:jsonschema:test.ml:1633:45167"))
+                        :: (List.filter (fun (k, _) -> k <> "$id") pairs))
+                  | other -> other)));
              ("email",
                ((match `Assoc [("type", (`String "string"))] with
                  | `Assoc (("type", `String t)::[]) ->
@@ -3601,7 +3589,16 @@ include
     let obj1_jsonschema =
       `Assoc
         [("type", (`String "object"));
-        ("properties", (`Assoc [("obj2", obj2_jsonschema)]));
+        ("properties",
+          (`Assoc
+             [("obj2",
+                ((match obj2_jsonschema with
+                  | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                      `Assoc
+                        (("$id",
+                           (`String "urn:jsonschema:test.ml:2107:56585"))
+                        :: (List.filter (fun (k, _) -> k <> "$id") pairs))
+                  | other -> other)))]));
         ("required", (`List [`String "obj2"]));
         ("additionalProperties", (`Bool false))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
@@ -3612,7 +3609,16 @@ include
     let nested_obj_jsonschema =
       `Assoc
         [("type", (`String "object"));
-        ("properties", (`Assoc [("obj1", obj1_jsonschema)]));
+        ("properties",
+          (`Assoc
+             [("obj1",
+                ((match obj1_jsonschema with
+                  | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                      `Assoc
+                        (("$id",
+                           (`String "urn:jsonschema:test.ml:2108:56643"))
+                        :: (List.filter (fun (k, _) -> k <> "$id") pairs))
+                  | other -> other)))]));
         ("required", (`List [`String "obj1"]));
         ("additionalProperties", (`Bool true))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
@@ -3724,8 +3730,13 @@ type string_link_traffic = string generic_link_traffic[@@deriving jsonschema]
 include
   struct
     let string_link_traffic_jsonschema =
-      generic_link_traffic_jsonschema (`Assoc [("type", (`String "string"))])
-      [@@warning "-32-39"]
+      match generic_link_traffic_jsonschema
+              (`Assoc [("type", (`String "string"))])
+      with
+      | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+          `Assoc (("$id", (`String "urn:jsonschema:test.ml:2182:58623")) ::
+            (List.filter (fun (k, _) -> k <> "$id") pairs))
+      | other -> other[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "instantiated_parameterized_record" =
@@ -3892,8 +3903,12 @@ include
 type ('a, 'b) either_alias = ('a, 'b) either[@@deriving jsonschema]
 include
   struct
-    let either_alias_jsonschema a b = either_jsonschema a b[@@warning
-                                                             "-32-39"]
+    let either_alias_jsonschema a b =
+      match either_jsonschema a b with
+      | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+          `Assoc (("$id", (`String "urn:jsonschema:test.ml:2294:61412")) ::
+            (List.filter (fun (k, _) -> k <> "$id") pairs))
+      | other -> other[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "multi_param_abstract" =
@@ -4022,7 +4037,15 @@ include
         ("properties",
           (`Assoc
              [("composing_type",
-                ((match composing_type_jsonschema with
+                ((match match composing_type_jsonschema with
+                        | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                            `Assoc
+                              (("$id",
+                                 (`String "urn:jsonschema:test.ml:2368:63427"))
+                              ::
+                              (List.filter (fun (k, _) -> k <> "$id") pairs))
+                        | other -> other
+                  with
                   | `Assoc (("type", `String t)::[]) ->
                       `Assoc [("type", (`List [`String t; `String "null"]))]
                   | s ->
@@ -4049,5 +4072,583 @@ include
       },
       "required": [],
       "additionalProperties": false
+    }
+    |}]]
+type 'a grade' =
+  | A of 'a 
+  | B of ('a grade' * 'a grade') 
+  | C 
+type 'a grade = 'a grade' =
+  | A of 'a 
+  | B of ('a grade * 'a grade) 
+  | C [@@deriving jsonschema]
+include
+  struct
+    let grade_jsonschema a =
+      let _ppx_eds = ref [] in
+      let _ppx_body =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "A"))]; a]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "B"))];
+                       `Assoc
+                         [("type", (`String "array"));
+                         ("prefixItems",
+                           (`List
+                              [`Assoc [("$ref", (`String "#/$defs/grade"))];
+                              `Assoc [("$ref", (`String "#/$defs/grade"))]]));
+                         ("unevaluatedItems", (`Bool false));
+                         ("minItems", (`Int 2));
+                         ("maxItems", (`Int 2))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "C"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))]]))] in
+      `Assoc
+        [("$id", (`String "urn:jsonschema:grade"));
+        ("$defs", (`Assoc (("grade", _ppx_body) :: (!_ppx_eds))));
+        ("$ref", (`String "#/$defs/grade"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "grade" =
+    print_schema (grade_jsonschema int_jsonschema);
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:grade",
+      "$defs": {
+        "grade": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "A" }, { "type": "integer" } ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "B" },
+                {
+                  "type": "array",
+                  "prefixItems": [
+                    { "$ref": "#/$defs/grade" }, { "$ref": "#/$defs/grade" }
+                  ],
+                  "unevaluatedItems": false,
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "C" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/grade"
+    }
+    |}]]
+type self_ref = {
+  children: self_ref list }[@@deriving jsonschema]
+include
+  struct
+    let self_ref_jsonschema =
+      let _ppx_eds = ref [] in
+      let _ppx_body =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("children",
+                  (`Assoc
+                     [("type", (`String "array"));
+                     ("items",
+                       (`Assoc [("$ref", (`String "#/$defs/self_ref"))]))]))]));
+          ("required", (`List [`String "children"]));
+          ("additionalProperties", (`Bool false))] in
+      `Assoc
+        [("$id", (`String "urn:jsonschema:self_ref"));
+        ("$defs", (`Assoc (("self_ref", _ppx_body) :: (!_ppx_eds))));
+        ("$ref", (`String "#/$defs/self_ref"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type two_self_refs = {
+  a: self_ref ;
+  b: self_ref }[@@deriving jsonschema]
+include
+  struct
+    let two_self_refs_jsonschema =
+      `Assoc
+        [("type", (`String "object"));
+        ("properties",
+          (`Assoc
+             [("b",
+                ((match self_ref_jsonschema with
+                  | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                      `Assoc
+                        (("$id",
+                           (`String "urn:jsonschema:test.ml:2456:65714"))
+                        :: (List.filter (fun (k, _) -> k <> "$id") pairs))
+                  | other -> other)));
+             ("a",
+               ((match self_ref_jsonschema with
+                 | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                     `Assoc
+                       (("$id",
+                          (`String "urn:jsonschema:test.ml:2455:65698"))
+                       :: (List.filter (fun (k, _) -> k <> "$id") pairs))
+                 | other -> other)))]));
+        ("required", (`List [`String "b"; `String "a"]));
+        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "no_duplicate_id_when_recursive_type_used_twice" =
+    print_schema two_self_refs_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "b": {
+          "$id": "urn:jsonschema:test/test.ml:2456:65714",
+          "$defs": {
+            "self_ref": {
+              "type": "object",
+              "properties": {
+                "children": {
+                  "type": "array",
+                  "items": { "$ref": "#/$defs/self_ref" }
+                }
+              },
+              "required": [ "children" ],
+              "additionalProperties": false
+            }
+          },
+          "$ref": "#/$defs/self_ref"
+        },
+        "a": {
+          "$id": "urn:jsonschema:test/test.ml:2455:65698",
+          "$defs": {
+            "self_ref": {
+              "type": "object",
+              "properties": {
+                "children": {
+                  "type": "array",
+                  "items": { "$ref": "#/$defs/self_ref" }
+                }
+              },
+              "required": [ "children" ],
+              "additionalProperties": false
+            }
+          },
+          "$ref": "#/$defs/self_ref"
+        }
+      },
+      "required": [ "b", "a" ],
+      "additionalProperties": false
+    }
+    |}]]
+type ('atom, 'group_atom) filter =
+  | Atom of 'atom 
+  | Group of ('atom, 'group_atom) filter list * 'group_atom [@@deriving
+                                                              jsonschema]
+include
+  struct
+    let filter_jsonschema atom group_atom =
+      let _ppx_eds = ref [] in
+      let _ppx_body =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Atom"))]; atom]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Group"))];
+                       `Assoc
+                         [("type", (`String "array"));
+                         ("items",
+                           (`Assoc [("$ref", (`String "#/$defs/filter"))]))];
+                       group_atom]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 3));
+                  ("maxItems", (`Int 3))]]))] in
+      `Assoc
+        [("$id", (`String "urn:jsonschema:filter"));
+        ("$defs", (`Assoc (("filter", _ppx_body) :: (!_ppx_eds))));
+        ("$ref", (`String "#/$defs/filter"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type ('atom, 'group_atom) bool_filter =
+  | BoolAtom of ('atom, 'group_atom) filter 
+  | BoolFilterGroup of ('atom, 'group_atom) bool_filter list [@@deriving
+                                                               jsonschema]
+include
+  struct
+    let bool_filter_jsonschema atom group_atom =
+      let _ppx_eds = ref [] in
+      let _ppx_body =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "BoolAtom"))];
+                        (match filter_jsonschema atom group_atom with
+                         | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                             `Assoc
+                               (("$id",
+                                  (`String
+                                     "urn:jsonschema:test.ml:2514:67360"))
+                               ::
+                               (List.filter (fun (k, _) -> k <> "$id") pairs))
+                         | other -> other)]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "BoolFilterGroup"))];
+                       `Assoc
+                         [("type", (`String "array"));
+                         ("items",
+                           (`Assoc
+                              [("$ref", (`String "#/$defs/bool_filter"))]))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      `Assoc
+        [("$id", (`String "urn:jsonschema:bool_filter"));
+        ("$defs", (`Assoc (("bool_filter", _ppx_body) :: (!_ppx_eds))));
+        ("$ref", (`String "#/$defs/bool_filter"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "polymorphic_recursive_ref" =
+    print_schema (filter_jsonschema int_jsonschema string_jsonschema);
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:filter",
+      "$defs": {
+        "filter": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Atom" }, { "type": "integer" } ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "Group" },
+                { "type": "array", "items": { "$ref": "#/$defs/filter" } },
+                { "type": "string" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 3,
+              "maxItems": 3
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/filter"
+    }
+    |}]]
+type 'a rec_wrapper =
+  | RWrap of 'a 
+  | RNested of 'a rec_wrapper [@@deriving jsonschema]
+include
+  struct
+    let rec_wrapper_jsonschema a =
+      let _ppx_eds = ref [] in
+      let _ppx_body =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "RWrap"))]; a]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "RNested"))];
+                       `Assoc [("$ref", (`String "#/$defs/rec_wrapper"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      `Assoc
+        [("$id", (`String "urn:jsonschema:rec_wrapper"));
+        ("$defs", (`Assoc (("rec_wrapper", _ppx_body) :: (!_ppx_eds))));
+        ("$ref", (`String "#/$defs/rec_wrapper"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type outer_rec =
+  | ORLeaf of int 
+  | ORNode of outer_rec rec_wrapper [@@deriving jsonschema]
+include
+  struct
+    let outer_rec_jsonschema =
+      let _ppx_eds = ref [] in
+      let _ppx_body =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "ORLeaf"))];
+                        `Assoc [("type", (`String "integer"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "ORNode"))];
+                       (let _ppx_sub =
+                          rec_wrapper_jsonschema
+                            (`Assoc [("$ref", (`String "#/$defs/outer_rec"))]) in
+                        match _ppx_sub with
+                        | `Assoc _ppx_pairs when
+                            List.mem_assoc "$defs" _ppx_pairs ->
+                            let _ppx_inner_defs =
+                              match List.assoc_opt "$defs" _ppx_pairs with
+                              | Some (`Assoc d) -> d
+                              | _ -> [] in
+                            let _ppx_suffix = "2561_68692" in
+                            let _ppx_mk n = n ^ ("__" ^ _ppx_suffix) in
+                            let _ppx_rmap =
+                              List.map (fun (n, _) -> (n, (_ppx_mk n)))
+                                _ppx_inner_defs in
+                            let rec _ppx_ren t =
+                              match t with
+                              | `Assoc pairs ->
+                                  `Assoc
+                                    (List.map
+                                       (fun (k, v) ->
+                                          let v' =
+                                            if k = "$ref"
+                                            then
+                                              match v with
+                                              | `String r when
+                                                  ((String.length r) > 8) &&
+                                                    ((String.sub r 0 8) =
+                                                       "#/$defs/")
+                                                  ->
+                                                  let n =
+                                                    String.sub r 8
+                                                      ((String.length r) - 8) in
+                                                  `String
+                                                    ("#/$defs/" ^
+                                                       ((match List.assoc_opt
+                                                                 n _ppx_rmap
+                                                         with
+                                                         | Some m -> m
+                                                         | None -> n)))
+                                              | _ -> v
+                                            else _ppx_ren v in
+                                          (k, v')) pairs)
+                              | `List xs -> `List (List.map _ppx_ren xs)
+                              | other -> other in
+                            let _ppx_hoisted =
+                              List.map
+                                (fun (n, b) -> ((_ppx_mk n), (_ppx_ren b)))
+                                _ppx_inner_defs in
+                            (_ppx_eds := ((!_ppx_eds) @ _ppx_hoisted);
+                             (match List.assoc_opt "$ref" _ppx_pairs with
+                              | Some (`String _ppx_r) when
+                                  ((String.length _ppx_r) > 8) &&
+                                    ((String.sub _ppx_r 0 8) = "#/$defs/")
+                                  ->
+                                  let _ppx_n =
+                                    String.sub _ppx_r 8
+                                      ((String.length _ppx_r) - 8) in
+                                  `Assoc
+                                    [("$ref",
+                                       (`String
+                                          ("#/$defs/" ^ (_ppx_mk _ppx_n))))]
+                              | _ ->
+                                  `Assoc
+                                    (List.filter (fun (k, _) -> k <> "$id")
+                                       _ppx_pairs)))
+                        | _ppx_other -> _ppx_other)]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      `Assoc
+        [("$id", (`String "urn:jsonschema:outer_rec"));
+        ("$defs", (`Assoc (("outer_rec", _ppx_body) :: (!_ppx_eds))));
+        ("$ref", (`String "#/$defs/outer_rec"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "parametric_recursive_cross_ref" =
+    print_schema outer_rec_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:outer_rec",
+      "$defs": {
+        "outer_rec": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "ORLeaf" }, { "type": "integer" } ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "ORNode" },
+                { "$ref": "#/$defs/rec_wrapper__2561_68692" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            }
+          ]
+        },
+        "rec_wrapper__2561_68692": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "RWrap" }, { "$ref": "#/$defs/outer_rec" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "RNested" },
+                { "$ref": "#/$defs/rec_wrapper__2561_68692" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/outer_rec"
+    }
+    |}]]
+[%%expect_test
+  let "polymorphic_recursive_ref_bool_filter" =
+    print_schema (bool_filter_jsonschema int_jsonschema string_jsonschema);
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:bool_filter",
+      "$defs": {
+        "bool_filter": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "BoolAtom" },
+                {
+                  "$id": "urn:jsonschema:test/test.ml:2514:67360",
+                  "$defs": {
+                    "filter": {
+                      "anyOf": [
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            { "const": "Atom" }, { "type": "integer" }
+                          ],
+                          "unevaluatedItems": false,
+                          "minItems": 2,
+                          "maxItems": 2
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            { "const": "Group" },
+                            {
+                              "type": "array",
+                              "items": { "$ref": "#/$defs/filter" }
+                            },
+                            { "type": "string" }
+                          ],
+                          "unevaluatedItems": false,
+                          "minItems": 3,
+                          "maxItems": 3
+                        }
+                      ]
+                    }
+                  },
+                  "$ref": "#/$defs/filter"
+                }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "BoolFilterGroup" },
+                { "type": "array", "items": { "$ref": "#/$defs/bool_filter" } }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/bool_filter"
     }
     |}]]

--- a/test/test.ml
+++ b/test/test.ml
@@ -2386,7 +2386,6 @@ let%expect_test "nullable_option_composing" =
     }
     |}]
 
-
 (* Parametric recursive type: the recursive call carries type arguments *)
 type 'a grade' =
   | A of 'a
@@ -2401,7 +2400,8 @@ type 'a grade = 'a grade' =
 
 let%expect_test "grade" =
   print_schema (grade_jsonschema int_jsonschema);
-  [%expect {|
+  [%expect
+    {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "urn:jsonschema:grade",
@@ -2448,8 +2448,7 @@ let%expect_test "grade" =
     |}]
 
 (* Recursive type referenced in two fields of the same parent record *)
-type self_ref = { children : self_ref list }
-[@@deriving jsonschema]
+type self_ref = { children : self_ref list } [@@deriving jsonschema]
 
 type two_self_refs = {
   a : self_ref;
@@ -2459,7 +2458,8 @@ type two_self_refs = {
 
 let%expect_test "no_duplicate_id_when_recursive_type_used_twice" =
   print_schema two_self_refs_jsonschema;
-  [%expect {|
+  [%expect
+    {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -2517,7 +2517,8 @@ type ('atom, 'group_atom) bool_filter =
 
 let%expect_test "polymorphic_recursive_ref" =
   print_schema (filter_jsonschema int_jsonschema string_jsonschema);
-  [%expect {|
+  [%expect
+    {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "urn:jsonschema:filter",
@@ -2563,7 +2564,8 @@ type outer_rec =
 
 let%expect_test "parametric_recursive_cross_ref" =
   print_schema outer_rec_jsonschema;
-  [%expect {|
+  [%expect
+    {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "urn:jsonschema:outer_rec",
@@ -2619,7 +2621,8 @@ let%expect_test "parametric_recursive_cross_ref" =
 
 let%expect_test "polymorphic_recursive_ref_bool_filter" =
   print_schema (bool_filter_jsonschema int_jsonschema string_jsonschema);
-  [%expect {|
+  [%expect
+    {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "urn:jsonschema:bool_filter",

--- a/test/test.ml
+++ b/test/test.ml
@@ -484,6 +484,7 @@ let%expect_test "recursive_record" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:recursive_record",
       "$defs": {
         "recursive_record": {
           "type": "object",
@@ -513,6 +514,7 @@ let%expect_test "recursive_variant" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:recursive_variant",
       "$defs": {
         "recursive_variant": {
           "anyOf": [
@@ -555,6 +557,7 @@ let%expect_test "tree" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:tree",
       "$defs": {
         "tree": {
           "anyOf": [
@@ -621,6 +624,7 @@ let%expect_test "mutually_recursive_foo" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:foo",
       "$defs": {
         "foo": {
           "type": "object",
@@ -649,6 +653,7 @@ let%expect_test "mutually_recursive_bar" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:bar",
       "$defs": {
         "foo": {
           "type": "object",
@@ -692,6 +697,7 @@ let%expect_test "mutually_recursive_expr" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:expr",
       "$defs": {
         "expr": {
           "anyOf": [
@@ -815,6 +821,7 @@ let%expect_test "three_way_mutual_recursion" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:node_a",
       "$defs": {
         "node_a": {
           "type": "object",
@@ -872,6 +879,7 @@ let%expect_test "recursive_tuple" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:recursive_tuple",
       "$defs": {
         "recursive_tuple": {
           "anyOf": [
@@ -917,6 +925,7 @@ let%expect_test "recursive_abstract_alias" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:test/test.ml:920:23215",
       "$defs": {
         "tree": {
           "anyOf": [
@@ -2374,5 +2383,304 @@ let%expect_test "nullable_option_composing" =
       },
       "required": [],
       "additionalProperties": false
+    }
+    |}]
+
+
+(* Parametric recursive type: the recursive call carries type arguments *)
+type 'a grade' =
+  | A of 'a
+  | B of ('a grade' * 'a grade')
+  | C
+
+type 'a grade = 'a grade' =
+  | A of 'a
+  | B of ('a grade * 'a grade)
+  | C
+[@@deriving jsonschema]
+
+let%expect_test "grade" =
+  print_schema (grade_jsonschema int_jsonschema);
+  [%expect {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:grade",
+      "$defs": {
+        "grade": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "A" }, { "type": "integer" } ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "B" },
+                {
+                  "type": "array",
+                  "prefixItems": [
+                    { "$ref": "#/$defs/grade" }, { "$ref": "#/$defs/grade" }
+                  ],
+                  "unevaluatedItems": false,
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "C" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/grade"
+    }
+    |}]
+
+(* Recursive type referenced in two fields of the same parent record *)
+type self_ref = { children : self_ref list }
+[@@deriving jsonschema]
+
+type two_self_refs = {
+  a : self_ref;
+  b : self_ref;
+}
+[@@deriving jsonschema]
+
+let%expect_test "no_duplicate_id_when_recursive_type_used_twice" =
+  print_schema two_self_refs_jsonschema;
+  [%expect {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "b": {
+          "$id": "urn:jsonschema:test/test.ml:2456:65714",
+          "$defs": {
+            "self_ref": {
+              "type": "object",
+              "properties": {
+                "children": {
+                  "type": "array",
+                  "items": { "$ref": "#/$defs/self_ref" }
+                }
+              },
+              "required": [ "children" ],
+              "additionalProperties": false
+            }
+          },
+          "$ref": "#/$defs/self_ref"
+        },
+        "a": {
+          "$id": "urn:jsonschema:test/test.ml:2455:65698",
+          "$defs": {
+            "self_ref": {
+              "type": "object",
+              "properties": {
+                "children": {
+                  "type": "array",
+                  "items": { "$ref": "#/$defs/self_ref" }
+                }
+              },
+              "required": [ "children" ],
+              "additionalProperties": false
+            }
+          },
+          "$ref": "#/$defs/self_ref"
+        }
+      },
+      "required": [ "b", "a" ],
+      "additionalProperties": false
+    }
+    |}]
+
+(* Polymorphic recursive type: the recursive reference carries type arguments *)
+type ('atom, 'group_atom) filter =
+  | Atom of 'atom
+  | Group of ('atom, 'group_atom) filter list * 'group_atom
+[@@deriving jsonschema]
+
+type ('atom, 'group_atom) bool_filter =
+  | BoolAtom of ('atom, 'group_atom) filter
+  | BoolFilterGroup of ('atom, 'group_atom) bool_filter list
+[@@deriving jsonschema]
+
+let%expect_test "polymorphic_recursive_ref" =
+  print_schema (filter_jsonschema int_jsonschema string_jsonschema);
+  [%expect {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:filter",
+      "$defs": {
+        "filter": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Atom" }, { "type": "integer" } ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "Group" },
+                { "type": "array", "items": { "$ref": "#/$defs/filter" } },
+                { "type": "string" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 3,
+              "maxItems": 3
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/filter"
+    }
+    |}]
+
+(* Cross-$ref bug: outer recursive type uses a parametric recursive type with
+   itself as the type argument *)
+type 'a rec_wrapper =
+  | RWrap of 'a
+  | RNested of 'a rec_wrapper
+[@@deriving jsonschema]
+
+type outer_rec =
+  | ORLeaf of int
+  | ORNode of outer_rec rec_wrapper
+[@@deriving jsonschema]
+
+let%expect_test "parametric_recursive_cross_ref" =
+  print_schema outer_rec_jsonschema;
+  [%expect {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:outer_rec",
+      "$defs": {
+        "outer_rec": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "ORLeaf" }, { "type": "integer" } ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "ORNode" },
+                { "$ref": "#/$defs/rec_wrapper__2561_68692" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            }
+          ]
+        },
+        "rec_wrapper__2561_68692": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "RWrap" }, { "$ref": "#/$defs/outer_rec" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "RNested" },
+                { "$ref": "#/$defs/rec_wrapper__2561_68692" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/outer_rec"
+    }
+    |}]
+
+let%expect_test "polymorphic_recursive_ref_bool_filter" =
+  print_schema (bool_filter_jsonschema int_jsonschema string_jsonschema);
+  [%expect {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "urn:jsonschema:bool_filter",
+      "$defs": {
+        "bool_filter": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "BoolAtom" },
+                {
+                  "$id": "urn:jsonschema:test/test.ml:2514:67360",
+                  "$defs": {
+                    "filter": {
+                      "anyOf": [
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            { "const": "Atom" }, { "type": "integer" }
+                          ],
+                          "unevaluatedItems": false,
+                          "minItems": 2,
+                          "maxItems": 2
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            { "const": "Group" },
+                            {
+                              "type": "array",
+                              "items": { "$ref": "#/$defs/filter" }
+                            },
+                            { "type": "string" }
+                          ],
+                          "unevaluatedItems": false,
+                          "minItems": 3,
+                          "maxItems": 3
+                        }
+                      ]
+                    }
+                  },
+                  "$ref": "#/$defs/filter"
+                }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "BoolFilterGroup" },
+                { "type": "array", "items": { "$ref": "#/$defs/bool_filter" } }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/bool_filter"
     }
     |}]


### PR DESCRIPTION
## Description

This PR solves 2 bugs:

Bug 1: For parametric recursive types such as type 'a grade = A of 'a | B of ('a grade * 'a grade), the deriver was inlining the schema at the recursive call site instead of emitting a $ref. This produced a schema that was structurally wrong (infinite expansion or broken references).

Bug 2: When an outer recursive type uses a parametric recursive type with itself as the type argument — e.g. type outer = ... | N of outer wrapper where wrapper is also recursive — the inner $defs block has its own $id, creating a JSON Schema resource boundary. Any $ref inside that inner schema (like #/$defs/wrapper) resolves against the inner $id instead of the outer root, producing wrong references at runtime.

## Solution 

A two-pass generation strategy is introduced. The first pass detects recursion; the second pass emits a _ppx_eds accumulator ref. When a recursive $ref is passed as an argument to a parametric type, the inner $defs are hoisted into the root schema's $defs with unique suffixed names, and the $ref is rewritten accordingly.


## Before

```ocaml
type 'a grade' = 
| A of 'a
| B of ('a grade' * 'a grade')
| C

type 'a grade = 'a grade' = 
| A of 'a
| B of ('a grade * 'a grade)
| C
[@@deriving jsonschema]

let%expect_test "grade" =
  print_schema (grade_jsonschema int_jsonschema);

(* Error:
File "test/test.ml", line 2308, characters 11-16:
2308 | | B of ('a grade * 'a grade)
                  ^^^^^
Error: Unbound value grade_jsonschema
Hint: Did you mean tree_jsonschema?
*)
```

## After

```ocaml
type 'a grade' = 
| A of 'a
| B of ('a grade' * 'a grade')
| C

type 'a grade = 'a grade' = 
| A of 'a
| B of ('a grade * 'a grade)
| C
[@@deriving jsonschema]

let%expect_test "grade" =
  print_schema (grade_jsonschema int_jsonschema);
  [%expect {|
    {
      "$schema": "https://json-schema.org/draft/2020-12/schema",
      "$defs": {
        "grade": {
          "anyOf": [
            {
              "type": "array",
              "prefixItems": [ { "const": "A" }, { "type": "integer" } ],
              "unevaluatedItems": false,
              "minItems": 2,
              "maxItems": 2
            },
            {
              "type": "array",
              "prefixItems": [
                { "const": "B" },
                {
                  "type": "array",
                  "prefixItems": [
                    { "$ref": "#/$defs/grade" }, { "$ref": "#/$defs/grade" }
                  ],
                  "unevaluatedItems": false,
                  "minItems": 2,
                  "maxItems": 2
                }
              ],
              "unevaluatedItems": false,
              "minItems": 2,
              "maxItems": 2
            },
            {
              "type": "array",
              "prefixItems": [ { "const": "C" } ],
              "unevaluatedItems": false,
              "minItems": 1,
              "maxItems": 1
            }
          ]
        }
      },
      "$ref": "#/$defs/grade"
    }
    |}]
```