### PR TITLE
Pedrolisboa/minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,49 @@ Type `'a ref` is treated as `'a`.
 
 Type `unit` is converted to `{ "type": "null" }`.
 
+#### Option
+
+Option types are converted to `{ "type": ["...", "null"] }` and added to the `required` list.
+
+```ocaml
+type t = {
+  name : string option;
+} [@@deriving jsonschema]
+```
+
+```json
+{ 
+  "type": "object", 
+  "properties": { 
+    "name": { 
+      "type": [ "string", "null" ] 
+    },
+  },
+  "required": [ "name" ], 
+  "additionalProperties": false 
+}
+```
+
+To make a field optional, use the `[@@jsonschema.option]` attribute:
+
+```ocaml
+type t = {
+  name : string option; [@jsonschema.option]
+} [@@deriving jsonschema]
+```
+
+```json
+{ 
+  "type": "object", 
+  "properties": { 
+    "name": { 
+      "type": [ "string", "null" ] 
+    },
+  },
+  "required": [], 
+  "additionalProperties": false 
+}
+```
 #### List and arrays
 
 OCaml lists and arrays are converted to `{ "type": "array", "items": { "type": "..." } }`.

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -129,21 +129,21 @@ module Schema = struct
 
   let with_defs ~loc type_name ~extra_defs_var schema =
     [%expr
-      let _ppx_body = [%e schema] in
+      let ppx_body = [%e schema] in
       `Assoc
         [
           "$id", `String [%e estring ~loc ("urn:jsonschema:" ^ type_name)];
-          "$defs", `Assoc (([%e estring ~loc type_name], _ppx_body) :: ![%e extra_defs_var]);
+          "$defs", `Assoc (([%e estring ~loc type_name], ppx_body) :: ![%e extra_defs_var]);
           "$ref", `String [%e estring ~loc ("#/$defs/" ^ type_name)];
         ]]
 
   (* For mutually recursive types: multiple definitions, ref to first type.
-     Schemas are bound to _ppx_body_N variables so they execute before !extra_defs_var
+     Schemas are bound to ppx_body_N variables so they execute before !extra_defs_var
      is read — this ensures any hoisted $defs accumulate into extra_defs_var first. *)
   let with_multi_defs ~loc ~primary_type ~extra_defs_var defs =
     let id = "urn:jsonschema:" ^ primary_type in
     let indexed = List.mapi (fun i (name, schema) -> i, name, schema) defs in
-    let body_vars = List.map (fun (i, name, _) -> name, Printf.sprintf "_ppx_body_%d" i) indexed in
+    let body_vars = List.map (fun (i, name, _) -> name, Printf.sprintf "ppx_body_%d" i) indexed in
     let pairs_expr =
       elist ~loc (List.map (fun (name, vname) -> [%expr [%e estring ~loc name], [%e evar ~loc vname]]) body_vars)
     in
@@ -158,7 +158,7 @@ module Schema = struct
     in
     List.fold_right
       (fun (i, _name, schema) acc ->
-        let vname = Printf.sprintf "_ppx_body_%d" i in
+        let vname = Printf.sprintf "ppx_body_%d" i in
         [%expr
           let [%p ppat_var ~loc { txt = vname; loc }] = [%e schema] in
           [%e acc]])
@@ -243,8 +243,7 @@ let rec type_of_core ~config ?(recursive_types = []) ?extra_defs_var core_type =
             | `Assoc ppx_pairs ->
               (match List.assoc_opt "$defs" ppx_pairs with
               | Some (`Assoc ppx_defs) ->
-                [%e edv] :=
-                  ![%e edv] @ List.filter (fun (n, _) -> not (List.mem_assoc n ![%e edv])) ppx_defs;
+                [%e edv] := ![%e edv] @ List.filter (fun (n, _) -> not (List.mem_assoc n ![%e edv])) ppx_defs;
                 `Assoc (List.filter (fun (k, _) -> k <> "$id" && k <> "$defs") ppx_pairs)
               | _ -> `Assoc ppx_pairs)
             | ppx_other -> ppx_other],
@@ -497,9 +496,8 @@ let derive_jsonschema ~ctxt ast flag_variant_as_string flag_polymorphic_variant_
 
 let generator () = Deriving.Generator.V2.make ~attributes (args ()) derive_jsonschema
 
-
 let derive_jsonschema_sig ~ctxt ast _flag_variant_as_string _flag_polymorphic_variant_tuple =
-  let jsonschema_t ~loc = ptyp_constr ~loc { txt = Ldot (Lident "Ppx_deriving_jsonschema_runtime", "t"); loc } []
+  let jsonschema_t ~loc = ptyp_constr ~loc { txt = Ldot (Lident "Ppx_deriving_jsonschema_runtime", "t"); loc } [] in
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
   match ast with
   | _, [ td ] ->

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -237,55 +237,17 @@ let rec type_of_core ~config ?(recursive_types = []) ?extra_defs_var core_type =
         (* A recursive $ref was passed as an arg to a parametric type.
            The parametric type's schema will have {$id, $defs, $ref}; the $id
            creates a JSON Schema resource boundary so internal $refs like
-           "#/$defs/outer" would resolve against the inner $id — wrong.
-           Fix: hoist the inner $defs into the outer type's _ppx_eds accumulator
-           with unique suffixed names, and return just a renamed $ref. *)
-        let suffix = estring ~loc (Printf.sprintf "%d_%d" loc.loc_start.pos_lnum loc.loc_start.pos_cnum) in
+           "#/$defs/outer" would resolve against the inner $id — wrong. *)
         ( [%expr
-            let _ppx_sub = [%e schema] in
-            match _ppx_sub with
-            | `Assoc _ppx_pairs when List.mem_assoc "$defs" _ppx_pairs ->
-              let _ppx_inner_defs =
-                match List.assoc_opt "$defs" _ppx_pairs with
-                | Some (`Assoc d) -> d
-                | _ -> []
-              in
-              let _ppx_suffix = [%e suffix] in
-              let _ppx_mk n = n ^ "__" ^ _ppx_suffix in
-              let _ppx_rmap = List.map (fun (n, _) -> n, _ppx_mk n) _ppx_inner_defs in
-              let rec _ppx_ren t =
-                match t with
-                | `Assoc pairs ->
-                  `Assoc
-                    (List.map
-                       (fun (k, v) ->
-                         let v' =
-                           if k = "$ref" then (
-                             match v with
-                             | `String r when String.length r > 8 && String.sub r 0 8 = "#/$defs/" ->
-                               let n = String.sub r 8 (String.length r - 8) in
-                               `String
-                                 ("#/$defs/"
-                                 ^
-                                 match List.assoc_opt n _ppx_rmap with
-                                 | Some m -> m
-                                 | None -> n)
-                             | _ -> v)
-                           else _ppx_ren v
-                         in
-                         k, v')
-                       pairs)
-                | `List xs -> `List (List.map _ppx_ren xs)
-                | other -> other
-              in
-              let _ppx_hoisted = List.map (fun (n, b) -> _ppx_mk n, _ppx_ren b) _ppx_inner_defs in
-              [%e edv] := ![%e edv] @ _ppx_hoisted;
-              (match List.assoc_opt "$ref" _ppx_pairs with
-              | Some (`String _ppx_r) when String.length _ppx_r > 8 && String.sub _ppx_r 0 8 = "#/$defs/" ->
-                let _ppx_n = String.sub _ppx_r 8 (String.length _ppx_r - 8) in
-                `Assoc [ "$ref", `String ("#/$defs/" ^ _ppx_mk _ppx_n) ]
-              | _ -> `Assoc (List.filter (fun (k, _) -> k <> "$id") _ppx_pairs))
-            | _ppx_other -> _ppx_other],
+            match [%e schema] with
+            | `Assoc ppx_pairs ->
+              (match List.assoc_opt "$defs" ppx_pairs with
+              | Some (`Assoc ppx_defs) ->
+                [%e edv] :=
+                  ![%e edv] @ List.filter (fun (n, _) -> not (List.mem_assoc n ![%e edv])) ppx_defs;
+                `Assoc (List.filter (fun (k, _) -> k <> "$id" && k <> "$defs") ppx_pairs)
+              | _ -> `Assoc ppx_pairs)
+            | ppx_other -> ppx_other],
           true )
       | _ ->
         (* Non-recursive arg (or no accumulator): add a location-based $id to mark
@@ -469,14 +431,14 @@ let derive_jsonschema ~ctxt ast flag_variant_as_string flag_polymorphic_variant_
     let _, raw_schema, is_rec, params, params_prefix = derive_single_type ~loc ~config ~recursive_types type_decl in
     (* Apply with_defs before wrap_type_params so params wrap the full schema.
        For recursive types, do a second pass with extra_defs_var so hoisting
-       code referencing _ppx_eds is generated in the body expression. *)
+       code referencing ppx_eds is generated in the body expression. *)
     let schema =
       if is_rec then (
-        let edv = evar ~loc "_ppx_eds" in
-        let _, raw_schema2, _, _, _ = derive_single_type ~loc ~config ~recursive_types ~extra_defs_var:edv type_decl in
+        let edv = evar ~loc "ppx_eds" in
+        let _, raw_schema', _, _, _ = derive_single_type ~loc ~config ~recursive_types ~extra_defs_var:edv type_decl in
         [%expr
-          let _ppx_eds = ref [] in
-          [%e Schema.with_defs ~loc type_name ~extra_defs_var:edv raw_schema2]])
+          let ppx_eds = ref [] in
+          [%e Schema.with_defs ~loc type_name ~extra_defs_var:edv raw_schema']])
       else raw_schema
     in
     let schema = wrap_type_params ~loc ~prefix:params_prefix params schema in
@@ -492,20 +454,20 @@ let derive_jsonschema ~ctxt ast flag_variant_as_string flag_polymorphic_variant_
     let any_recursive = List.exists (fun (_, _, is_rec, _, _) -> is_rec) raw_results in
     if any_recursive then (
       (* Second pass: regenerate with extra_defs_var so hoisting code is emitted *)
-      let edv = evar ~loc "_ppx_eds" in
+      let edv = evar ~loc "ppx_eds" in
       let raw_results2 =
         List.map (fun td -> derive_single_type ~loc ~config ~recursive_types ~extra_defs_var:edv td) type_decls
       in
       let defs2 = List.map (fun (name, raw, _, _, _) -> name, raw) raw_results2 in
       (* Build $defs from raw schemas, then wrap the combined schema with type params.
-         Each binding gets its own _ppx_eds ref so hoisted defs don't leak across. *)
+         Each binding gets its own ppx_eds ref so hoisted defs don't leak across. *)
       let primary_value =
         let _, _, _, params, prefix = List.find (fun (name, _, _, _, _) -> name = primary_type) raw_results2 in
         let schema_inner = Schema.with_multi_defs ~loc ~primary_type ~extra_defs_var:edv defs2 in
         let schema =
           wrap_type_params ~loc ~prefix params
             [%expr
-              let _ppx_eds = ref [] in
+              let ppx_eds = ref [] in
               [%e schema_inner]]
         in
         create_value ~loc primary_type schema
@@ -519,7 +481,7 @@ let derive_jsonschema ~ctxt ast flag_variant_as_string flag_polymorphic_variant_
               let schema =
                 wrap_type_params ~loc ~prefix params
                   [%expr
-                    let _ppx_eds = ref [] in
+                    let ppx_eds = ref [] in
                     [%e schema_inner]]
               in
               Some (create_value ~loc name schema)))
@@ -535,9 +497,9 @@ let derive_jsonschema ~ctxt ast flag_variant_as_string flag_polymorphic_variant_
 
 let generator () = Deriving.Generator.V2.make ~attributes (args ()) derive_jsonschema
 
-let jsonschema_t ~loc = ptyp_constr ~loc { txt = Ldot (Lident "Ppx_deriving_jsonschema_runtime", "t"); loc } []
 
 let derive_jsonschema_sig ~ctxt ast _flag_variant_as_string _flag_polymorphic_variant_tuple =
+  let jsonschema_t ~loc = ptyp_constr ~loc { txt = Ldot (Lident "Ppx_deriving_jsonschema_runtime", "t"); loc } []
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
   match ast with
   | _, [ td ] ->

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -4451,73 +4451,27 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "ORNode"))];
-                       (let _ppx_sub =
-                          rec_wrapper_jsonschema
-                            (`Assoc [("$ref", (`String "#/$defs/outer_rec"))]) in
-                        match _ppx_sub with
-                        | `Assoc _ppx_pairs when
-                            List.mem_assoc "$defs" _ppx_pairs ->
-                            let _ppx_inner_defs =
-                              match List.assoc_opt "$defs" _ppx_pairs with
-                              | Some (`Assoc d) -> d
-                              | _ -> [] in
-                            let _ppx_suffix = "2561_68692" in
-                            let _ppx_mk n = n ^ ("__" ^ _ppx_suffix) in
-                            let _ppx_rmap =
-                              List.map (fun (n, _) -> (n, (_ppx_mk n)))
-                                _ppx_inner_defs in
-                            let rec _ppx_ren t =
-                              match t with
-                              | `Assoc pairs ->
+                       (match rec_wrapper_jsonschema
+                                (`Assoc
+                                   [("$ref", (`String "#/$defs/outer_rec"))])
+                        with
+                        | `Assoc ppx_pairs ->
+                            (match List.assoc_opt "$defs" ppx_pairs with
+                             | Some (`Assoc ppx_defs) ->
+                                 (_ppx_eds :=
+                                    ((!_ppx_eds) @
+                                       (List.filter
+                                          (fun (n, _) ->
+                                             not
+                                               (List.mem_assoc n (!_ppx_eds)))
+                                          ppx_defs));
                                   `Assoc
-                                    (List.map
-                                       (fun (k, v) ->
-                                          let v' =
-                                            if k = "$ref"
-                                            then
-                                              match v with
-                                              | `String r when
-                                                  ((String.length r) > 8) &&
-                                                    ((String.sub r 0 8) =
-                                                       "#/$defs/")
-                                                  ->
-                                                  let n =
-                                                    String.sub r 8
-                                                      ((String.length r) - 8) in
-                                                  `String
-                                                    ("#/$defs/" ^
-                                                       ((match List.assoc_opt
-                                                                 n _ppx_rmap
-                                                         with
-                                                         | Some m -> m
-                                                         | None -> n)))
-                                              | _ -> v
-                                            else _ppx_ren v in
-                                          (k, v')) pairs)
-                              | `List xs -> `List (List.map _ppx_ren xs)
-                              | other -> other in
-                            let _ppx_hoisted =
-                              List.map
-                                (fun (n, b) -> ((_ppx_mk n), (_ppx_ren b)))
-                                _ppx_inner_defs in
-                            (_ppx_eds := ((!_ppx_eds) @ _ppx_hoisted);
-                             (match List.assoc_opt "$ref" _ppx_pairs with
-                              | Some (`String _ppx_r) when
-                                  ((String.length _ppx_r) > 8) &&
-                                    ((String.sub _ppx_r 0 8) = "#/$defs/")
-                                  ->
-                                  let _ppx_n =
-                                    String.sub _ppx_r 8
-                                      ((String.length _ppx_r) - 8) in
-                                  `Assoc
-                                    [("$ref",
-                                       (`String
-                                          ("#/$defs/" ^ (_ppx_mk _ppx_n))))]
-                              | _ ->
-                                  `Assoc
-                                    (List.filter (fun (k, _) -> k <> "$id")
-                                       _ppx_pairs)))
-                        | _ppx_other -> _ppx_other)]));
+                                    (List.filter
+                                       (fun (k, _) ->
+                                          (k <> "$id") && (k <> "$defs"))
+                                       ppx_pairs))
+                             | _ -> `Assoc ppx_pairs)
+                        | ppx_other -> ppx_other)]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
@@ -4547,8 +4501,7 @@ include
             {
               "type": "array",
               "prefixItems": [
-                { "const": "ORNode" },
-                { "$ref": "#/$defs/rec_wrapper__2561_68692" }
+                { "const": "ORNode" }, { "$ref": "#/$defs/rec_wrapper" }
               ],
               "unevaluatedItems": false,
               "minItems": 2,
@@ -4556,7 +4509,7 @@ include
             }
           ]
         },
