### PR TITLE
Add jsonschema annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,42 @@ This will generate a schema that allows additional fields for the `User` variant
 }
 ```
 
+#### Annotations
+
+The `[@annotation "key" "value"]` attribute adds an arbitrary key-value pair to the generated schema. It can be used on record fields (single `@`) or type declarations (double `@@`), and can appear multiple times to add several annotations.
+
+```ocaml
+type user = {
+  name  : string;
+    [@annotation "description" "The user's full name"]
+    [@annotation "pattern" "^[A-Z].*"]
+  age   : int;    [@annotation "description" "Age in years"]
+  email : string option;
+}
+[@@deriving jsonschema]
+[@@annotation "description" "Represents a user account"]
+[@@annotation "title" "User"]
+```
+
+```json
+{
+  "title": "User",
+  "description": "Represents a user account",
+  "type": "object",
+  "properties": {
+    "email": { "type": "string" },
+    "age": { "description": "Age in years", "type": "integer" },
+    "name": {
+      "pattern": "^[A-Z].*",
+      "description": "The user's full name",
+      "type": "string"
+    }
+  },
+  "required": [ "age", "name" ],
+  "additionalProperties": false
+}
+```
+
 #### References
 
 Rather than inlining the definition of a type it is possible to use a [json schema `$ref`](https://json-schema.org/understanding-json-schema/structuring#dollarref) using the `[@ref "name"]` attribute. In such a case, the type definition must be passed to `Ppx_deriving_jsonschema_runtime.json_schema` as a parameter.

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -64,21 +64,28 @@ let get_annotations attributes =
         Attribute.mark_as_handled_manually attr;
         match attr.attr_payload with
         | PStr
-            [ { pstr_desc =
+            [
+              {
+                pstr_desc =
                   Pstr_eval
-                    ( { pexp_desc =
+                    ( {
+                        pexp_desc =
                           Pexp_apply
                             ( { pexp_desc = Pexp_constant (Pconst_string (key, _, _)); _ },
                               [ (Nolabel, { pexp_desc = Pexp_constant (Pconst_string (value, _, _)); _ }) ] );
-                        _ },
+                        _;
+                      },
                       _ );
-                _ }
-            ] -> Some (key, value)
+                _;
+              };
+            ] ->
+          Some (key, value)
         | _ ->
           Location.raise_errorf ~loc:attr.attr_name.loc
-            "ppx_deriving_jsonschema: [@@jsonschema.annotation] expects two string arguments, \
-             e.g. [@@jsonschema.annotation \"key\" \"value\"]"
-      end else None)
+            "ppx_deriving_jsonschema: [@@jsonschema.annotation] expects two string arguments, e.g. \
+             [@@jsonschema.annotation \"key\" \"value\"]"
+      end
+      else None)
     attributes
 
 (* Prepend arbitrary key-value pairs to a schema's assoc list. *)
@@ -87,9 +94,7 @@ let apply_annotations ~loc annotations schema =
   | [] -> schema
   | _ ->
     let annotation_fields =
-      List.map
-        (fun (key, value) -> [%expr [%e estring ~loc key], `String [%e estring ~loc value]])
-        annotations
+      List.map (fun (key, value) -> [%expr [%e estring ~loc key], `String [%e estring ~loc value]]) annotations
     in
     [%expr
       match [%e schema] with

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -53,6 +53,49 @@ let attributes =
     Attribute.T jsonschema_cd_allow_extra_fields;
   ]
 
+(* Collect all [@@jsonschema.annotation "key" "value"] attributes from a list.
+   ppxlib's Attribute.get raises on duplicates so we scan manually to support
+   multiple occurrences of the same attribute name. *)
+let get_annotations attributes =
+  List.filter_map
+    (fun attr ->
+      let name = attr.attr_name.txt in
+      if name = "jsonschema.annotation" || name = "annotation" then begin
+        Attribute.mark_as_handled_manually attr;
+        match attr.attr_payload with
+        | PStr
+            [ { pstr_desc =
+                  Pstr_eval
+                    ( { pexp_desc =
+                          Pexp_apply
+                            ( { pexp_desc = Pexp_constant (Pconst_string (key, _, _)); _ },
+                              [ (Nolabel, { pexp_desc = Pexp_constant (Pconst_string (value, _, _)); _ }) ] );
+                        _ },
+                      _ );
+                _ }
+            ] -> Some (key, value)
+        | _ ->
+          Location.raise_errorf ~loc:attr.attr_name.loc
+            "ppx_deriving_jsonschema: [@@jsonschema.annotation] expects two string arguments, \
+             e.g. [@@jsonschema.annotation \"key\" \"value\"]"
+      end else None)
+    attributes
+
+(* Prepend arbitrary key-value pairs to a schema's assoc list. *)
+let apply_annotations ~loc annotations schema =
+  match annotations with
+  | [] -> schema
+  | _ ->
+    let annotation_fields =
+      List.map
+        (fun (key, value) -> [%expr [%e estring ~loc key], `String [%e estring ~loc value]])
+        annotations
+    in
+    [%expr
+      match [%e schema] with
+      | `Assoc fields -> `Assoc ([%e elist ~loc annotation_fields] @ fields)
+      | other -> other]
+
 (* let args () = Deriving.Args.(empty) *)
 let args () = Deriving.Args.(empty +> flag "variant_as_string" +> flag "polymorphic_variant_tuple")
 
