### PR TITLE
Make option types nullable in generated JSON Schema

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
+# Next release
+- make option types nullable in generated JSON Schema (e.g. `int option` → `{"type":["integer","null"]}`); add `[@@jsonschema.option]` attribute to opt a field out of `required` without making its type nullable
+
 # 0.0.6
-- update jsonschema derivation to use t instead of Yojson.Basic for type signatures 
+- update jsonschema derivation to use t instead of Yojson.Basic for type signatures
 
 # 0.0.5
 

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -43,6 +43,9 @@ let jsonschema_cd_allow_extra_fields =
     Ast_pattern.(pstr nil)
     (fun () -> ())
 
+let jsonschema_option =
+  Attribute.declare_flag "jsonschema.option" Attribute.Context.label_declaration
+
 let attributes =
   [
     Attribute.T jsonschema_key;
@@ -51,6 +54,7 @@ let attributes =
     Attribute.T jsonschema_polymorphic_variant_name;
     Attribute.T jsonschema_td_allow_extra_fields;
     Attribute.T jsonschema_cd_allow_extra_fields;
+    Attribute.T jsonschema_option;
   ]
 
 (* let args () = Deriving.Args.(empty) *)
@@ -115,6 +119,15 @@ module Schema = struct
     let values = List.map (fun name -> [%expr `String [%e estring ~loc name]]) values in
     enum ~loc (Some "string") values
 
+  (* Make a schema explicitly nullable.
+     For simple {"type": "X"} schemas, produces {"type": ["X", "null"]}.
+     For complex schemas, falls back to {"anyOf": [schema, {"type": "null"}]}. *)
+  let nullable ~loc schema =
+    [%expr
+      match [%e schema] with
+      | `Assoc [ ("type", `String t) ] -> `Assoc [ "type", `List [ `String t; `String "null" ] ]
+      | s -> `Assoc [ "anyOf", `List [ s; `Assoc [ "type", `String "null" ] ] ]]
+
   let with_defs ~loc type_name schema =
     [%expr
       `Assoc
@@ -160,11 +173,6 @@ let value_name_pattern ~loc type_name = ppat_var ~loc { txt = type_name ^ "_json
 
 let create_value ~loc name value = [%stri let[@warning "-32-39"] [%p value_name_pattern ~loc name] = [%e value]]
 
-let is_optional_type core_type =
-  match core_type with
-  | [%type: [%t? _] option] -> true
-  | _ -> false
-
 (* Returns (schema_expression, is_recursive)
    recursive_types: list of type names in a mutually recursive group *)
 let rec type_of_core ~config ?(recursive_types = []) core_type =
@@ -176,7 +184,9 @@ let rec type_of_core ~config ?(recursive_types = []) core_type =
   | [%type: bool] -> Schema.type_def ~loc "boolean", false
   | [%type: char] -> Schema.char ~loc, false
   | [%type: unit] -> Schema.null ~loc, false
-  | [%type: [%t? t] option] -> type_of_core ~config ~recursive_types t
+  | [%type: [%t? t] option] ->
+    let s, is_rec = type_of_core ~config ~recursive_types t in
+    Schema.nullable ~loc s, is_rec
   | [%type: [%t? t] ref] -> type_of_core ~config ~recursive_types t
   | [%type: [%t? t] list] | [%type: [%t? t] array] ->
     let t, is_rec = type_of_core ~config ~recursive_types t in
@@ -259,13 +269,19 @@ let object_ ~loc ~config ?(recursive_types = []) fields allow_extra_fields =
           | Some name -> name.txt
           | None -> pld_name.txt
         in
+        let drop_required = Attribute.has_flag jsonschema_option field in
         let type_def, field_rec =
           match Attribute.get jsonschema_ref field with
           | Some def -> Schema.type_ref ~loc def.txt, false
-          | None -> type_of_core ~config ~recursive_types pld_type
+          | None ->
+            (match pld_type with
+            | [%type: [%t? inner] option] ->
+              let s, r = type_of_core ~config ~recursive_types inner in
+              Schema.nullable ~loc s, r
+            | _ -> type_of_core ~config ~recursive_types pld_type)
         in
         ( [%expr [%e estring ~loc name], [%e type_def]] :: fields,
-          (if is_optional_type pld_type then required else { txt = name; loc } :: required),
+          (if drop_required then required else { txt = name; loc } :: required),
           is_rec || field_rec ))
       ([], [], false) fields
   in

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -43,8 +43,7 @@ let jsonschema_cd_allow_extra_fields =
     Ast_pattern.(pstr nil)
     (fun () -> ())
 
-let jsonschema_option =
-  Attribute.declare_flag "jsonschema.option" Attribute.Context.label_declaration
+let jsonschema_option = Attribute.declare_flag "jsonschema.option" Attribute.Context.label_declaration
 
 let attributes =
   [
@@ -274,11 +273,11 @@ let object_ ~loc ~config ?(recursive_types = []) fields allow_extra_fields =
           match Attribute.get jsonschema_ref field with
           | Some def -> Schema.type_ref ~loc def.txt, false
           | None ->
-            (match pld_type with
-            | [%type: [%t? inner] option] ->
-              let s, r = type_of_core ~config ~recursive_types inner in
-              Schema.nullable ~loc s, r
-            | _ -> type_of_core ~config ~recursive_types pld_type)
+          match pld_type with
+          | [%type: [%t? inner] option] ->
+            let s, r = type_of_core ~config ~recursive_types inner in
+            Schema.nullable ~loc s, r
+          | _ -> type_of_core ~config ~recursive_types pld_type
         in
         ( [%expr [%e estring ~loc name], [%e type_def]] :: fields,
           (if drop_required then required else { txt = name; loc } :: required),

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -612,7 +612,14 @@ include
                (`Assoc
                   [("type", (`String "array"));
                   ("items", (`Assoc [("type", (`String "number"))]))]));
-             ("opt_int", (`Assoc [("type", (`String "integer"))]));
+             ("opt_int",
+               ((match `Assoc [("type", (`String "integer"))] with
+                 | `Assoc (("type", `String t)::[]) ->
+                     `Assoc [("type", (`List [`String t; `String "null"]))]
+                 | s ->
+                     `Assoc
+                       [("anyOf",
+                          (`List [s; `Assoc [("type", (`String "null"))]]))])));
              ("comment", (`Assoc [("type", (`String "string"))]));
              ("kind_f", kind_jsonschema);
              ("date", (`Assoc [("type", (`String "number"))]))]));