-        "rec_wrapper__2561_68692": {
+        "rec_wrapper": {
           "anyOf": [
             {
               "type": "array",
@@ -4570,8 +4523,7 @@ include
             {
               "type": "array",
               "prefixItems": [
-                { "const": "RNested" },
-                { "$ref": "#/$defs/rec_wrapper__2561_68692" }
+                { "const": "RNested" }, { "$ref": "#/$defs/rec_wrapper" }
               ],
               "unevaluatedItems": false,
               "minItems": 2,
@@ -4599,7 +4551,7 @@ include
               "prefixItems": [
                 { "const": "BoolAtom" },
                 {
-                  "$id": "urn:jsonschema:test/test.ml:2514:67360",
+                  "$id": "urn:jsonschema:test/test.ml:2505:67189",
                   "$defs": {
                     "filter": {
                       "anyOf": [

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -751,8 +751,8 @@ type recursive_record = {
 include
   struct
     let recursive_record_jsonschema =
-      let _ppx_eds = ref [] in
-      let _ppx_body =
+      let ppx_eds = ref [] in
+      let ppx_body =
         `Assoc
           [("type", (`String "object"));
           ("properties",
@@ -768,7 +768,7 @@ include
           ("additionalProperties", (`Bool false))] in
       `Assoc
         [("$id", (`String "urn:jsonschema:recursive_record"));
-        ("$defs", (`Assoc (("recursive_record", _ppx_body) :: (!_ppx_eds))));
+        ("$defs", (`Assoc (("recursive_record", ppx_body) :: (!ppx_eds))));
         ("$ref", (`String "#/$defs/recursive_record"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -802,8 +802,8 @@ type recursive_variant =
 include
   struct
     let recursive_variant_jsonschema =
-      let _ppx_eds = ref [] in
-      let _ppx_body =
+      let ppx_eds = ref [] in
+      let ppx_body =
         `Assoc
           [("anyOf",
              (`List
@@ -826,7 +826,7 @@ include
                   ("maxItems", (`Int 1))]]))] in
       `Assoc
         [("$id", (`String "urn:jsonschema:recursive_variant"));
-        ("$defs", (`Assoc (("recursive_variant", _ppx_body) :: (!_ppx_eds))));
+        ("$defs", (`Assoc (("recursive_variant", ppx_body) :: (!ppx_eds))));
         ("$ref", (`String "#/$defs/recursive_variant"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -871,8 +871,8 @@ type tree =
 include
   struct
     let tree_jsonschema =
-      let _ppx_eds = ref [] in
-      let _ppx_body =
+      let ppx_eds = ref [] in
+      let ppx_body =
         `Assoc
           [("anyOf",
              (`List
@@ -909,7 +909,7 @@ include
                   ("maxItems", (`Int 2))]]))] in
       `Assoc
         [("$id", (`String "urn:jsonschema:tree"));
-        ("$defs", (`Assoc (("tree", _ppx_body) :: (!_ppx_eds))));
+        ("$defs", (`Assoc (("tree", ppx_body) :: (!ppx_eds))));
         ("$ref", (`String "#/$defs/tree"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -990,8 +990,8 @@ and bar = {
 include
   struct
     let foo_jsonschema =
-      let _ppx_eds = ref [] in
-      let _ppx_body_0 =
+      let ppx_eds = ref [] in
+      let ppx_body_0 =
         `Assoc
           [("type", (`String "object"));
           ("properties",
@@ -1007,7 +1007,7 @@ include
                              (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
           ("required", (`List [`String "bar"]));
           ("additionalProperties", (`Bool false))] in
-      let _ppx_body_1 =
+      let ppx_body_1 =
         `Assoc
           [("type", (`String "object"));
           ("properties",
@@ -1026,12 +1026,11 @@ include
       `Assoc
         [("$id", (`String "urn:jsonschema:foo"));
         ("$defs",
-          (`Assoc
-             ([("foo", _ppx_body_0); ("bar", _ppx_body_1)] @ (!_ppx_eds))));
+          (`Assoc ([("foo", ppx_body_0); ("bar", ppx_body_1)] @ (!ppx_eds))));
         ("$ref", (`String "#/$defs/foo"))][@@warning "-32-39"]
     let bar_jsonschema =
-      let _ppx_eds = ref [] in
-      let _ppx_body_0 =
+      let ppx_eds = ref [] in
+      let ppx_body_0 =
         `Assoc
           [("type", (`String "object"));
           ("properties",
@@ -1047,7 +1046,7 @@ include
                              (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
           ("required", (`List [`String "bar"]));
           ("additionalProperties", (`Bool false))] in
-      let _ppx_body_1 =
+      let ppx_body_1 =
         `Assoc
           [("type", (`String "object"));
           ("properties",
@@ -1066,8 +1065,7 @@ include
       `Assoc
         [("$id", (`String "urn:jsonschema:bar"));
         ("$defs",
-          (`Assoc
-             ([("foo", _ppx_body_0); ("bar", _ppx_body_1)] @ (!_ppx_eds))));
+          (`Assoc ([("foo", ppx_body_0); ("bar", ppx_body_1)] @ (!ppx_eds))));
         ("$ref", (`String "#/$defs/bar"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -1141,8 +1139,8 @@ and stmt =
 include
   struct
     let expr_jsonschema =
-      let _ppx_eds = ref [] in
-      let _ppx_body_0 =
+      let ppx_eds = ref [] in
+      let ppx_body_0 =
         `Assoc
           [("anyOf",
              (`List
@@ -1177,7 +1175,7 @@ include
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
-      let _ppx_body_1 =
+      let ppx_body_1 =
         `Assoc
           [("anyOf",
              (`List
@@ -1232,12 +1230,11 @@ include
       `Assoc
         [("$id", (`String "urn:jsonschema:expr"));
         ("$defs",
-          (`Assoc
-             ([("expr", _ppx_body_0); ("stmt", _ppx_body_1)] @ (!_ppx_eds))));
+          (`Assoc ([("expr", ppx_body_0); ("stmt", ppx_body_1)] @ (!ppx_eds))));
         ("$ref", (`String "#/$defs/expr"))][@@warning "-32-39"]
     let stmt_jsonschema =
-      let _ppx_eds = ref [] in
-      let _ppx_body_0 =
+      let ppx_eds = ref [] in
+      let ppx_body_0 =
         `Assoc
           [("anyOf",
              (`List
@@ -1272,7 +1269,7 @@ include
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
-      let _ppx_body_1 =
+      let ppx_body_1 =
         `Assoc
           [("anyOf",
              (`List
@@ -1327,8 +1324,7 @@ include
       `Assoc
         [("$id", (`String "urn:jsonschema:stmt"));
         ("$defs",
-          (`Assoc
-             ([("expr", _ppx_body_0); ("stmt", _ppx_body_1)] @ (!_ppx_eds))));
+          (`Assoc ([("expr", ppx_body_0); ("stmt", ppx_body_1)] @ (!ppx_eds))));
         ("$ref", (`String "#/$defs/stmt"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -1469,8 +1465,8 @@ and node_c = {
 include
   struct
     let node_a_jsonschema =
-      let _ppx_eds = ref [] in
-      let _ppx_body_0 =
+      let ppx_eds = ref [] in
+      let ppx_body_0 =
         `Assoc
           [("type", (`String "object"));
           ("properties",
@@ -1494,7 +1490,7 @@ include
                             (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
           ("required", (`List [`String "c"; `String "b"]));
           ("additionalProperties", (`Bool false))] in
-      let _ppx_body_1 =
+      let ppx_body_1 =
         `Assoc
           [("type", (`String "object"));
           ("properties",
@@ -1518,7 +1514,7 @@ include
                             (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
           ("required", (`List [`String "c"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
-      let _ppx_body_2 =
+      let ppx_body_2 =
         `Assoc
           [("type", (`String "object"));
           ("properties",
@@ -1546,13 +1542,13 @@ include
         [("$id", (`String "urn:jsonschema:node_a"));
         ("$defs",
           (`Assoc
-             ([("node_a", _ppx_body_0);
-              ("node_b", _ppx_body_1);
-              ("node_c", _ppx_body_2)] @ (!_ppx_eds))));
+             ([("node_a", ppx_body_0);
+              ("node_b", ppx_body_1);
+              ("node_c", ppx_body_2)] @ (!ppx_eds))));
         ("$ref", (`String "#/$defs/node_a"))][@@warning "-32-39"]
     let node_b_jsonschema =
-      let _ppx_eds = ref [] in
-      let _ppx_body_0 =
+      let ppx_eds = ref [] in
+      let ppx_body_0 =
         `Assoc
           [("type", (`String "object"));
           ("properties",
@@ -1576,7 +1572,7 @@ include
                             (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
           ("required", (`List [`String "c"; `String "b"]));
           ("additionalProperties", (`Bool false))] in
-      let _ppx_body_1 =
+      let ppx_body_1 =
         `Assoc
           [("type", (`String "object"));
           ("properties",
@@ -1600,7 +1596,7 @@ include
                             (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
           ("required", (`List [`String "c"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
-      let _ppx_body_2 =
+      let ppx_body_2 =
         `Assoc
           [("type", (`String "object"));
           ("properties",
@@ -1628,13 +1624,13 @@ include
         [("$id", (`String "urn:jsonschema:node_b"));
         ("$defs",
           (`Assoc
-             ([("node_a", _ppx_body_0);
-              ("node_b", _ppx_body_1);
-              ("node_c", _ppx_body_2)] @ (!_ppx_eds))));
+             ([("node_a", ppx_body_0);
+              ("node_b", ppx_body_1);
+              ("node_c", ppx_body_2)] @ (!ppx_eds))));
         ("$ref", (`String "#/$defs/node_b"))][@@warning "-32-39"]
     let node_c_jsonschema =
-      let _ppx_eds = ref [] in
-      let _ppx_body_0 =
+      let ppx_eds = ref [] in
+      let ppx_body_0 =
         `Assoc
           [("type", (`String "object"));
           ("properties",
@@ -1658,7 +1654,7 @@ include
                             (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
           ("required", (`List [`String "c"; `String "b"]));
           ("additionalProperties", (`Bool false))] in
-      let _ppx_body_1 =
+      let ppx_body_1 =
         `Assoc
           [("type", (`String "object"));
           ("properties",
@@ -1682,7 +1678,7 @@ include
                             (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
           ("required", (`List [`String "c"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
-      let _ppx_body_2 =
+      let ppx_body_2 =
         `Assoc
           [("type", (`String "object"));
           ("properties",
@@ -1710,9 +1706,9 @@ include
         [("$id", (`String "urn:jsonschema:node_c"));
         ("$defs",
           (`Assoc
-             ([("node_a", _ppx_body_0);
-              ("node_b", _ppx_body_1);
-              ("node_c", _ppx_body_2)] @ (!_ppx_eds))));
+             ([("node_a", ppx_body_0);
+              ("node_b", ppx_body_1);
+              ("node_c", ppx_body_2)] @ (!ppx_eds))));
         ("$ref", (`String "#/$defs/node_c"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -1773,8 +1769,8 @@ type recursive_tuple =
 include
   struct
     let recursive_tuple_jsonschema =
-      let _ppx_eds = ref [] in
-      let _ppx_body =
+      let ppx_eds = ref [] in
+      let ppx_body =
         `Assoc
           [("anyOf",
              (`List
@@ -1810,7 +1806,7 @@ include
                   ("maxItems", (`Int 2))]]))] in
       `Assoc
         [("$id", (`String "urn:jsonschema:recursive_tuple"));
-        ("$defs", (`Assoc (("recursive_tuple", _ppx_body) :: (!_ppx_eds))));
+        ("$defs", (`Assoc (("recursive_tuple", ppx_body) :: (!ppx_eds))));
         ("$ref", (`String "#/$defs/recursive_tuple"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -4085,8 +4081,8 @@ type 'a grade = 'a grade' =
 include
   struct
     let grade_jsonschema a =
-      let _ppx_eds = ref [] in
-      let _ppx_body =
+      let ppx_eds = ref [] in
+      let ppx_body =
         `Assoc
           [("anyOf",
              (`List
@@ -4123,7 +4119,7 @@ include
                   ("maxItems", (`Int 1))]]))] in
       `Assoc
         [("$id", (`String "urn:jsonschema:grade"));
-        ("$defs", (`Assoc (("grade", _ppx_body) :: (!_ppx_eds))));
+        ("$defs", (`Assoc (("grade", ppx_body) :: (!ppx_eds))));
         ("$ref", (`String "#/$defs/grade"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -4180,8 +4176,8 @@ type self_ref = {
 include
   struct
     let self_ref_jsonschema =
-      let _ppx_eds = ref [] in
-      let _ppx_body =
+      let ppx_eds = ref [] in
+      let ppx_body =
         `Assoc
           [("type", (`String "object"));
           ("properties",
@@ -4195,7 +4191,7 @@ include
           ("additionalProperties", (`Bool false))] in
       `Assoc
         [("$id", (`String "urn:jsonschema:self_ref"));
-        ("$defs", (`Assoc (("self_ref", _ppx_body) :: (!_ppx_eds))));
+        ("$defs", (`Assoc (("self_ref", ppx_body) :: (!ppx_eds))));
         ("$ref", (`String "#/$defs/self_ref"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type two_self_refs = {
@@ -4213,7 +4209,7 @@ include
                   | `Assoc pairs when List.mem_assoc "$defs" pairs ->
                       `Assoc
                         (("$id",
-                           (`String "urn:jsonschema:test.ml:2456:65714"))
+                           (`String "urn:jsonschema:test.ml:2455:65717"))
                         :: (List.filter (fun (k, _) -> k <> "$id") pairs))
                   | other -> other)));
              ("a",
@@ -4221,7 +4217,7 @@ include
                  | `Assoc pairs when List.mem_assoc "$defs" pairs ->
                      `Assoc
                        (("$id",
-                          (`String "urn:jsonschema:test.ml:2455:65698"))
+                          (`String "urn:jsonschema:test.ml:2454:65701"))
                        :: (List.filter (fun (k, _) -> k <> "$id") pairs))
                  | other -> other)))]));
         ("required", (`List [`String "b"; `String "a"]));
@@ -4237,7 +4233,7 @@ include
       "type": "object",
       "properties": {
         "b": {
-          "$id": "urn:jsonschema:test/test.ml:2456:65714",
+          "$id": "urn:jsonschema:test/test.ml:2455:65717",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -4254,7 +4250,7 @@ include
           "$ref": "#/$defs/self_ref"
         },
         "a": {
-          "$id": "urn:jsonschema:test/test.ml:2455:65698",
+          "$id": "urn:jsonschema:test/test.ml:2454:65701",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -4282,8 +4278,8 @@ type ('atom, 'group_atom) filter =
 include
   struct
     let filter_jsonschema atom group_atom =
-      let _ppx_eds = ref [] in
-      let _ppx_body =
+      let ppx_eds = ref [] in
+      let ppx_body =
         `Assoc
           [("anyOf",
              (`List
@@ -4309,7 +4305,7 @@ include
                   ("maxItems", (`Int 3))]]))] in
       `Assoc
         [("$id", (`String "urn:jsonschema:filter"));
-        ("$defs", (`Assoc (("filter", _ppx_body) :: (!_ppx_eds))));
+        ("$defs", (`Assoc (("filter", ppx_body) :: (!ppx_eds))));
         ("$ref", (`String "#/$defs/filter"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type ('atom, 'group_atom) bool_filter =
@@ -4319,8 +4315,8 @@ type ('atom, 'group_atom) bool_filter =
 include
   struct
     let bool_filter_jsonschema atom group_atom =
-      let _ppx_eds = ref [] in
-      let _ppx_body =
+      let ppx_eds = ref [] in
+      let ppx_body =
         `Assoc
           [("anyOf",
              (`List
@@ -4334,7 +4330,7 @@ include
                              `Assoc
                                (("$id",
                                   (`String
-                                     "urn:jsonschema:test.ml:2514:67360"))
+                                     "urn:jsonschema:test.ml:2514:67367"))
                                ::
                                (List.filter (fun (k, _) -> k <> "$id") pairs))
                          | other -> other)]));
@@ -4356,7 +4352,7 @@ include
                   ("maxItems", (`Int 2))]]))] in
       `Assoc
         [("$id", (`String "urn:jsonschema:bool_filter"));
-        ("$defs", (`Assoc (("bool_filter", _ppx_body) :: (!_ppx_eds))));
+        ("$defs", (`Assoc (("bool_filter", ppx_body) :: (!ppx_eds))));
         ("$ref", (`String "#/$defs/bool_filter"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -4400,8 +4396,8 @@ type 'a rec_wrapper =
 include
   struct
     let rec_wrapper_jsonschema a =
-      let _ppx_eds = ref [] in
-      let _ppx_body =
+      let ppx_eds = ref [] in
+      let ppx_body =
         `Assoc
           [("anyOf",
              (`List
@@ -4423,7 +4419,7 @@ include
                   ("maxItems", (`Int 2))]]))] in
       `Assoc
         [("$id", (`String "urn:jsonschema:rec_wrapper"));
-        ("$defs", (`Assoc (("rec_wrapper", _ppx_body) :: (!_ppx_eds))));
+        ("$defs", (`Assoc (("rec_wrapper", ppx_body) :: (!ppx_eds))));
         ("$ref", (`String "#/$defs/rec_wrapper"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type outer_rec =
@@ -4432,8 +4428,8 @@ type outer_rec =
 include
   struct
     let outer_rec_jsonschema =
-      let _ppx_eds = ref [] in
-      let _ppx_body =
+      let ppx_eds = ref [] in
+      let ppx_body =
         `Assoc
           [("anyOf",
              (`List
@@ -4458,12 +4454,12 @@ include
                         | `Assoc ppx_pairs ->
                             (match List.assoc_opt "$defs" ppx_pairs with
                              | Some (`Assoc ppx_defs) ->
-                                 (_ppx_eds :=
-                                    ((!_ppx_eds) @
+                                 (ppx_eds :=
+                                    ((!ppx_eds) @
                                        (List.filter
                                           (fun (n, _) ->
                                              not
-                                               (List.mem_assoc n (!_ppx_eds)))
+                                               (List.mem_assoc n (!ppx_eds)))
                                           ppx_defs));
                                   `Assoc
                                     (List.filter
@@ -4477,7 +4473,7 @@ include
                   ("maxItems", (`Int 2))]]))] in
       `Assoc
         [("$id", (`String "urn:jsonschema:outer_rec"));
-        ("$defs", (`Assoc (("outer_rec", _ppx_body) :: (!_ppx_eds))));
+        ("$defs", (`Assoc (("outer_rec", ppx_body) :: (!ppx_eds))));
         ("$ref", (`String "#/$defs/outer_rec"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -4551,7 +4547,7 @@ include
               "prefixItems": [
                 { "const": "BoolAtom" },
                 {
-                  "$id": "urn:jsonschema:test/test.ml:2505:67189",
+                  "$id": "urn:jsonschema:test/test.ml:2514:67367",
                   "$defs": {
                     "filter": {
                       "anyOf": [

--- a/test/test.ml
+++ b/test/test.ml
@@ -2582,8 +2582,7 @@ let%expect_test "parametric_recursive_cross_ref" =
             {
               "type": "array",
               "prefixItems": [
-                { "const": "ORNode" },
-                { "$ref": "#/$defs/rec_wrapper__2561_68692" }
+                { "const": "ORNode" }, { "$ref": "#/$defs/rec_wrapper" }
               ],
               "unevaluatedItems": false,
               "minItems": 2,
@@ -2591,7 +2590,7 @@ let%expect_test "parametric_recursive_cross_ref" =
             }
           ]
         },
-        "rec_wrapper__2561_68692": {
+        "rec_wrapper": {
           "anyOf": [
             {
               "type": "array",
@@ -2605,8 +2604,7 @@ let%expect_test "parametric_recursive_cross_ref" =
             {
               "type": "array",
               "prefixItems": [
-                { "const": "RNested" },
-                { "$ref": "#/$defs/rec_wrapper__2561_68692" }
+                { "const": "RNested" }, { "$ref": "#/$defs/rec_wrapper" }
               ],
               "unevaluatedItems": false,
               "minItems": 2,

--- a/test/test.ml
+++ b/test/test.ml
@@ -2465,7 +2465,7 @@ let%expect_test "no_duplicate_id_when_recursive_type_used_twice" =
       "type": "object",
       "properties": {
         "b": {
-          "$id": "urn:jsonschema:test/test.ml:2456:65714",
+          "$id": "urn:jsonschema:test/test.ml:2455:65717",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -2482,7 +2482,7 @@ let%expect_test "no_duplicate_id_when_recursive_type_used_twice" =
           "$ref": "#/$defs/self_ref"
         },
         "a": {
-          "$id": "urn:jsonschema:test/test.ml:2455:65698",
+          "$id": "urn:jsonschema:test/test.ml:2454:65701",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -2632,7 +2632,7 @@ let%expect_test "polymorphic_recursive_ref_bool_filter" =
               "prefixItems": [
                 { "const": "BoolAtom" },
                 {
-                  "$id": "urn:jsonschema:test/test.ml:2514:67360",
+                  "$id": "urn:jsonschema:test/test.ml:2514:67367",
                   "$defs": {
                     "filter": {
                       "anyOf": [


### PR DESCRIPTION
## Summary

A minor fix and a refactor following the introduction of nullable option fields and parametric recursive type support.\

### Simplified `$defs` hoisting for parametric recursive types

The previous approach renamed every hoisted `$def` with a unique `name__line_col` suffix to avoid collisions, then rewrote all `$ref` strings pointing to those defs. This was ~60 lines of generated OCaml and the suffix made the output schema less readable (e.g. `"$ref": "#/$defs/rec_wrapper__2561_68692"`).

Also drops the leading underscore from generated internal variable names (`_ppx_eds` → `ppx_eds`, `_ppx_body` → `ppx_body`) since they don't need to suppress unused-variable warnings.

### Docs

Added an `Option` section to the README covering both the default nullable behavior and the `[@jsonschema.option]` attribute.