@@ -264,6 +307,8 @@ let object_ ~loc ~config ?(recursive_types = []) fields allow_extra_fields =
           | Some def -> Schema.type_ref ~loc def.txt, false
           | None -> type_of_core ~config ~recursive_types pld_type
         in
+        let field_annotations = get_annotations field.pld_attributes in
+        let type_def = apply_annotations ~loc field_annotations type_def in
         ( [%expr [%e estring ~loc name], [%e type_def]] :: fields,
           (if is_optional_type pld_type then required else { txt = name; loc } :: required),
           is_rec || field_rec ))
@@ -294,6 +339,7 @@ let derive_single_type ~loc ~config ~recursive_types type_decl =
   let type_name = type_decl.ptype_name.txt in
   let allow_extra_fields = Attribute.get jsonschema_td_allow_extra_fields type_decl |> Option.is_some in
   let params = List.map (fun tp -> (get_type_param_name tp).txt) type_decl.ptype_params in
+  let type_annotations = get_annotations type_decl.ptype_attributes in
   match type_decl.ptype_kind with
   | Ptype_variant variants ->
     let variants, is_rec =
@@ -323,14 +369,17 @@ let derive_single_type ~loc ~config ~recursive_types type_decl =
       | true -> variant_as_string ~loc variants, "_"
       | false -> variant_as_array ~loc variants, ""
     in
+    let schema = apply_annotations ~loc type_annotations schema in
     type_name, wrap_type_params ~loc ~prefix:params_prefix params schema, is_rec
   | Ptype_record label_declarations ->
     let schema, is_rec = object_ ~loc ~config ~recursive_types label_declarations allow_extra_fields in
+    let schema = apply_annotations ~loc type_annotations schema in
     type_name, wrap_type_params ~loc params schema, is_rec
   | Ptype_abstract ->
     (match type_decl.ptype_manifest with
     | Some core_type ->
       let schema, is_rec = type_of_core ~config ~recursive_types core_type in
+      let schema = apply_annotations ~loc type_annotations schema in
       type_name, wrap_type_params ~loc params schema, is_rec
     | None ->
       let msg = "ppx_deriving_jsonschema: abstract type without manifest" in

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -3575,3 +3575,74 @@ include
       "anyOf": [ { "const": "North" }, { "const": "South" } ]
     }
     |}]]