@@ -626,6 +633,7 @@ include
              `String "t";
              `String "l";
              `String "a";
+             `String "opt_int";
              `String "comment";
              `String "kind_f";
              `String "date"]));
@@ -672,7 +680,7 @@ include
         },
         "l": { "type": "array", "items": { "type": "string" } },
         "a": { "type": "array", "items": { "type": "number" } },
-        "opt_int": { "type": "integer" },
+        "opt_int": { "type": [ "integer", "null" ] },
         "comment": { "type": "string" },
         "kind_f": {
           "anyOf": [
@@ -703,7 +711,7 @@ include
       },
       "required": [
         "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l", "a",
-        "comment", "kind_f", "date"
+        "opt_int", "comment", "kind_f", "date"
       ],
       "additionalProperties": false
     }
@@ -963,8 +971,20 @@ include
                     ("properties",
                       (`Assoc
                          [("bar",
-                            (`Assoc [("$ref", (`String "#/$defs/bar"))]))]));
-                    ("required", (`List []));
+                            ((match `Assoc
+                                      [("$ref", (`String "#/$defs/bar"))]
+                              with
+                              | `Assoc (("type", `String t)::[]) ->
+                                  `Assoc
+                                    [("type",
+                                       (`List [`String t; `String "null"]))]
+                              | s ->
+                                  `Assoc
+                                    [("anyOf",
+                                       (`List
+                                          [s;
+                                          `Assoc [("type", (`String "null"))]]))])))]));
+                    ("required", (`List [`String "bar"]));
                     ("additionalProperties", (`Bool false))]));
               ("bar",
                 (`Assoc
@@ -972,8 +992,19 @@ include
                    ("properties",
                      (`Assoc
                         [("foo",
-                           (`Assoc [("$ref", (`String "#/$defs/foo"))]))]));
-                   ("required", (`List []));
+                           ((match `Assoc [("$ref", (`String "#/$defs/foo"))]
+                             with
+                             | `Assoc (("type", `String t)::[]) ->
+                                 `Assoc
+                                   [("type",
+                                      (`List [`String t; `String "null"]))]
+                             | s ->
+                                 `Assoc
+                                   [("anyOf",
+                                      (`List
+                                         [s;
+                                         `Assoc [("type", (`String "null"))]]))])))]));
+                   ("required", (`List [`String "foo"]));
                    ("additionalProperties", (`Bool false))]))]));
         ("$ref", (`String "#/$defs/foo"))][@@warning "-32-39"]
     let bar_jsonschema =
@@ -986,8 +1017,20 @@ include
                     ("properties",
                       (`Assoc
                          [("bar",
-                            (`Assoc [("$ref", (`String "#/$defs/bar"))]))]));
-                    ("required", (`List []));
+                            ((match `Assoc
+                                      [("$ref", (`String "#/$defs/bar"))]
+                              with
+                              | `Assoc (("type", `String t)::[]) ->
+                                  `Assoc
+                                    [("type",
+                                       (`List [`String t; `String "null"]))]
+                              | s ->
+                                  `Assoc
+                                    [("anyOf",
+                                       (`List
+                                          [s;
+                                          `Assoc [("type", (`String "null"))]]))])))]));
+                    ("required", (`List [`String "bar"]));
                     ("additionalProperties", (`Bool false))]));
               ("bar",
                 (`Assoc
@@ -995,8 +1038,19 @@ include
                    ("properties",
                      (`Assoc
                         [("foo",
-                           (`Assoc [("$ref", (`String "#/$defs/foo"))]))]));
-                   ("required", (`List []));
+                           ((match `Assoc [("$ref", (`String "#/$defs/foo"))]
+                             with
+                             | `Assoc (("type", `String t)::[]) ->
+                                 `Assoc
+                                   [("type",
+                                      (`List [`String t; `String "null"]))]
+                             | s ->
+                                 `Assoc
+                                   [("anyOf",
+                                      (`List
+                                         [s;
+                                         `Assoc [("type", (`String "null"))]]))])))]));
+                   ("required", (`List [`String "foo"]));
                    ("additionalProperties", (`Bool false))]))]));
         ("$ref", (`String "#/$defs/bar"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
@@ -1010,14 +1064,18 @@ include
       "$defs": {
         "foo": {
           "type": "object",
-          "properties": { "bar": { "$ref": "#/$defs/bar" } },
-          "required": [],
+          "properties": {
+            "bar": { "anyOf": [ { "$ref": "#/$defs/bar" }, { "type": "null" } ] }
+          },
+          "required": [ "bar" ],
           "additionalProperties": false
         },
         "bar": {
           "type": "object",
-          "properties": { "foo": { "$ref": "#/$defs/foo" } },
-          "required": [],
+          "properties": {
+            "foo": { "anyOf": [ { "$ref": "#/$defs/foo" }, { "type": "null" } ] }
+          },
+          "required": [ "foo" ],
           "additionalProperties": false
         }
       },
@@ -1034,14 +1092,18 @@ include
       "$defs": {
         "foo": {
           "type": "object",
-          "properties": { "bar": { "$ref": "#/$defs/bar" } },
-          "required": [],
+          "properties": {
+            "bar": { "anyOf": [ { "$ref": "#/$defs/bar" }, { "type": "null" } ] }
+          },
+          "required": [ "bar" ],
           "additionalProperties": false
         },
         "bar": {
           "type": "object",
-          "properties": { "foo": { "$ref": "#/$defs/foo" } },
-          "required": [],
+          "properties": {
+            "foo": { "anyOf": [ { "$ref": "#/$defs/foo" }, { "type": "null" } ] }
+          },
+          "required": [ "foo" ],
           "additionalProperties": false
         }
       },
@@ -1123,9 +1185,26 @@ include
                                   ("properties",
                                     (`Assoc
                                        [("else_",
-                                          (`Assoc
-                                             [("$ref",
-                                                (`String "#/$defs/stmt"))]));
+                                          ((match `Assoc
+                                                    [("$ref",
+                                                       (`String
+                                                          "#/$defs/stmt"))]
+                                            with
+                                            | `Assoc
+                                                (("type", `String t)::[]) ->
+                                                `Assoc
+                                                  [("type",
+                                                     (`List
+                                                        [`String t;
+                                                        `String "null"]))]
+                                            | s ->
+                                                `Assoc
+                                                  [("anyOf",
+                                                     (`List
+                                                        [s;
+                                                        `Assoc
+                                                          [("type",
+                                                             (`String "null"))]]))])));
                                        ("then_",
                                          (`Assoc
                                             [("$ref",
@@ -1135,7 +1214,10 @@ include
                                             [("$ref",
                                                (`String "#/$defs/expr"))]))]));
                                   ("required",
-                                    (`List [`String "then_"; `String "cond"]));
+                                    (`List
+                                       [`String "else_";
+                                       `String "then_";
+                                       `String "cond"]));
                                   ("additionalProperties", (`Bool false))]]));
                            ("unevaluatedItems", (`Bool false));
                            ("minItems", (`Int 2));
@@ -1204,9 +1286,26 @@ include
                                   ("properties",
                                     (`Assoc
                                        [("else_",
-                                          (`Assoc
-                                             [("$ref",
-                                                (`String "#/$defs/stmt"))]));
+                                          ((match `Assoc
+                                                    [("$ref",
+                                                       (`String
+                                                          "#/$defs/stmt"))]
+                                            with
+                                            | `Assoc
+                                                (("type", `String t)::[]) ->
+                                                `Assoc
+                                                  [("type",
+                                                     (`List
+                                                        [`String t;
+                                                        `String "null"]))]
+                                            | s ->
+                                                `Assoc
+                                                  [("anyOf",
+                                                     (`List
+                                                        [s;
+                                                        `Assoc
+                                                          [("type",
+                                                             (`String "null"))]]))])));
                                        ("then_",
                                          (`Assoc
                                             [("$ref",
@@ -1216,7 +1315,10 @@ include
                                             [("$ref",
                                                (`String "#/$defs/expr"))]))]));
                                   ("required",
-                                    (`List [`String "then_"; `String "cond"]));
+                                    (`List
+                                       [`String "else_";
+                                       `String "then_";
+                                       `String "cond"]));
                                   ("additionalProperties", (`Bool false))]]));
                            ("unevaluatedItems", (`Bool false));
                            ("minItems", (`Int 2));
@@ -1281,11 +1383,13 @@ include
                 {
                   "type": "object",
                   "properties": {
-                    "else_": { "$ref": "#/$defs/stmt" },
+                    "else_": {
+                      "anyOf": [ { "$ref": "#/$defs/stmt" }, { "type": "null" } ]
+                    },
                     "then_": { "$ref": "#/$defs/stmt" },
                     "cond": { "$ref": "#/$defs/expr" }
                   },
-                  "required": [ "then_", "cond" ],
+                  "required": [ "else_", "then_", "cond" ],
                   "additionalProperties": false
                 }
               ],
@@ -1367,10 +1471,34 @@ include
                     ("properties",
                       (`Assoc
                          [("c",
-                            (`Assoc [("$ref", (`String "#/$defs/node_c"))]));
+                            ((match `Assoc
+                                      [("$ref", (`String "#/$defs/node_c"))]
+                              with
+                              | `Assoc (("type", `String t)::[]) ->
+                                  `Assoc
+                                    [("type",
+                                       (`List [`String t; `String "null"]))]
+                              | s ->
+                                  `Assoc
+                                    [("anyOf",
+                                       (`List
+                                          [s;
+                                          `Assoc [("type", (`String "null"))]]))])));
                          ("b",
-                           (`Assoc [("$ref", (`String "#/$defs/node_b"))]))]));
-                    ("required", (`List []));
+                           ((match `Assoc
+                                     [("$ref", (`String "#/$defs/node_b"))]
+                             with
+                             | `Assoc (("type", `String t)::[]) ->
+                                 `Assoc
+                                   [("type",
+                                      (`List [`String t; `String "null"]))]
+                             | s ->
+                                 `Assoc
+                                   [("anyOf",
+                                      (`List
+                                         [s;
+                                         `Assoc [("type", (`String "null"))]]))])))]));
+                    ("required", (`List [`String "c"; `String "b"]));
                     ("additionalProperties", (`Bool false))]));
               ("node_b",
                 (`Assoc
@@ -1378,10 +1506,34 @@ include
                    ("properties",
                      (`Assoc
                         [("c",
-                           (`Assoc [("$ref", (`String "#/$defs/node_c"))]));
+                           ((match `Assoc
+                                     [("$ref", (`String "#/$defs/node_c"))]
+                             with
+                             | `Assoc (("type", `String t)::[]) ->
+                                 `Assoc
+                                   [("type",
+                                      (`List [`String t; `String "null"]))]
+                             | s ->
+                                 `Assoc
+                                   [("anyOf",
+                                      (`List
+                                         [s;
+                                         `Assoc [("type", (`String "null"))]]))])));
                         ("a",
-                          (`Assoc [("$ref", (`String "#/$defs/node_a"))]))]));
-                   ("required", (`List []));
+                          ((match `Assoc
+                                    [("$ref", (`String "#/$defs/node_a"))]
+                            with
+                            | `Assoc (("type", `String t)::[]) ->
+                                `Assoc
+                                  [("type",
+                                     (`List [`String t; `String "null"]))]
+                            | s ->
+                                `Assoc
+                                  [("anyOf",
+                                     (`List
+                                        [s;
+                                        `Assoc [("type", (`String "null"))]]))])))]));
+                   ("required", (`List [`String "c"; `String "a"]));
                    ("additionalProperties", (`Bool false))]));
               ("node_c",
                 (`Assoc
@@ -1389,10 +1541,34 @@ include
                    ("properties",
                      (`Assoc
                         [("b",
-                           (`Assoc [("$ref", (`String "#/$defs/node_b"))]));
+                           ((match `Assoc
+                                     [("$ref", (`String "#/$defs/node_b"))]
+                             with
+                             | `Assoc (("type", `String t)::[]) ->
+                                 `Assoc
+                                   [("type",
+                                      (`List [`String t; `String "null"]))]
+                             | s ->
+                                 `Assoc
+                                   [("anyOf",
+                                      (`List
+                                         [s;
+                                         `Assoc [("type", (`String "null"))]]))])));
                         ("a",
-                          (`Assoc [("$ref", (`String "#/$defs/node_a"))]))]));
-                   ("required", (`List []));
+                          ((match `Assoc
+                                    [("$ref", (`String "#/$defs/node_a"))]
+                            with
+                            | `Assoc (("type", `String t)::[]) ->
+                                `Assoc
+                                  [("type",
+                                     (`List [`String t; `String "null"]))]
+                            | s ->
+                                `Assoc
+                                  [("anyOf",
+                                     (`List
+                                        [s;
+                                        `Assoc [("type", (`String "null"))]]))])))]));
+                   ("required", (`List [`String "b"; `String "a"]));
                    ("additionalProperties", (`Bool false))]))]));
         ("$ref", (`String "#/$defs/node_a"))][@@warning "-32-39"]
     let node_b_jsonschema =
@@ -1405,10 +1581,34 @@ include
                     ("properties",
                       (`Assoc
                          [("c",
-                            (`Assoc [("$ref", (`String "#/$defs/node_c"))]));
+                            ((match `Assoc
+                                      [("$ref", (`String "#/$defs/node_c"))]
+                              with
+                              | `Assoc (("type", `String t)::[]) ->
+                                  `Assoc
+                                    [("type",
+                                       (`List [`String t; `String "null"]))]
+                              | s ->
+                                  `Assoc
+                                    [("anyOf",
+                                       (`List
+                                          [s;
+                                          `Assoc [("type", (`String "null"))]]))])));
                          ("b",
-                           (`Assoc [("$ref", (`String "#/$defs/node_b"))]))]));
-                    ("required", (`List []));
+                           ((match `Assoc
+                                     [("$ref", (`String "#/$defs/node_b"))]
+                             with
+                             | `Assoc (("type", `String t)::[]) ->
+                                 `Assoc
+                                   [("type",
+                                      (`List [`String t; `String "null"]))]
+                             | s ->
+                                 `Assoc
+                                   [("anyOf",
+                                      (`List
+                                         [s;
+                                         `Assoc [("type", (`String "null"))]]))])))]));
+                    ("required", (`List [`String "c"; `String "b"]));
                     ("additionalProperties", (`Bool false))]));
               ("node_b",
                 (`Assoc
@@ -1416,10 +1616,34 @@ include
                    ("properties",
                      (`Assoc
                         [("c",
-                           (`Assoc [("$ref", (`String "#/$defs/node_c"))]));
+                           ((match `Assoc
+                                     [("$ref", (`String "#/$defs/node_c"))]
+                             with
+                             | `Assoc (("type", `String t)::[]) ->
+                                 `Assoc
+                                   [("type",
+                                      (`List [`String t; `String "null"]))]
+                             | s ->
+                                 `Assoc
+                                   [("anyOf",
+                                      (`List
+                                         [s;
+                                         `Assoc [("type", (`String "null"))]]))])));
                         ("a",
-                          (`Assoc [("$ref", (`String "#/$defs/node_a"))]))]));
-                   ("required", (`List []));
+                          ((match `Assoc
+                                    [("$ref", (`String "#/$defs/node_a"))]
+                            with
+                            | `Assoc (("type", `String t)::[]) ->
+                                `Assoc
+                                  [("type",
+                                     (`List [`String t; `String "null"]))]
+                            | s ->
+                                `Assoc
+                                  [("anyOf",
+                                     (`List
+                                        [s;
+                                        `Assoc [("type", (`String "null"))]]))])))]));
+                   ("required", (`List [`String "c"; `String "a"]));
                    ("additionalProperties", (`Bool false))]));
               ("node_c",
                 (`Assoc
@@ -1427,10 +1651,34 @@ include
                    ("properties",
                      (`Assoc
                         [("b",
-                           (`Assoc [("$ref", (`String "#/$defs/node_b"))]));
+                           ((match `Assoc
+                                     [("$ref", (`String "#/$defs/node_b"))]
+                             with
+                             | `Assoc (("type", `String t)::[]) ->
+                                 `Assoc
+                                   [("type",
+                                      (`List [`String t; `String "null"]))]
+                             | s ->
+                                 `Assoc
+                                   [("anyOf",
+                                      (`List
+                                         [s;
+                                         `Assoc [("type", (`String "null"))]]))])));
                         ("a",
-                          (`Assoc [("$ref", (`String "#/$defs/node_a"))]))]));
-                   ("required", (`List []));
+                          ((match `Assoc
+                                    [("$ref", (`String "#/$defs/node_a"))]
+                            with
+                            | `Assoc (("type", `String t)::[]) ->
+                                `Assoc
+                                  [("type",
+                                     (`List [`String t; `String "null"]))]
+                            | s ->
+                                `Assoc
+                                  [("anyOf",
+                                     (`List
+                                        [s;
+                                        `Assoc [("type", (`String "null"))]]))])))]));
+                   ("required", (`List [`String "b"; `String "a"]));
                    ("additionalProperties", (`Bool false))]))]));
         ("$ref", (`String "#/$defs/node_b"))][@@warning "-32-39"]
     let node_c_jsonschema =
@@ -1443,10 +1691,34 @@ include
                     ("properties",
                       (`Assoc
                          [("c",
-                            (`Assoc [("$ref", (`String "#/$defs/node_c"))]));
+                            ((match `Assoc
+                                      [("$ref", (`String "#/$defs/node_c"))]
+                              with
+                              | `Assoc (("type", `String t)::[]) ->
+                                  `Assoc
+                                    [("type",
+                                       (`List [`String t; `String "null"]))]
+                              | s ->
+                                  `Assoc
+                                    [("anyOf",
+                                       (`List
+                                          [s;
+                                          `Assoc [("type", (`String "null"))]]))])));
                          ("b",
-                           (`Assoc [("$ref", (`String "#/$defs/node_b"))]))]));
-                    ("required", (`List []));
+                           ((match `Assoc
+                                     [("$ref", (`String "#/$defs/node_b"))]
+                             with
+                             | `Assoc (("type", `String t)::[]) ->
+                                 `Assoc
+                                   [("type",
+                                      (`List [`String t; `String "null"]))]
+                             | s ->
+                                 `Assoc
+                                   [("anyOf",
+                                      (`List
+                                         [s;
+                                         `Assoc [("type", (`String "null"))]]))])))]));
+                    ("required", (`List [`String "c"; `String "b"]));
                     ("additionalProperties", (`Bool false))]));
               ("node_b",
                 (`Assoc
@@ -1454,10 +1726,34 @@ include
                    ("properties",
                      (`Assoc
                         [("c",
-                           (`Assoc [("$ref", (`String "#/$defs/node_c"))]));
+                           ((match `Assoc
+                                     [("$ref", (`String "#/$defs/node_c"))]
+                             with
+                             | `Assoc (("type", `String t)::[]) ->
+                                 `Assoc
+                                   [("type",
+                                      (`List [`String t; `String "null"]))]
+                             | s ->
+                                 `Assoc
+                                   [("anyOf",
+                                      (`List
+                                         [s;
+                                         `Assoc [("type", (`String "null"))]]))])));
                         ("a",
-                          (`Assoc [("$ref", (`String "#/$defs/node_a"))]))]));
-                   ("required", (`List []));
+                          ((match `Assoc
+                                    [("$ref", (`String "#/$defs/node_a"))]
+                            with
+                            | `Assoc (("type", `String t)::[]) ->
+                                `Assoc
+                                  [("type",
+                                     (`List [`String t; `String "null"]))]
+                            | s ->
+                                `Assoc
+                                  [("anyOf",
+                                     (`List
+                                        [s;
+                                        `Assoc [("type", (`String "null"))]]))])))]));
+                   ("required", (`List [`String "c"; `String "a"]));
                    ("additionalProperties", (`Bool false))]));
               ("node_c",
                 (`Assoc
@@ -1465,10 +1761,34 @@ include
                    ("properties",
                      (`Assoc
                         [("b",
-                           (`Assoc [("$ref", (`String "#/$defs/node_b"))]));
+                           ((match `Assoc
+                                     [("$ref", (`String "#/$defs/node_b"))]
+                             with
+                             | `Assoc (("type", `String t)::[]) ->
+                                 `Assoc
+                                   [("type",
+                                      (`List [`String t; `String "null"]))]
+                             | s ->
+                                 `Assoc
+                                   [("anyOf",
+                                      (`List
+                                         [s;
+                                         `Assoc [("type", (`String "null"))]]))])));
                         ("a",
-                          (`Assoc [("$ref", (`String "#/$defs/node_a"))]))]));
-                   ("required", (`List []));
+                          ((match `Assoc
+                                    [("$ref", (`String "#/$defs/node_a"))]
+                            with
+                            | `Assoc (("type", `String t)::[]) ->
+                                `Assoc
+                                  [("type",
+                                     (`List [`String t; `String "null"]))]
+                            | s ->
+                                `Assoc
+                                  [("anyOf",
+                                     (`List
+                                        [s;
+                                        `Assoc [("type", (`String "null"))]]))])))]));
+                   ("required", (`List [`String "b"; `String "a"]));
                    ("additionalProperties", (`Bool false))]))]));
         ("$ref", (`String "#/$defs/node_c"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
@@ -1483,28 +1803,40 @@ include
         "node_a": {
           "type": "object",
           "properties": {
-            "c": { "$ref": "#/$defs/node_c" },
-            "b": { "$ref": "#/$defs/node_b" }
+            "c": {
+              "anyOf": [ { "$ref": "#/$defs/node_c" }, { "type": "null" } ]
+            },
+            "b": {
+              "anyOf": [ { "$ref": "#/$defs/node_b" }, { "type": "null" } ]
+            }
           },
-          "required": [],
+          "required": [ "c", "b" ],
           "additionalProperties": false
         },
         "node_b": {
           "type": "object",
           "properties": {
-            "c": { "$ref": "#/$defs/node_c" },
-            "a": { "$ref": "#/$defs/node_a" }
+            "c": {
+              "anyOf": [ { "$ref": "#/$defs/node_c" }, { "type": "null" } ]
+            },
+            "a": {
+              "anyOf": [ { "$ref": "#/$defs/node_a" }, { "type": "null" } ]
+            }
           },
-          "required": [],
+          "required": [ "c", "a" ],
           "additionalProperties": false
         },
         "node_c": {
           "type": "object",
           "properties": {
-            "b": { "$ref": "#/$defs/node_b" },
-            "a": { "$ref": "#/$defs/node_a" }
+            "b": {
+              "anyOf": [ { "$ref": "#/$defs/node_b" }, { "type": "null" } ]
+            },
+            "a": {
+              "anyOf": [ { "$ref": "#/$defs/node_a" }, { "type": "null" } ]
+            }
           },
-          "required": [],
+          "required": [ "b", "a" ],
           "additionalProperties": false
         }
       },
@@ -1696,7 +2028,7 @@ include
           },
           "l": { "type": "array", "items": { "type": "string" } },
           "a": { "type": "array", "items": { "type": "number" } },
-          "opt_int": { "type": "integer" },
+          "opt_int": { "type": [ "integer", "null" ] },
           "comment": { "type": "string" },
           "kind_f": {
             "anyOf": [
@@ -1727,7 +2059,7 @@ include
         },
         "required": [
           "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l",
-          "a", "comment", "kind_f", "date"
+          "a", "opt_int", "comment", "kind_f", "date"
         ],
         "additionalProperties": false
       }
@@ -1788,7 +2120,7 @@ include
             },
             "l": { "type": "array", "items": { "type": "string" } },
             "a": { "type": "array", "items": { "type": "number" } },
-            "opt_int": { "type": "integer" },
+            "opt_int": { "type": [ "integer", "null" ] },
             "comment": { "type": "string" },
             "kind_f": {
               "anyOf": [
@@ -1819,7 +2151,7 @@ include
           },
           "required": [
             "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l",
-            "a", "comment", "kind_f", "date"
+            "a", "opt_int", "comment", "kind_f", "date"
           ],
           "additionalProperties": false
         }
@@ -1882,7 +2214,7 @@ include
             },
             "l": { "type": "array", "items": { "type": "string" } },
             "a": { "type": "array", "items": { "type": "number" } },
-            "opt_int": { "type": "integer" },
+            "opt_int": { "type": [ "integer", "null" ] },
             "comment": { "type": "string" },
             "kind_f": {
               "anyOf": [
@@ -1913,7 +2245,7 @@ include
           },
           "required": [
             "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l",
-            "a", "comment", "kind_f", "date"
+            "a", "opt_int", "comment", "kind_f", "date"
           ],
           "additionalProperties": false
         },
@@ -1978,7 +2310,7 @@ include
               },
               "l": { "type": "array", "items": { "type": "string" } },
               "a": { "type": "array", "items": { "type": "number" } },
-              "opt_int": { "type": "integer" },
+              "opt_int": { "type": [ "integer", "null" ] },
               "comment": { "type": "string" },
               "kind_f": {
                 "anyOf": [
@@ -2009,7 +2341,7 @@ include
             },
             "required": [
               "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
-              "l", "a", "comment", "kind_f", "date"
+              "l", "a", "opt_int", "comment", "kind_f", "date"
             ],
             "additionalProperties": false
           },
@@ -2083,7 +2415,7 @@ include
               },
               "l": { "type": "array", "items": { "type": "string" } },
               "a": { "type": "array", "items": { "type": "number" } },
-              "opt_int": { "type": "integer" },
+              "opt_int": { "type": [ "integer", "null" ] },
               "comment": { "type": "string" },
               "kind_f": {
                 "anyOf": [
@@ -2114,7 +2446,7 @@ include
             },
             "required": [
               "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
-              "l", "a", "comment", "kind_f", "date"
+              "l", "a", "opt_int", "comment", "kind_f", "date"
             ],
             "additionalProperties": false
           },
@@ -2178,7 +2510,7 @@ include
             },
             "l": { "type": "array", "items": { "type": "string" } },
             "a": { "type": "array", "items": { "type": "number" } },
-            "opt_int": { "type": "integer" },
+            "opt_int": { "type": [ "integer", "null" ] },
             "comment": { "type": "string" },
             "kind_f": {
               "anyOf": [
@@ -2209,7 +2541,7 @@ include
           },
           "required": [
             "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l",
-            "a", "comment", "kind_f", "date"
+            "a", "opt_int", "comment", "kind_f", "date"
           ],
           "additionalProperties": false
         }
@@ -2238,8 +2570,14 @@ include
 type opt = int option[@@deriving jsonschema]
 include
   struct
-    let opt_jsonschema = `Assoc [("type", (`String "integer"))][@@warning
-                                                                 "-32-39"]
+    let opt_jsonschema =
+      match `Assoc [("type", (`String "integer"))] with
+      | `Assoc (("type", `String t)::[]) ->
+          `Assoc [("type", (`List [`String t; `String "null"]))]
+      | s ->
+          `Assoc
+            [("anyOf", (`List [s; `Assoc [("type", (`String "null"))]]))]
+      [@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "opt" =
@@ -2248,8 +2586,9 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "integer"
-    } |}]]
+      "type": [ "integer", "null" ]
+    }
+    |}]]
 type using_m = {
   m: Mod1.m_1 }[@@deriving jsonschema]
 include
@@ -2445,11 +2784,22 @@ include
         ("properties",
           (`Assoc
              [("address", address_jsonschema);
-             ("email", (`Assoc [("type", (`String "string"))]));
+             ("email",
+               ((match `Assoc [("type", (`String "string"))] with
+                 | `Assoc (("type", `String t)::[]) ->
+                     `Assoc [("type", (`List [`String t; `String "null"]))]
+                 | s ->
+                     `Assoc
+                       [("anyOf",
+                          (`List [s; `Assoc [("type", (`String "null"))]]))])));
              ("age", (`Assoc [("type", (`String "integer"))]));
              ("name", (`Assoc [("type", (`String "string"))]))]));
         ("required",
-          (`List [`String "address"; `String "age"; `String "name"]));
+          (`List
+             [`String "address";
+             `String "email";
+             `String "age";
+             `String "name"]));
         ("additionalProperties", (`Bool false))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -2471,11 +2821,11 @@ include
           "required": [ "zip", "city", "street" ],
           "additionalProperties": false
         },
-        "email": { "type": "string" },
+        "email": { "type": [ "string", "null" ] },
         "age": { "type": "integer" },
         "name": { "type": "string" }
       },
-      "required": [ "address", "age", "name" ],
+      "required": [ "address", "email", "age", "name" ],
       "additionalProperties": false
     }
     |}]]
@@ -2500,7 +2850,14 @@ include
                (`Assoc [("$ref", (`String "#/$defs/shared_address"))]));
              ("home_address",
                (`Assoc [("$ref", (`String "#/$defs/shared_address"))]));
-             ("email", (`Assoc [("type", (`String "string"))]));
+             ("email",
+               ((match `Assoc [("type", (`String "string"))] with
+                 | `Assoc (("type", `String t)::[]) ->
+                     `Assoc [("type", (`List [`String t; `String "null"]))]
+                 | s ->
+                     `Assoc
+                       [("anyOf",
+                          (`List [s; `Assoc [("type", (`String "null"))]]))])));
              ("age", (`Assoc [("type", (`String "integer"))]));
              ("name", (`Assoc [("type", (`String "string"))]))]));
         ("required",
@@ -2508,6 +2865,7 @@ include
              [`String "retreat_address";
              `String "work_address";
              `String "home_address";
+             `String "email";
              `String "age";
              `String "name"]));
         ("additionalProperties", (`Bool false))][@@warning "-32-39"]
@@ -2537,12 +2895,12 @@ include
         "retreat_address": { "$ref": "#/$defs/shared_address" },
         "work_address": { "$ref": "#/$defs/shared_address" },
         "home_address": { "$ref": "#/$defs/shared_address" },
-        "email": { "type": "string" },
+        "email": { "type": [ "string", "null" ] },
         "age": { "type": "integer" },
         "name": { "type": "string" }
       },
       "required": [
-        "retreat_address", "work_address", "home_address", "age", "name"
+        "retreat_address", "work_address", "home_address", "email", "age", "name"
       ],
       "additionalProperties": false
     }
@@ -3335,8 +3693,15 @@ include
         ("properties",
           (`Assoc
              [("url", url);
-             ("title", (`Assoc [("type", (`String "string"))]))]));
-        ("required", (`List [`String "url"]));
+             ("title",
+               ((match `Assoc [("type", (`String "string"))] with
+                 | `Assoc (("type", `String t)::[]) ->
+                     `Assoc [("type", (`List [`String t; `String "null"]))]
+                 | s ->
+                     `Assoc
+                       [("anyOf",
+                          (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+        ("required", (`List [`String "url"; `String "title"]));
         ("additionalProperties", (`Bool false))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -3349,11 +3714,12 @@ include
       "type": "object",
       "properties": {
         "url": { "type": "string" },
-        "title": { "type": "string" }
+        "title": { "type": [ "string", "null" ] }
       },
-      "required": [ "url" ],
+      "required": [ "url", "title" ],
       "additionalProperties": false
-    } |}]]
+    }
+    |}]]
 type string_link_traffic = string generic_link_traffic[@@deriving jsonschema]
 include
   struct
@@ -3371,11 +3737,12 @@ include
       "type": "object",
       "properties": {
         "url": { "type": "string" },
-        "title": { "type": "string" }
+        "title": { "type": [ "string", "null" ] }
       },
-      "required": [ "url" ],
+      "required": [ "url", "title" ],
       "additionalProperties": false
-    } |}]]
+    }
+    |}]]
 type 'a poly_variant =
   | A 
   | B of 'a [@@deriving jsonschema]
@@ -3573,5 +3940,114 @@ include
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "anyOf": [ { "const": "North" }, { "const": "South" } ]
+    }
+    |}]]
+type nullable_fields =
+  {
+  plain: string option ;
+  drop_simple: string option [@jsonschema.option ];
+  drop_complex: int list option [@jsonschema.option ]}[@@deriving jsonschema]
+include
+  struct
+    let nullable_fields_jsonschema =
+      `Assoc
+        [("type", (`String "object"));
+        ("properties",
+          (`Assoc
+             [("drop_complex",
+                ((match `Assoc
+                          [("type", (`String "array"));
+                          ("items", (`Assoc [("type", (`String "integer"))]))]
+                  with
+                  | `Assoc (("type", `String t)::[]) ->
+                      `Assoc [("type", (`List [`String t; `String "null"]))]
+                  | s ->
+                      `Assoc
+                        [("anyOf",
+                           (`List [s; `Assoc [("type", (`String "null"))]]))])));
+             ("drop_simple",
+               ((match `Assoc [("type", (`String "string"))] with
+                 | `Assoc (("type", `String t)::[]) ->
+                     `Assoc [("type", (`List [`String t; `String "null"]))]
+                 | s ->
+                     `Assoc
+                       [("anyOf",
+                          (`List [s; `Assoc [("type", (`String "null"))]]))])));
+             ("plain",
+               ((match `Assoc [("type", (`String "string"))] with
+                 | `Assoc (("type", `String t)::[]) ->
+                     `Assoc [("type", (`List [`String t; `String "null"]))]
+                 | s ->
+                     `Assoc
+                       [("anyOf",
+                          (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+        ("required", (`List [`String "plain"]));
+        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "nullable_fields" =
+    print_schema nullable_fields_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "drop_complex": {
+          "anyOf": [
+            { "type": "array", "items": { "type": "integer" } },
+            { "type": "null" }
+          ]
+        },
+        "drop_simple": { "type": [ "string", "null" ] },
+        "plain": { "type": [ "string", "null" ] }
+      },
+      "required": [ "plain" ],
+      "additionalProperties": false
+    }
+    |}]]
+type composing_type = string
+let composing_type_jsonschema =
+  `Assoc
+    [("type", (`String "string")); ("description", (`String "A string"))]
+type composing_record =
+  {
+  composing_type: composing_type option [@jsonschema.option ]}[@@deriving
+                                                                jsonschema]
+include
+  struct
+    let composing_record_jsonschema =
+      `Assoc
+        [("type", (`String "object"));
+        ("properties",
+          (`Assoc
+             [("composing_type",
+                ((match composing_type_jsonschema with
+                  | `Assoc (("type", `String t)::[]) ->
+                      `Assoc [("type", (`List [`String t; `String "null"]))]
+                  | s ->
+                      `Assoc
+                        [("anyOf",
+                           (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+        ("required", (`List []));
+        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "nullable_option_composing" =
+    print_schema composing_record_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "composing_type": {
+          "anyOf": [
+            { "type": "string", "description": "A string" }, { "type": "null" }
+          ]
+        }
+      },
+      "required": [],
+      "additionalProperties": false
     }
     |}]]

--- a/test/test.ml
+++ b/test/test.ml
@@ -1491,7 +1491,8 @@ type opt = int option [@@deriving jsonschema]
 
 let%expect_test "opt" =
   print_schema opt_jsonschema;
-  [%expect {|
+  [%expect
+    {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": [ "integer", "null" ]
@@ -2332,7 +2333,8 @@ type nullable_fields = {
 
 let%expect_test "nullable_fields" =
   print_schema nullable_fields_jsonschema;
-  [%expect {|
+  [%expect
+    {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -2354,13 +2356,12 @@ let%expect_test "nullable_fields" =
 type composing_type = string
 let composing_type_jsonschema = `Assoc [ "type", `String "string"; "description", `String "A string" ]
 
-type composing_record = {
-  composing_type: composing_type option; [@jsonschema.option]
-} [@@deriving jsonschema]
+type composing_record = { composing_type : composing_type option [@jsonschema.option] } [@@deriving jsonschema]
 
 let%expect_test "nullable_option_composing" =
   print_schema composing_record_jsonschema;
-  [%expect {|
+  [%expect
+    {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",

--- a/test/test.ml
+++ b/test/test.ml
@@ -435,7 +435,7 @@ let%expect_test "event" =
         },
         "l": { "type": "array", "items": { "type": "string" } },
         "a": { "type": "array", "items": { "type": "number" } },
-        "opt_int": { "type": "integer" },
+        "opt_int": { "type": [ "integer", "null" ] },
         "comment": { "type": "string" },
         "kind_f": {
           "anyOf": [
@@ -466,7 +466,7 @@ let%expect_test "event" =
       },
       "required": [
         "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l", "a",
-        "comment", "kind_f", "date"
+        "opt_int", "comment", "kind_f", "date"
       ],
       "additionalProperties": false
     }
@@ -624,14 +624,18 @@ let%expect_test "mutually_recursive_foo" =
       "$defs": {
         "foo": {
           "type": "object",
-          "properties": { "bar": { "$ref": "#/$defs/bar" } },
-          "required": [],
+          "properties": {
+            "bar": { "anyOf": [ { "$ref": "#/$defs/bar" }, { "type": "null" } ] }
+          },
+          "required": [ "bar" ],
           "additionalProperties": false
         },
         "bar": {
           "type": "object",
-          "properties": { "foo": { "$ref": "#/$defs/foo" } },
-          "required": [],
+          "properties": {
+            "foo": { "anyOf": [ { "$ref": "#/$defs/foo" }, { "type": "null" } ] }
+          },
+          "required": [ "foo" ],
           "additionalProperties": false
         }
       },
@@ -648,14 +652,18 @@ let%expect_test "mutually_recursive_bar" =
       "$defs": {
         "foo": {
           "type": "object",
-          "properties": { "bar": { "$ref": "#/$defs/bar" } },
-          "required": [],
+          "properties": {
+            "bar": { "anyOf": [ { "$ref": "#/$defs/bar" }, { "type": "null" } ] }
+          },
+          "required": [ "bar" ],
           "additionalProperties": false
         },
         "bar": {
           "type": "object",
-          "properties": { "foo": { "$ref": "#/$defs/foo" } },
-          "required": [],
+          "properties": {
+            "foo": { "anyOf": [ { "$ref": "#/$defs/foo" }, { "type": "null" } ] }
+          },
+          "required": [ "foo" ],
           "additionalProperties": false
         }
       },
@@ -735,11 +743,13 @@ let%expect_test "mutually_recursive_expr" =
                 {
                   "type": "object",
                   "properties": {
-                    "else_": { "$ref": "#/$defs/stmt" },
+                    "else_": {
+                      "anyOf": [ { "$ref": "#/$defs/stmt" }, { "type": "null" } ]
+                    },
                     "then_": { "$ref": "#/$defs/stmt" },
                     "cond": { "$ref": "#/$defs/expr" }
                   },
-                  "required": [ "then_", "cond" ],
+                  "required": [ "else_", "then_", "cond" ],
                   "additionalProperties": false
                 }
               ],
@@ -809,28 +819,40 @@ let%expect_test "three_way_mutual_recursion" =
         "node_a": {
           "type": "object",
           "properties": {
-            "c": { "$ref": "#/$defs/node_c" },
-            "b": { "$ref": "#/$defs/node_b" }
+            "c": {
+              "anyOf": [ { "$ref": "#/$defs/node_c" }, { "type": "null" } ]
+            },
+            "b": {
+              "anyOf": [ { "$ref": "#/$defs/node_b" }, { "type": "null" } ]
+            }
           },
-          "required": [],
+          "required": [ "c", "b" ],
           "additionalProperties": false
         },
         "node_b": {
           "type": "object",
           "properties": {
-            "c": { "$ref": "#/$defs/node_c" },
-            "a": { "$ref": "#/$defs/node_a" }
+            "c": {
+              "anyOf": [ { "$ref": "#/$defs/node_c" }, { "type": "null" } ]
+            },
+            "a": {
+              "anyOf": [ { "$ref": "#/$defs/node_a" }, { "type": "null" } ]
+            }
           },
-          "required": [],
+          "required": [ "c", "a" ],
           "additionalProperties": false
         },
         "node_c": {
           "type": "object",
           "properties": {
-            "b": { "$ref": "#/$defs/node_b" },
-            "a": { "$ref": "#/$defs/node_a" }
+            "b": {
+              "anyOf": [ { "$ref": "#/$defs/node_b" }, { "type": "null" } ]
+            },
+            "a": {
+              "anyOf": [ { "$ref": "#/$defs/node_a" }, { "type": "null" } ]
+            }
           },
-          "required": [],
+          "required": [ "b", "a" ],
           "additionalProperties": false
         }
       },
@@ -975,7 +997,7 @@ let%expect_test "events" =
           },
           "l": { "type": "array", "items": { "type": "string" } },
           "a": { "type": "array", "items": { "type": "number" } },
-          "opt_int": { "type": "integer" },
+          "opt_int": { "type": [ "integer", "null" ] },
           "comment": { "type": "string" },
           "kind_f": {
             "anyOf": [
@@ -1006,7 +1028,7 @@ let%expect_test "events" =
         },
         "required": [
           "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l",
-          "a", "comment", "kind_f", "date"
+          "a", "opt_int", "comment", "kind_f", "date"
         ],
         "additionalProperties": false
       }
@@ -1059,7 +1081,7 @@ let%expect_test "eventss" =
             },
             "l": { "type": "array", "items": { "type": "string" } },
             "a": { "type": "array", "items": { "type": "number" } },
-            "opt_int": { "type": "integer" },
+            "opt_int": { "type": [ "integer", "null" ] },
             "comment": { "type": "string" },
             "kind_f": {
               "anyOf": [
@@ -1090,7 +1112,7 @@ let%expect_test "eventss" =
           },
           "required": [
             "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l",
-            "a", "comment", "kind_f", "date"
+            "a", "opt_int", "comment", "kind_f", "date"
           ],
           "additionalProperties": false
         }
@@ -1143,7 +1165,7 @@ let%expect_test "event_comment" =
             },
             "l": { "type": "array", "items": { "type": "string" } },
             "a": { "type": "array", "items": { "type": "number" } },
-            "opt_int": { "type": "integer" },
+            "opt_int": { "type": [ "integer", "null" ] },
             "comment": { "type": "string" },
             "kind_f": {
               "anyOf": [
@@ -1174,7 +1196,7 @@ let%expect_test "event_comment" =
           },
           "required": [
             "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l",
-            "a", "comment", "kind_f", "date"
+            "a", "opt_int", "comment", "kind_f", "date"
           ],
           "additionalProperties": false
         },
@@ -1233,7 +1255,7 @@ let%expect_test "event_comments'" =
               },
               "l": { "type": "array", "items": { "type": "string" } },
               "a": { "type": "array", "items": { "type": "number" } },
-              "opt_int": { "type": "integer" },
+              "opt_int": { "type": [ "integer", "null" ] },
               "comment": { "type": "string" },
               "kind_f": {
                 "anyOf": [
@@ -1264,7 +1286,7 @@ let%expect_test "event_comments'" =
             },
             "required": [
               "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
-              "l", "a", "comment", "kind_f", "date"
+              "l", "a", "opt_int", "comment", "kind_f", "date"
             ],
             "additionalProperties": false
           },
@@ -1324,7 +1346,7 @@ let%expect_test "event_n" =
               },
               "l": { "type": "array", "items": { "type": "string" } },
               "a": { "type": "array", "items": { "type": "number" } },
-              "opt_int": { "type": "integer" },
+              "opt_int": { "type": [ "integer", "null" ] },
               "comment": { "type": "string" },
               "kind_f": {
                 "anyOf": [
@@ -1355,7 +1377,7 @@ let%expect_test "event_n" =
             },
             "required": [
               "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
-              "l", "a", "comment", "kind_f", "date"
+              "l", "a", "opt_int", "comment", "kind_f", "date"
             ],
             "additionalProperties": false
           },
@@ -1414,7 +1436,7 @@ let%expect_test "events_array" =
             },
             "l": { "type": "array", "items": { "type": "string" } },
             "a": { "type": "array", "items": { "type": "number" } },
-            "opt_int": { "type": "integer" },
+            "opt_int": { "type": [ "integer", "null" ] },
             "comment": { "type": "string" },
             "kind_f": {
               "anyOf": [
@@ -1445,7 +1467,7 @@ let%expect_test "events_array" =
           },
           "required": [
             "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l",
-            "a", "comment", "kind_f", "date"
+            "a", "opt_int", "comment", "kind_f", "date"
           ],
           "additionalProperties": false
         }
@@ -1472,8 +1494,9 @@ let%expect_test "opt" =
   [%expect {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "integer"
-    } |}]
+      "type": [ "integer", "null" ]
+    }
+    |}]
 
 type using_m = { m : Mod1.m_1 } [@@deriving jsonschema]
 
@@ -1619,11 +1642,11 @@ let%expect_test "t" =
           "required": [ "zip", "city", "street" ],
           "additionalProperties": false
         },
-        "email": { "type": "string" },
+        "email": { "type": [ "string", "null" ] },
         "age": { "type": "integer" },
         "name": { "type": "string" }
       },
-      "required": [ "address", "age", "name" ],
+      "required": [ "address", "email", "age", "name" ],
       "additionalProperties": false
     }
     |}]
@@ -1661,12 +1684,12 @@ let%expect_test "tt" =
         "retreat_address": { "$ref": "#/$defs/shared_address" },
         "work_address": { "$ref": "#/$defs/shared_address" },
         "home_address": { "$ref": "#/$defs/shared_address" },
-        "email": { "type": "string" },
+        "email": { "type": [ "string", "null" ] },
         "age": { "type": "integer" },
         "name": { "type": "string" }
       },
       "required": [
-        "retreat_address", "work_address", "home_address", "age", "name"
+        "retreat_address", "work_address", "home_address", "email", "age", "name"
       ],
       "additionalProperties": false
     }
@@ -2139,11 +2162,12 @@ let%expect_test "parameterized_record" =
       "type": "object",
       "properties": {
         "url": { "type": "string" },
-        "title": { "type": "string" }
+        "title": { "type": [ "string", "null" ] }
       },
-      "required": [ "url" ],
+      "required": [ "url", "title" ],
       "additionalProperties": false
-    } |}]
+    }
+    |}]
 
 type string_link_traffic = string generic_link_traffic [@@deriving jsonschema]
 
@@ -2156,11 +2180,12 @@ let%expect_test "instantiated_parameterized_record" =
       "type": "object",
       "properties": {
         "url": { "type": "string" },
-        "title": { "type": "string" }
+        "title": { "type": [ "string", "null" ] }
       },
-      "required": [ "url" ],
+      "required": [ "url", "title" ],
       "additionalProperties": false
-    } |}]
+    }
+    |}]
 
 type 'a poly_variant =
   | A
@@ -2295,5 +2320,58 @@ let%expect_test "multi_param_variant_as_string" =
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "anyOf": [ { "const": "North" }, { "const": "South" } ]
+    }
+    |}]
+
+type nullable_fields = {
+  plain : string option;
+  drop_simple : string option; [@jsonschema.option]
+  drop_complex : int list option; [@jsonschema.option]
+}
+[@@deriving jsonschema]
+
+let%expect_test "nullable_fields" =
+  print_schema nullable_fields_jsonschema;
+  [%expect {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "drop_complex": {
+          "anyOf": [
+            { "type": "array", "items": { "type": "integer" } },
+            { "type": "null" }
+          ]
+        },
+        "drop_simple": { "type": [ "string", "null" ] },
+        "plain": { "type": [ "string", "null" ] }
+      },
+      "required": [ "plain" ],
+      "additionalProperties": false
+    }
+    |}]
+
+type composing_type = string
+let composing_type_jsonschema = `Assoc [ "type", `String "string"; "description", `String "A string" ]
+
+type composing_record = {
+  composing_type: composing_type option; [@jsonschema.option]
+} [@@deriving jsonschema]
+
+let%expect_test "nullable_option_composing" =
+  print_schema composing_record_jsonschema;
+  [%expect {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "composing_type": {
+          "anyOf": [
+            { "type": "string", "description": "A string" }, { "type": "null" }
+          ]
+        }
+      },
+      "required": [],
+      "additionalProperties": false
     }
     |}]

--- a/test/test_schemas.expected.json
+++ b/test/test_schemas.expected.json
@@ -231,7 +231,7 @@
         },
         "l": { "type": "array", "items": { "type": "string" } },
         "a": { "type": "array", "items": { "type": "number" } },
-        "opt_int": { "type": "integer" },
+        "opt_int": { "type": [ "integer", "null" ] },
         "comment": { "type": "string" },
         "kind_f": {
           "anyOf": [
@@ -262,7 +262,7 @@
       },
       "required": [
         "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l",
-        "a", "comment", "kind_f", "date"
+        "a", "opt_int", "comment", "kind_f", "date"
       ],
       "additionalProperties": false
     },
@@ -304,7 +304,7 @@
           },
           "l": { "type": "array", "items": { "type": "string" } },
           "a": { "type": "array", "items": { "type": "number" } },
-          "opt_int": { "type": "integer" },
+          "opt_int": { "type": [ "integer", "null" ] },
           "comment": { "type": "string" },
           "kind_f": {
             "anyOf": [
@@ -335,7 +335,7 @@
         },
         "required": [
           "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
-          "l", "a", "comment", "kind_f", "date"
+          "l", "a", "opt_int", "comment", "kind_f", "date"
         ],
         "additionalProperties": false
       }
@@ -380,7 +380,7 @@
             },
             "l": { "type": "array", "items": { "type": "string" } },
             "a": { "type": "array", "items": { "type": "number" } },
-            "opt_int": { "type": "integer" },
+            "opt_int": { "type": [ "integer", "null" ] },
             "comment": { "type": "string" },
             "kind_f": {
               "anyOf": [
@@ -411,7 +411,7 @@
           },
           "required": [
             "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
-            "l", "a", "comment", "kind_f", "date"
+            "l", "a", "opt_int", "comment", "kind_f", "date"
           ],
           "additionalProperties": false
         }
@@ -456,7 +456,7 @@
             },
             "l": { "type": "array", "items": { "type": "string" } },
             "a": { "type": "array", "items": { "type": "number" } },
-            "opt_int": { "type": "integer" },
+            "opt_int": { "type": [ "integer", "null" ] },
             "comment": { "type": "string" },
             "kind_f": {
               "anyOf": [
@@ -487,7 +487,7 @@
           },
           "required": [
             "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
-            "l", "a", "comment", "kind_f", "date"
+            "l", "a", "opt_int", "comment", "kind_f", "date"
           ],
           "additionalProperties": false
         },
@@ -538,7 +538,7 @@
               },
               "l": { "type": "array", "items": { "type": "string" } },
               "a": { "type": "array", "items": { "type": "number" } },
-              "opt_int": { "type": "integer" },
+              "opt_int": { "type": [ "integer", "null" ] },
               "comment": { "type": "string" },
               "kind_f": {
                 "anyOf": [
@@ -569,7 +569,7 @@
             },
             "required": [
               "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
-              "l", "a", "comment", "kind_f", "date"
+              "l", "a", "opt_int", "comment", "kind_f", "date"
             ],
             "additionalProperties": false
           },
@@ -621,7 +621,7 @@
               },
               "l": { "type": "array", "items": { "type": "string" } },
               "a": { "type": "array", "items": { "type": "number" } },
-              "opt_int": { "type": "integer" },
+              "opt_int": { "type": [ "integer", "null" ] },
               "comment": { "type": "string" },
               "kind_f": {
                 "anyOf": [
@@ -652,7 +652,7 @@
             },
             "required": [
               "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
-              "l", "a", "comment", "kind_f", "date"
+              "l", "a", "opt_int", "comment", "kind_f", "date"
             ],
             "additionalProperties": false
           },
@@ -703,7 +703,7 @@
             },
             "l": { "type": "array", "items": { "type": "string" } },
             "a": { "type": "array", "items": { "type": "number" } },
-            "opt_int": { "type": "integer" },
+            "opt_int": { "type": [ "integer", "null" ] },
             "comment": { "type": "string" },
             "kind_f": {
               "anyOf": [
@@ -734,7 +734,7 @@
           },
           "required": [
             "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
-            "l", "a", "comment", "kind_f", "date"
+            "l", "a", "opt_int", "comment", "kind_f", "date"
           ],
           "additionalProperties": false
         }
@@ -747,7 +747,7 @@
     },
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "integer"
+      "type": [ "integer", "null" ]
     },
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -837,11 +837,11 @@
           "required": [ "zip", "city", "street" ],
           "additionalProperties": false
         },
-        "email": { "type": "string" },
+        "email": { "type": [ "string", "null" ] },
         "age": { "type": "integer" },
         "name": { "type": "string" }
       },
-      "required": [ "address", "age", "name" ],
+      "required": [ "address", "email", "age", "name" ],
       "additionalProperties": false
     },
     {
@@ -863,12 +863,13 @@
         "retreat_address": { "$ref": "#/$defs/shared_address" },
         "work_address": { "$ref": "#/$defs/shared_address" },
         "home_address": { "$ref": "#/$defs/shared_address" },
-        "email": { "type": "string" },
+        "email": { "type": [ "string", "null" ] },
         "age": { "type": "integer" },
         "name": { "type": "string" }
       },
       "required": [
-        "retreat_address", "work_address", "home_address", "age", "name"
+        "retreat_address", "work_address", "home_address", "email", "age",
+        "name"
       ],
       "additionalProperties": false
     },


### PR DESCRIPTION
## Description
Currently, int option in a record generates {"type":"integer"} and the field is silently omitted from required. This is ambiguous: consumers cannot tell whether a field can be null or is just optional.

This PR changes the behaviour so that option types produce nullable schemas:

## Details

- Simple types: int option → {"type":["integer","null"]}
- Complex types: t option → {"anyOf":[<schema>, {"type":"null"}]}

All option fields are now included by default (they are required to be present, but may be null)

A new attribute [@jsonschema.option] was added for cases where you want to opt a field out of required entirely. Aligning it with melange-json