+type name = string[@@deriving jsonschema]
+include
+  struct
+    let name_jsonschema = `Assoc [("type", (`String "string"))][@@warning
+                                                                 "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type annotated_user =
+  {
+  name: name
+    [@annotation "description" "The user's full name"][@annotation
+                                                        "pattern" "^[A-Z].*"];
+  age: int [@annotation "description" "Age in years"];
+  email: string option }[@@deriving jsonschema][@@annotation
+                                                 "description"
+                                                   "Represents a user account"]
+[@@annotation "title" "User"]
+include
+  struct
+    let annotated_user_jsonschema =
+      match `Assoc
+              [("type", (`String "object"));
+              ("properties",
+                (`Assoc
+                   [("email", (`Assoc [("type", (`String "string"))]));
+                   ("age",
+                     ((match `Assoc [("type", (`String "integer"))] with
+                       | `Assoc fields ->
+                           `Assoc
+                             ([("description", (`String "Age in years"))] @
+                                fields)
+                       | other -> other)));
+                   ("name",
+                     ((match name_jsonschema with
+                       | `Assoc fields ->
+                           `Assoc
+                             ([("description",
+                                 (`String "The user's full name"));
+                              ("pattern", (`String "^[A-Z].*"))] @ fields)
+                       | other -> other)))]));
+              ("required", (`List [`String "age"; `String "name"]));
+              ("additionalProperties", (`Bool false))]
+      with
+      | `Assoc fields ->
+          `Assoc
+            ([("description", (`String "Represents a user account"));
+             ("title", (`String "User"))] @ fields)
+      | other -> other[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "annotated_user" =
+    print_schema annotated_user_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Represents a user account",
+      "title": "User",
+      "type": "object",
+      "properties": {
+        "email": { "type": "string" },
+        "age": { "description": "Age in years", "type": "integer" },
+        "name": {
+          "description": "The user's full name",
+          "pattern": "^[A-Z].*",
+          "type": "string"
+        }
+      },
+      "required": [ "age", "name" ],
+      "additionalProperties": false
+    }
+    |}]]

--- a/test/test.ml
+++ b/test/test.ml
@@ -2297,3 +2297,39 @@ let%expect_test "multi_param_variant_as_string" =
       "anyOf": [ { "const": "North" }, { "const": "South" } ]
     }
     |}]
+
+type name = string [@@deriving jsonschema]
+
+type annotated_user = {
+  name : name;
+    [@annotation "description" "The user's full name"]
+    [@annotation "pattern" "^[A-Z].*"]
+  age : int; [@annotation "description" "Age in years"]
+  email : string option;
+}
+[@@deriving jsonschema]
+[@@annotation "description" "Represents a user account"]
+[@@annotation "title" "User"]
+
+let%expect_test "annotated_user" =
+  print_schema annotated_user_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Represents a user account",
+      "title": "User",
+      "type": "object",
+      "properties": {
+        "email": { "type": "string" },
+        "age": { "description": "Age in years", "type": "integer" },
+        "name": {
+          "description": "The user's full name",
+          "pattern": "^[A-Z].*",
+          "type": "string"
+        }
+      },
+      "required": [ "age", "name" ],
+      "additionalProperties": false
+    }
+    |}]

--- a/test/test.ml
+++ b/test/test.ml
@@ -2301,15 +2301,11 @@ let%expect_test "multi_param_variant_as_string" =
 type name = string [@@deriving jsonschema]
 
 type annotated_user = {
-  name : name;
-    [@annotation "description" "The user's full name"]
-    [@annotation "pattern" "^[A-Z].*"]
+  name : name; [@annotation "description" "The user's full name"] [@annotation "pattern" "^[A-Z].*"]
   age : int; [@annotation "description" "Age in years"]
   email : string option;
 }
-[@@deriving jsonschema]
-[@@annotation "description" "Represents a user account"]
-[@@annotation "title" "User"]
+[@@deriving jsonschema] [@@annotation "description" "Represents a user account"] [@@annotation "title" "User"]
 
 let%expect_test "annotated_user" =
   print_schema annotated_user_jsonschema;


### PR DESCRIPTION
## Summary

- Adds a new `[@jsonschema.annotation "key" "value"]` attribute that injects arbitrary key-value pairs into the generated JSON schema
- Works on record fields (`@`) and type declarations (`@@`), and can appear multiple times on the same node
- Annotations are prepended to the schema's field list in source declaration order

## Notes

ppxlib's `Attribute.get` errors on duplicate attribute names, so this attribute cannot be declared via `Attribute.declare` in the normal way. Instead, raw attributes are scanned manually with `Attribute.mark_as_handled_manually` to satisfy ppxlib's hygiene checks.