### PR TITLE
Split ppx_deriving_jsonschema into multiple files and functions

### DIFF
--- a/src/attrs.ml
+++ b/src/attrs.ml
@@ -1,0 +1,56 @@
+open Ppxlib
+
+type config = {
+  variant_as_string : bool;
+    (** Encode variants as string instead of string array.
+        This option breaks compatibility with yojson derivers and
+        doesn't support constructors with a payload. *)
+  polymorphic_variant_tuple : bool;
+    (** Preserve the implicit tuple in a polymorphic variant.
+        This option breaks compatibility with yojson derivers. *)
+}
+
+let jsonschema_key =
+  Attribute.declare "jsonschema.key" Attribute.Context.label_declaration
+    Ast_pattern.(single_expr_payload (estring __'))
+    (fun x -> x)
+
+let jsonschema_ref =
+  Attribute.declare "jsonschema.ref" Attribute.Context.label_declaration
+    Ast_pattern.(single_expr_payload (estring __'))
+    (fun x -> x)
+
+let jsonschema_variant_name =
+  Attribute.declare "jsonschema.name" Attribute.Context.constructor_declaration
+    Ast_pattern.(single_expr_payload (estring __'))
+    (fun x -> x)
+
+let jsonschema_polymorphic_variant_name =
+  Attribute.declare "jsonschema.name" Attribute.Context.rtag
+    Ast_pattern.(single_expr_payload (estring __'))
+    (fun x -> x)
+
+let jsonschema_td_allow_extra_fields =
+  Attribute.declare "jsonschema.allow_extra_fields" Attribute.Context.type_declaration
+    Ast_pattern.(pstr nil)
+    (fun () -> ())
+
+let jsonschema_cd_allow_extra_fields =
+  Attribute.declare "jsonschema.allow_extra_fields" Attribute.Context.constructor_declaration
+    Ast_pattern.(pstr nil)
+    (fun () -> ())
+
+let jsonschema_option = Attribute.declare_flag "jsonschema.option" Attribute.Context.label_declaration
+
+let attributes =
+  [
+    Attribute.T jsonschema_key;
+    Attribute.T jsonschema_ref;
+    Attribute.T jsonschema_variant_name;
+    Attribute.T jsonschema_polymorphic_variant_name;
+    Attribute.T jsonschema_td_allow_extra_fields;
+    Attribute.T jsonschema_cd_allow_extra_fields;
+    Attribute.T jsonschema_option;
+  ]
+
+let args () = Deriving.Args.(empty +> flag "variant_as_string" +> flag "polymorphic_variant_tuple")

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -212,9 +212,7 @@ let schema_of_type_decl ~loc ~(config : Attrs.config) ~recursive_types type_decl
     let schema, is_rec, params_prefix = schema_of_variants ~loc ~config ~recursive_types variants in
     type_name, schema, is_rec, params, params_prefix
   | Ptype_record label_declarations ->
-    let schema, is_rec =
-      schema_of_record ~loc ~config ~recursive_types label_declarations allow_extra_fields
-    in
+    let schema, is_rec = schema_of_record ~loc ~config ~recursive_types label_declarations allow_extra_fields in
     type_name, schema, is_rec, params, ""
   | Ptype_abstract ->
     (match type_decl.ptype_manifest with
@@ -228,8 +226,7 @@ let schema_of_type_decl ~loc ~(config : Attrs.config) ~recursive_types type_decl
     let msg = "ppx_deriving_jsonschema: open types not supported" in
     type_name, [%expr [%ocaml.error [%e estring ~loc msg]]], false, params, ""
 
-let apply_defs ~loc =
-  function
+let apply_defs ~loc = function
   | `Rec (primary, defs) ->
     let edv = evar ~loc "ppx_eds" in
     let vname name = "ppx_body_" ^ name in
@@ -239,9 +236,7 @@ let apply_defs ~loc =
     let base_expr =
       [%expr
         `Assoc
-          [
-            "$defs", `Assoc ([%e pairs_expr] @ ![%e edv]); "$ref", `String [%e estring ~loc ("#/$defs/" ^ primary)];
-          ]]
+          [ "$defs", `Assoc ([%e pairs_expr] @ ![%e edv]); "$ref", `String [%e estring ~loc ("#/$defs/" ^ primary)] ]]
     in
     List.fold_right
       (fun (name, s) acc ->

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -1,220 +1,40 @@
 open Ppxlib
 open Ast_builder.Default
 
-type config = {
-  variant_as_string : bool;
-    (** Encode variants as string instead of string array.
-        This option breaks compatibility with yojson derivers and
-        doesn't support constructors with a payload. *)
-  polymorphic_variant_tuple : bool;
-    (** Preserve the implicit tuple in a polymorphic variant.
-        This option breaks compatibility with yojson derivers. *)
-}
-
 let deriver_name = "jsonschema"
-
-let jsonschema_key =
-  Attribute.declare "jsonschema.key" Attribute.Context.label_declaration
-    Ast_pattern.(single_expr_payload (estring __'))
-    (fun x -> x)
-
-let jsonschema_ref =
-  Attribute.declare "jsonschema.ref" Attribute.Context.label_declaration
-    Ast_pattern.(single_expr_payload (estring __'))
-    (fun x -> x)
-
-let jsonschema_variant_name =
-  Attribute.declare "jsonschema.name" Attribute.Context.constructor_declaration
-    Ast_pattern.(single_expr_payload (estring __'))
-    (fun x -> x)
-
-let jsonschema_polymorphic_variant_name =
-  Attribute.declare "jsonschema.name" Attribute.Context.rtag
-    Ast_pattern.(single_expr_payload (estring __'))
-    (fun x -> x)
-
-let jsonschema_td_allow_extra_fields =
-  Attribute.declare "jsonschema.allow_extra_fields" Attribute.Context.type_declaration
-    Ast_pattern.(pstr nil)
-    (fun () -> ())
-
-let jsonschema_cd_allow_extra_fields =
-  Attribute.declare "jsonschema.allow_extra_fields" Attribute.Context.constructor_declaration
-    Ast_pattern.(pstr nil)
-    (fun () -> ())
-
-let jsonschema_option = Attribute.declare_flag "jsonschema.option" Attribute.Context.label_declaration
-
-let attributes =
-  [
-    Attribute.T jsonschema_key;
-    Attribute.T jsonschema_ref;
-    Attribute.T jsonschema_variant_name;
-    Attribute.T jsonschema_polymorphic_variant_name;
-    Attribute.T jsonschema_td_allow_extra_fields;
-    Attribute.T jsonschema_cd_allow_extra_fields;
-    Attribute.T jsonschema_option;
-  ]
-
-(* let args () = Deriving.Args.(empty) *)
-let args () = Deriving.Args.(empty +> flag "variant_as_string" +> flag "polymorphic_variant_tuple")
-
-let deps = []
-
-let predefined_types = [ "string"; "int"; "float"; "bool" ]
-let is_predefined_type type_name = List.mem type_name predefined_types
-
-module Schema = struct
-  let const ~loc value = [%expr `Assoc [ "const", `String [%e estring ~loc value] ]]
-
-  let type_ref ~loc type_name =
-    let name = estring ~loc ("#/$defs/" ^ type_name) in
-    [%expr `Assoc [ "$ref", `String [%e name] ]]
-
-  let type_def ~loc type_name = [%expr `Assoc [ "type", `String [%e estring ~loc type_name] ]]
-
-  let null ~loc = [%expr `Assoc [ "type", `String "null" ]]
-
-  let char ~loc = [%expr `Assoc [ "type", `String "string"; "minLength", `Int 1; "maxLength", `Int 1 ]]
-
-  let oneOf ~loc values = [%expr `Assoc [ "oneOf", `List [%e elist ~loc values] ]]
-
-  let anyOf ~loc values = [%expr `Assoc [ "anyOf", `List [%e elist ~loc values] ]]
-
-  let array_ ~loc ?min_items ?max_items element_type =
-    let fields =
-      List.filter_map
-        (fun x -> x)
-        [
-          Some [%expr "type", `String "array"];
-          Some [%expr "items", [%e element_type]];
-          (match min_items with
-          | Some min -> Some [%expr "minItems", `Int [%e eint ~loc min]]
-          | None -> None);
-          (match max_items with
-          | Some max -> Some [%expr "maxItems", `Int [%e eint ~loc max]]
-          | None -> None);
-        ]
-    in
-    [%expr `Assoc [%e elist ~loc fields]]
-
-  let tuple ~loc elements =
-    [%expr
-      `Assoc
-        [
-          "type", `String "array";
-          "prefixItems", `List [%e elist ~loc elements];
-          "unevaluatedItems", `Bool false;
-          "minItems", `Int [%e eint ~loc (List.length elements)];
-          "maxItems", `Int [%e eint ~loc (List.length elements)];
-        ]]
-
-  let enum ~loc typ values =
-    match typ with
-    | Some typ -> [%expr `Assoc [ "type", `String [%e estring ~loc typ]; "enum", `List [%e elist ~loc values] ]]
-    | None -> [%expr `Assoc [ "enum", `List [%e elist ~loc values] ]]
-
-  let enum_string ~loc values =
-    let values = List.map (fun name -> [%expr `String [%e estring ~loc name]]) values in
-    enum ~loc (Some "string") values
-
-  (* Make a schema explicitly nullable.
-     For simple {"type": "X"} schemas, produces {"type": ["X", "null"]}.
-     For complex schemas, falls back to {"anyOf": [schema, {"type": "null"}]}. *)
-  let nullable ~loc schema =
-    [%expr
-      match [%e schema] with
-      | `Assoc [ ("type", `String t) ] -> `Assoc [ "type", `List [ `String t; `String "null" ] ]
-      | s -> `Assoc [ "anyOf", `List [ s; `Assoc [ "type", `String "null" ] ] ]]
-
-  let with_defs ~loc type_name ~extra_defs_var schema =
-    [%expr
-      let ppx_body = [%e schema] in
-      `Assoc
-        [
-          "$id", `String [%e estring ~loc ("urn:jsonschema:" ^ type_name)];
-          "$defs", `Assoc (([%e estring ~loc type_name], ppx_body) :: ![%e extra_defs_var]);
-          "$ref", `String [%e estring ~loc ("#/$defs/" ^ type_name)];
-        ]]
-
-  (* For mutually recursive types: multiple definitions, ref to first type.
-     Schemas are bound to ppx_body_N variables so they execute before !extra_defs_var
-     is read — this ensures any hoisted $defs accumulate into extra_defs_var first. *)
-  let with_multi_defs ~loc ~primary_type ~extra_defs_var defs =
-    let id = "urn:jsonschema:" ^ primary_type in
-    let indexed = List.mapi (fun i (name, schema) -> i, name, schema) defs in
-    let body_vars = List.map (fun (i, name, _) -> name, Printf.sprintf "ppx_body_%d" i) indexed in
-    let pairs_expr =
-      elist ~loc (List.map (fun (name, vname) -> [%expr [%e estring ~loc name], [%e evar ~loc vname]]) body_vars)
-    in
-    let base_expr =
-      [%expr
-        `Assoc
-          [
-            "$id", `String [%e estring ~loc id];
-            "$defs", `Assoc ([%e pairs_expr] @ ![%e extra_defs_var]);
-            "$ref", `String [%e estring ~loc ("#/$defs/" ^ primary_type)];
-          ]]
-    in
-    List.fold_right
-      (fun (i, _name, schema) acc ->
-        let vname = Printf.sprintf "ppx_body_%d" i in
-        [%expr
-          let [%p ppat_var ~loc { txt = vname; loc }] = [%e schema] in
-          [%e acc]])
-      indexed base_expr
-end
-
-let variant_as_string ~loc constrs =
-  Schema.anyOf ~loc
-    (List.map
-       (function
-         | `Tag (name, _typs) -> Schema.const ~loc name
-         | `Inherit typ -> typ)
-       constrs)
-
-let variant_as_array ~loc constrs =
-  Schema.anyOf ~loc
-    (List.map
-       (function
-         | `Tag (name, typs) -> Schema.tuple ~loc (Schema.const ~loc name :: typs)
-         | `Inherit typ -> typ)
-       constrs)
-
-let variant ~loc ~config constrs =
-  Schema.anyOf ~loc
-    (List.map
-       (function
-         | `Inherit typ -> typ
-         | `Tag (name, typs) ->
-         match config.variant_as_string with
-         | true -> Schema.const ~loc name
-         | false -> Schema.tuple ~loc (Schema.const ~loc name :: typs))
-       constrs)
 
 let value_name_pattern ~loc type_name = ppat_var ~loc { txt = type_name ^ "_jsonschema"; loc }
 
 let create_value ~loc name value = [%stri let[@warning "-32-39"] [%p value_name_pattern ~loc name] = [%e value]]
 
-(* Returns (schema_expression, is_recursive)
-   recursive_types: list of type names in a mutually recursive group
-   extra_defs_var: when Some edv, edv is an expression for a (string * t) list ref that
-     accumulates hoisted $defs from parametric recursive sub-schemas *)
-let rec type_of_core ~config ?(recursive_types = []) ?extra_defs_var core_type =
+(* Wraps [body] in nested lambdas, one per type parameter.
+   Parametric types like [('a, 'b) t] derive as [fun a b -> <schema>],
+   so callers can pass schemas for each type variable.
+   Use [~prefix:"_"] to mark params unused in the body. *)
+let wrap_type_params ~loc ?(prefix = "") params body =
+  List.fold_right
+    (fun param body -> [%expr fun [%p ppat_var ~loc { txt = prefix ^ param; loc }] -> [%e body]])
+    params body
+
+(* schema_of_core_type and schema_of_poly_variant are mutually recursive.
+   All other functions only call downward and use plain let. *)
+let rec schema_of_core_type ~(config : Attrs.config) ?(recursive_types = []) core_type =
   let loc = core_type.ptyp_loc in
   match core_type with
-  | [%type: int] | [%type: int32] | [%type: int64] | [%type: nativeint] -> Schema.type_def ~loc "integer", false
+  | [%type: int] | [%type: int32] | [%type: nativeint] -> Schema.type_def ~loc "integer", false
+  | [%type: int64] ->
+    Schema.type_def ~loc "string" |> Schema.description ~loc ~description:"int64 is represented as a string", false
   | [%type: float] -> Schema.type_def ~loc "number", false
   | [%type: string] | [%type: bytes] -> Schema.type_def ~loc "string", false
   | [%type: bool] -> Schema.type_def ~loc "boolean", false
   | [%type: char] -> Schema.char ~loc, false
   | [%type: unit] -> Schema.null ~loc, false
   | [%type: [%t? t] option] ->
-    let s, is_rec = type_of_core ~config ~recursive_types ?extra_defs_var t in
+    let s, is_rec = schema_of_core_type ~config ~recursive_types t in
     Schema.nullable ~loc s, is_rec
-  | [%type: [%t? t] ref] -> type_of_core ~config ~recursive_types ?extra_defs_var t
+  | [%type: [%t? t] ref] -> schema_of_core_type ~config ~recursive_types t
   | [%type: [%t? t] list] | [%type: [%t? t] array] ->
-    let t, is_rec = type_of_core ~config ~recursive_types ?extra_defs_var t in
+    let t, is_rec = schema_of_core_type ~config ~recursive_types t in
     Schema.array_ ~loc t, is_rec
   | _ ->
   match core_type.ptyp_desc with
@@ -222,39 +42,34 @@ let rec type_of_core ~config ?(recursive_types = []) ?extra_defs_var core_type =
   | Ptyp_constr (id, args) ->
     (match id.txt with
     | Lident name when List.mem name recursive_types ->
-      (* Recursive reference: emit $ref regardless of type arguments.
-         The $defs entry for this type is the canonical definition; inlining
-         its schema here (with concrete args) would produce the wrong schema
-         and lose the self-reference structure. *)
+      (* Recursive reference: emit $ref regardless of type arguments. *)
       Schema.type_ref ~loc name, true
     | _ ->
-      let results = List.map (type_of_core ~config ~recursive_types ?extra_defs_var) args in
+      let results = List.map (schema_of_core_type ~config ~recursive_types) args in
       let args = List.map fst results in
       let is_rec = List.exists snd results in
       let schema = type_constr_conv ~loc id ~f:(fun s -> s ^ "_jsonschema") args in
-      (match is_rec, extra_defs_var with
-      | true, Some edv ->
-        (* A recursive $ref was passed as an arg to a parametric type.
-           The parametric type's schema will have {$id, $defs, $ref}; the $id
-           creates a JSON Schema resource boundary so internal $refs like
-           "#/$defs/outer" would resolve against the inner $id — wrong. *)
+      let edv = evar ~loc "ppx_eds" in
+      (match is_rec with
+      | true ->
+        (* Hoist $defs from the sub-schema into the parent accumulator and strip
+           resource boundary markers ($defs), leaving just the $ref. *)
         ( [%expr
             match [%e schema] with
             | `Assoc ppx_pairs ->
               (match List.assoc_opt "$defs" ppx_pairs with
               | Some (`Assoc ppx_defs) ->
-                [%e edv] := ![%e edv] @ List.filter (fun (n, _) -> not (List.mem_assoc n ![%e edv])) ppx_defs;
-                `Assoc (List.filter (fun (k, _) -> k <> "$id" && k <> "$defs") ppx_pairs)
-              | _ -> `Assoc ppx_pairs)
+                [%e edv] := ![%e edv] @ List.filter (fun (n, _) -> not (List.mem_assoc n ![%e edv])) ppx_defs
+              | _ -> ());
+              `Assoc (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs)
             | ppx_other -> ppx_other],
-          true )
-      | _ ->
+          is_rec )
+      | false ->
         (* Non-recursive arg (or no accumulator): add a location-based $id to mark
            the resource boundary so that any internal $defs refs resolve correctly. *)
         let unique_id =
           estring ~loc
-            (Printf.sprintf "urn:jsonschema:%s:%d:%d" loc.loc_start.pos_fname loc.loc_start.pos_lnum
-               loc.loc_start.pos_cnum)
+            (Printf.sprintf "file://%s:%d:%d" loc.loc_start.pos_fname loc.loc_start.pos_lnum loc.loc_start.pos_cnum)
         in
         ( [%expr
             match [%e schema] with
@@ -263,81 +78,81 @@ let rec type_of_core ~config ?(recursive_types = []) ?extra_defs_var core_type =
             | other -> other],
           is_rec )))
   | Ptyp_tuple types ->
-    let results = List.map (type_of_core ~config ~recursive_types ?extra_defs_var) types in
+    let results = List.map (schema_of_core_type ~config ~recursive_types) types in
     let ts = List.map fst results in
     let is_rec = List.exists snd results in
     Schema.tuple ~loc ts, is_rec
-  | Ptyp_variant (row_fields, _, _) ->
-    let constrs, is_rec =
-      List.fold_left
-        (fun (constrs, is_rec) row_field ->
-          match row_field.prf_desc with
-          | Rtag (name, true, []) ->
-            let name =
-              match Attribute.get jsonschema_polymorphic_variant_name row_field with
-              | Some name -> name.txt
-              | None -> name.txt
-            in
-            `Tag (name, []) :: constrs, is_rec
-          | Rtag (name, false, [ typ ]) ->
-            let name =
-              match Attribute.get jsonschema_polymorphic_variant_name row_field with
-              | Some name -> name.txt
-              | None -> name.txt
-            in
-            let raw_typs =
-              match config.polymorphic_variant_tuple with
-              | true -> [ typ ]
-              | false ->
-              match typ.ptyp_desc with
-              | Ptyp_tuple tps -> tps
-              | _ -> [ typ ]
-            in
-            let results = List.map (type_of_core ~config ~recursive_types ?extra_defs_var) raw_typs in
-            let typs = List.map fst results in
-            let typs_rec = List.exists snd results in
-            `Tag (name, typs) :: constrs, is_rec || typs_rec
-          | Rtag (_, true, [ _ ]) | Rtag (_, _, _ :: _ :: _) ->
-            Location.raise_errorf ~loc "ppx_deriving_jsonschema: polymorphic_variant/Rtag/&"
-          | Rinherit core_type ->
-            let typ, typ_rec = type_of_core ~config ~recursive_types ?extra_defs_var core_type in
-            `Inherit typ :: constrs, is_rec || typ_rec
-          (* impossible?*)
-          | Rtag (_, false, []) -> assert false)
-        ([], false) row_fields
-    in
-    let constrs = List.rev constrs in
-    (* todo: raise an error if encoding is as string and constructor has a payload *)
-    let v =
-      match config.variant_as_string with
-      | true -> variant_as_string ~loc constrs
-      | false -> variant_as_array ~loc constrs
-    in
-    v, is_rec
+  | Ptyp_variant (row_fields, _, _) -> schema_of_poly_variant ~loc ~config ~recursive_types row_fields
   | _ ->
     let msg = Format.asprintf "ppx_deriving_jsonschema: unsupported type %a" Astlib.Pprintast.core_type core_type in
     [%expr [%ocaml.error [%e estring ~loc msg]]], false
 
+and schema_of_poly_variant ~loc ~(config : Attrs.config) ?(recursive_types = []) row_fields =
+  let constrs, is_rec =
+    List.fold_left
+      (fun (constrs, is_rec) row_field ->
+        match row_field.prf_desc with
+        | Rtag (name, true, []) ->
+          let name =
+            match Attribute.get Attrs.jsonschema_polymorphic_variant_name row_field with
+            | Some name -> name.txt
+            | None -> name.txt
+          in
+          `Tag (name, []) :: constrs, is_rec
+        | Rtag (name, false, [ typ ]) ->
+          let name =
+            match Attribute.get Attrs.jsonschema_polymorphic_variant_name row_field with
+            | Some name -> name.txt
+            | None -> name.txt
+          in
+          let raw_typs =
+            match config.Attrs.polymorphic_variant_tuple with
+            | true -> [ typ ]
+            | false ->
+            match typ.ptyp_desc with
+            | Ptyp_tuple tps -> tps
+            | _ -> [ typ ]
+          in
+          let results = List.map (schema_of_core_type ~config ~recursive_types) raw_typs in
+          let typs = List.map fst results in
+          let typs_rec = List.exists snd results in
+          `Tag (name, typs) :: constrs, is_rec || typs_rec
+        | Rtag (_, true, [ _ ]) | Rtag (_, _, _ :: _ :: _) ->
+          Location.raise_errorf ~loc "ppx_deriving_jsonschema: polymorphic_variant/Rtag/&"
+        | Rinherit core_type ->
+          let typ, typ_rec = schema_of_core_type ~config ~recursive_types core_type in
+          `Inherit typ :: constrs, is_rec || typ_rec
+        | Rtag (_, false, []) -> assert false)
+      ([], false) row_fields
+  in
+  let constrs = List.rev constrs in
+  let v =
+    match config.Attrs.variant_as_string with
+    | true -> Schema.variant_as_string ~loc constrs
+    | false -> Schema.variant_as_array ~loc constrs
+  in
+  v, is_rec
+
 (* Returns (schema_expression, is_recursive) *)
-let object_ ~loc ~config ?(recursive_types = []) ?extra_defs_var fields allow_extra_fields =
+let schema_of_record ~loc ~(config : Attrs.config) ?(recursive_types = []) fields allow_extra_fields =
   let fields, required, is_rec =
     List.fold_left
       (fun (fields, required, is_rec) ({ pld_name; pld_type; pld_loc = _loc; _ } as field) ->
         let name =
-          match Attribute.get jsonschema_key field with
+          match Attribute.get Attrs.jsonschema_key field with
           | Some name -> name.txt
           | None -> pld_name.txt
         in
-        let drop_required = Attribute.has_flag jsonschema_option field in
+        let drop_required = Attribute.has_flag Attrs.jsonschema_option field in
         let type_def, field_rec =
-          match Attribute.get jsonschema_ref field with
+          match Attribute.get Attrs.jsonschema_ref field with
           | Some def -> Schema.type_ref ~loc def.txt, false
           | None ->
           match pld_type with
           | [%type: [%t? inner] option] ->
-            let s, r = type_of_core ~config ~recursive_types ?extra_defs_var inner in
+            let s, r = schema_of_core_type ~config ~recursive_types inner in
             Schema.nullable ~loc s, r
-          | _ -> type_of_core ~config ~recursive_types ?extra_defs_var pld_type
+          | _ -> schema_of_core_type ~config ~recursive_types pld_type
         in
         ( [%expr [%e estring ~loc name], [%e type_def]] :: fields,
           (if drop_required then required else { txt = name; loc } :: required),
@@ -355,59 +170,56 @@ let object_ ~loc ~config ?(recursive_types = []) ?extra_defs_var fields allow_ex
         ]],
     is_rec )
 
-(* Wraps [body] in nested lambdas, one per type parameter.
-   Parametric types like [('a, 'b) t] derive as [fun a b -> <schema>],
-   so callers can pass schemas for each type variable.
-   Use [~prefix:"_"] to mark params unused in the body. *)
-let wrap_type_params ~loc ?(prefix = "") params body =
-  List.fold_right
-    (fun param body -> [%expr fun [%p ppat_var ~loc { txt = prefix ^ param; loc }] -> [%e body]])
-    params body
+(* Returns (schema_expression, is_recursive, params_prefix) *)
+let schema_of_variants ~loc ~(config : Attrs.config) ?(recursive_types = []) variants =
+  let variants, is_rec =
+    List.fold_left
+      (fun (variants, is_rec) ({ pcd_args; pcd_name = { txt = name; _ }; _ } as var) ->
+        let name =
+          match Attribute.get Attrs.jsonschema_variant_name var with
+          | Some name -> name.txt
+          | None -> name
+        in
+        match pcd_args with
+        | Pcstr_record label_declarations ->
+          let allow_extra_fields = Attribute.get Attrs.jsonschema_cd_allow_extra_fields var |> Option.is_some in
+          let obj_schema, obj_rec =
+            schema_of_record ~loc ~config ~recursive_types label_declarations allow_extra_fields
+          in
+          `Tag (name, [ obj_schema ]) :: variants, is_rec || obj_rec
+        | Pcstr_tuple typs ->
+          let results = List.map (schema_of_core_type ~config ~recursive_types) typs in
+          let types = List.map fst results in
+          let typs_rec = List.exists snd results in
+          `Tag (name, types) :: variants, is_rec || typs_rec)
+      ([], false) variants
+  in
+  let variants = List.rev variants in
+  let schema, params_prefix =
+    match config.Attrs.variant_as_string with
+    | true -> Schema.variant_as_string ~loc variants, "_"
+    | false -> Schema.variant_as_array ~loc variants, ""
+  in
+  schema, is_rec, params_prefix
 
-(* Generate schema for a single type declaration, given the recursive type group *)
-let derive_single_type ~loc ~config ~recursive_types ?extra_defs_var type_decl =
+(* Returns (type_name, schema_expression, is_recursive, params, params_prefix) *)
+let schema_of_type_decl ~loc ~(config : Attrs.config) ~recursive_types type_decl =
   let type_name = type_decl.ptype_name.txt in
-  let allow_extra_fields = Attribute.get jsonschema_td_allow_extra_fields type_decl |> Option.is_some in
+  let allow_extra_fields = Attribute.get Attrs.jsonschema_td_allow_extra_fields type_decl |> Option.is_some in
   let params = List.map (fun tp -> (get_type_param_name tp).txt) type_decl.ptype_params in
   match type_decl.ptype_kind with
   | Ptype_variant variants ->
-    let variants, is_rec =
-      List.fold_left
-        (fun (variants, is_rec) ({ pcd_args; pcd_name = { txt = name; _ }; _ } as var) ->
-          let name =
-            match Attribute.get jsonschema_variant_name var with
-            | Some name -> name.txt
-            | None -> name
-          in
-          match pcd_args with
-          | Pcstr_record label_declarations ->
-            let allow_extra_fields = Attribute.get jsonschema_cd_allow_extra_fields var |> Option.is_some in
-            let obj_schema, obj_rec =
-              object_ ~loc ~config ~recursive_types ?extra_defs_var label_declarations allow_extra_fields
-            in
-            `Tag (name, [ obj_schema ]) :: variants, is_rec || obj_rec
-          | Pcstr_tuple typs ->
-            let results = List.map (type_of_core ~config ~recursive_types ?extra_defs_var) typs in
-            let types = List.map fst results in
-            let typs_rec = List.exists snd results in
-            `Tag (name, types) :: variants, is_rec || typs_rec)
-        ([], false) variants
-    in
-    let variants = List.rev variants in
-    (* todo: raise an error if encoding is as string and constructor has a payload *)
-    let schema, params_prefix =
-      match config.variant_as_string with
-      | true -> variant_as_string ~loc variants, "_"
-      | false -> variant_as_array ~loc variants, ""
-    in
+    let schema, is_rec, params_prefix = schema_of_variants ~loc ~config ~recursive_types variants in
     type_name, schema, is_rec, params, params_prefix
   | Ptype_record label_declarations ->
-    let schema, is_rec = object_ ~loc ~config ~recursive_types ?extra_defs_var label_declarations allow_extra_fields in
+    let schema, is_rec =
+      schema_of_record ~loc ~config ~recursive_types label_declarations allow_extra_fields
+    in
     type_name, schema, is_rec, params, ""
   | Ptype_abstract ->
     (match type_decl.ptype_manifest with
     | Some core_type ->
-      let schema, is_rec = type_of_core ~config ~recursive_types ?extra_defs_var core_type in
+      let schema, is_rec = schema_of_core_type ~config ~recursive_types core_type in
       type_name, schema, is_rec, params, ""
     | None ->
       let msg = "ppx_deriving_jsonschema: abstract type without manifest" in
@@ -416,87 +228,96 @@ let derive_single_type ~loc ~config ~recursive_types ?extra_defs_var type_decl =
     let msg = "ppx_deriving_jsonschema: open types not supported" in
     type_name, [%expr [%ocaml.error [%e estring ~loc msg]]], false, params, ""
 
-let derive_jsonschema ~ctxt ast flag_variant_as_string flag_polymorphic_variant_tuple =
+let apply_defs ~loc =
+  function
+  | `Rec (primary, defs) ->
+    let edv = evar ~loc "ppx_eds" in
+    let vname name = "ppx_body_" ^ name in
+    let pairs_expr =
+      elist ~loc (List.map (fun (name, _) -> [%expr [%e estring ~loc name], [%e evar ~loc (vname name)]]) defs)
+    in
+    let base_expr =
+      [%expr
+        `Assoc
+          [
+            "$defs", `Assoc ([%e pairs_expr] @ ![%e edv]); "$ref", `String [%e estring ~loc ("#/$defs/" ^ primary)];
+          ]]
+    in
+    List.fold_right
+      (fun (name, s) acc ->
+        [%expr
+          let [%p ppat_var ~loc { txt = vname name; loc }] = [%e s] in
+          [%e acc]])
+      defs base_expr
+  | `NonRec schema ->
+    let edv = evar ~loc "ppx_eds" in
+    [%expr
+      let ppx_result = [%e schema] in
+      match ![%e edv] with
+      | [] -> ppx_result
+      | ppx_defs ->
+      match ppx_result with
+      | `Assoc ppx_pairs -> `Assoc (("$defs", `Assoc ppx_defs) :: List.filter (fun (k, _) -> k <> "$defs") ppx_pairs)
+      | other -> other]
+
+let str_type_decl ~ctxt ast flag_variant_as_string flag_polymorphic_variant_tuple =
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
-  let config =
-    { variant_as_string = flag_variant_as_string; polymorphic_variant_tuple = flag_polymorphic_variant_tuple }
+  let config : Attrs.config =
+    {
+      Attrs.variant_as_string = flag_variant_as_string;
+      Attrs.polymorphic_variant_tuple = flag_polymorphic_variant_tuple;
+    }
   in
   match ast with
   (* Single type declaration *)
   | _, [ type_decl ] ->
     let type_name = type_decl.ptype_name.txt in
-    let recursive_types = [ type_name ] in
-    (* First pass: determine whether the type is recursive *)
-    let _, raw_schema, is_rec, params, params_prefix = derive_single_type ~loc ~config ~recursive_types type_decl in
-    (* Apply with_defs before wrap_type_params so params wrap the full schema.
-       For recursive types, do a second pass with extra_defs_var so hoisting
-       code referencing ppx_eds is generated in the body expression. *)
+    let _, raw_schema, is_rec, params, params_prefix =
+      schema_of_type_decl ~loc ~config ~recursive_types:[ type_name ] type_decl
+    in
     let schema =
-      if is_rec then (
-        let edv = evar ~loc "ppx_eds" in
-        let _, raw_schema', _, _, _ = derive_single_type ~loc ~config ~recursive_types ~extra_defs_var:edv type_decl in
+      if is_rec then
         [%expr
           let ppx_eds = ref [] in
-          [%e Schema.with_defs ~loc type_name ~extra_defs_var:edv raw_schema']])
-      else raw_schema
+          [%e apply_defs ~loc (`Rec (type_name, [ type_name, raw_schema ]))]]
+      else
+        [%expr
+          let ppx_eds = ref [] in
+          [%e apply_defs ~loc (`NonRec raw_schema)]]
     in
     let schema = wrap_type_params ~loc ~prefix:params_prefix params schema in
     [ create_value ~loc type_name schema ]
   (* Multiple type declarations (mutually recursive types) *)
   | _, type_decls when List.length type_decls > 1 ->
-    (* Collect all type names in the recursive group *)
     let recursive_types = List.map (fun td -> td.ptype_name.txt) type_decls in
-    let primary_type = List.hd recursive_types in
-    (* Collect raw schemas without wrapping type params yet — $defs must contain
-       the raw bodies so that parametric types remain valid OCaml expressions. *)
-    let raw_results = List.map (fun td -> derive_single_type ~loc ~config ~recursive_types td) type_decls in
+    let raw_results = List.map (schema_of_type_decl ~loc ~config ~recursive_types) type_decls in
     let any_recursive = List.exists (fun (_, _, is_rec, _, _) -> is_rec) raw_results in
     if any_recursive then (
-      (* Second pass: regenerate with extra_defs_var so hoisting code is emitted *)
-      let edv = evar ~loc "ppx_eds" in
-      let raw_results2 =
-        List.map (fun td -> derive_single_type ~loc ~config ~recursive_types ~extra_defs_var:edv td) type_decls
-      in
-      let defs2 = List.map (fun (name, raw, _, _, _) -> name, raw) raw_results2 in
-      (* Build $defs from raw schemas, then wrap the combined schema with type params.
-         Each binding gets its own ppx_eds ref so hoisted defs don't leak across. *)
-      let primary_value =
-        let _, _, _, params, prefix = List.find (fun (name, _, _, _, _) -> name = primary_type) raw_results2 in
-        let schema_inner = Schema.with_multi_defs ~loc ~primary_type ~extra_defs_var:edv defs2 in
-        let schema =
-          wrap_type_params ~loc ~prefix params
-            [%expr
-              let ppx_eds = ref [] in
-              [%e schema_inner]]
-        in
-        create_value ~loc primary_type schema
-      in
-      let other_values =
-        List.filter_map
-          (fun (name, _, _, params, prefix) ->
-            if name = primary_type then None
-            else (
-              let schema_inner = Schema.with_multi_defs ~loc ~primary_type:name ~extra_defs_var:edv defs2 in
-              let schema =
-                wrap_type_params ~loc ~prefix params
-                  [%expr
-                    let ppx_eds = ref [] in
-                    [%e schema_inner]]
-              in
-              Some (create_value ~loc name schema)))
-          raw_results2
-      in
-      primary_value :: other_values)
-    else
-      (* No recursion detected - wrap params and generate independent schemas *)
+      let defs = List.map (fun (name, raw, _, _, _) -> name, raw) raw_results in
       List.map
-        (fun (name, raw, _, params, prefix) -> create_value ~loc name (wrap_type_params ~loc ~prefix params raw))
+        (fun (name, _, _, params, prefix) ->
+          let schema =
+            wrap_type_params ~loc ~prefix params
+              [%expr
+                let ppx_eds = ref [] in
+                [%e apply_defs ~loc (`Rec (name, defs))]]
+          in
+          create_value ~loc name schema)
+        raw_results)
+    else
+      List.map
+        (fun (name, raw, _, params, prefix) ->
+          let schema =
+            wrap_type_params ~loc ~prefix params
+              [%expr
+                let ppx_eds = ref [] in
+                [%e apply_defs ~loc (`NonRec raw)]]
+          in
+          create_value ~loc name schema)
         raw_results
   | _, _ -> [%str [%ocaml.error "ppx_deriving_jsonschema: unsupported type"]]
 
-let generator () = Deriving.Generator.V2.make ~attributes (args ()) derive_jsonschema
-
-let derive_jsonschema_sig ~ctxt ast _flag_variant_as_string _flag_polymorphic_variant_tuple =
+let sig_type_decl ~ctxt ast _flag_variant_as_string _flag_polymorphic_variant_tuple =
   let jsonschema_t ~loc = ptyp_constr ~loc { txt = Ldot (Lident "Ppx_deriving_jsonschema_runtime", "t"); loc } [] in
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
   match ast with
@@ -515,6 +336,7 @@ let derive_jsonschema_sig ~ctxt ast _flag_variant_as_string _flag_polymorphic_va
     let ext = Location.error_extensionf ~loc "ppx_deriving_jsonschema: unsupported type" in
     [ psig_extension ~loc ext [] ]
 
-let sig_generator () = Deriving.Generator.V2.make (args ()) derive_jsonschema_sig
-
-let _ : Deriving.t = Deriving.add deriver_name ~str_type_decl:(generator ()) ~sig_type_decl:(sig_generator ())
+let _ : Deriving.t =
+  Deriving.add deriver_name
+    ~str_type_decl:(Deriving.Generator.V2.make ~attributes:Attrs.attributes (Attrs.args ()) str_type_decl)
+    ~sig_type_decl:(Deriving.Generator.V2.make ~attributes:Attrs.attributes (Attrs.args ()) sig_type_decl)

--- a/src/schema.ml
+++ b/src/schema.ml
@@ -1,0 +1,82 @@
+open Ppxlib
+open Ast_builder.Default
+
+let const ~loc value = [%expr `Assoc [ "const", `String [%e estring ~loc value] ]]
+
+let type_ref ~loc type_name =
+  let name = estring ~loc ("#/$defs/" ^ type_name) in
+  [%expr `Assoc [ "$ref", `String [%e name] ]]
+
+let type_def ~loc type_name = [%expr `Assoc [ "type", `String [%e estring ~loc type_name] ]]
+
+let null ~loc = [%expr `Assoc [ "type", `String "null" ]]
+
+let char ~loc = [%expr `Assoc [ "type", `String "string"; "minLength", `Int 1; "maxLength", `Int 1 ]]
+
+let oneOf ~loc values = [%expr `Assoc [ "oneOf", `List [%e elist ~loc values] ]]
+
+let anyOf ~loc values = [%expr `Assoc [ "anyOf", `List [%e elist ~loc values] ]]
+
+let array_ ~loc ?min_items ?max_items element_type =
+  let fields =
+    List.filter_map
+      (fun x -> x)
+      [
+        Some [%expr "type", `String "array"];
+        Some [%expr "items", [%e element_type]];
+        (match min_items with
+        | Some min -> Some [%expr "minItems", `Int [%e eint ~loc min]]
+        | None -> None);
+        (match max_items with
+        | Some max -> Some [%expr "maxItems", `Int [%e eint ~loc max]]
+        | None -> None);
+      ]
+  in
+  [%expr `Assoc [%e elist ~loc fields]]
+
+let tuple ~loc elements =
+  [%expr
+    `Assoc
+      [
+        "type", `String "array";
+        "prefixItems", `List [%e elist ~loc elements];
+        "unevaluatedItems", `Bool false;
+        "minItems", `Int [%e eint ~loc (List.length elements)];
+        "maxItems", `Int [%e eint ~loc (List.length elements)];
+      ]]
+
+let enum ~loc typ values =
+  match typ with
+  | Some typ -> [%expr `Assoc [ "type", `String [%e estring ~loc typ]; "enum", `List [%e elist ~loc values] ]]
+  | None -> [%expr `Assoc [ "enum", `List [%e elist ~loc values] ]]
+
+let enum_string ~loc values =
+  let values = List.map (fun name -> [%expr `String [%e estring ~loc name]]) values in
+  enum ~loc (Some "string") values
+
+let nullable ~loc schema =
+  match schema with
+    | [%expr`Assoc [ ("type", `String [%e? t]) ]] -> [%expr `Assoc [ "type", `List [ `String [%e t]; `String "null" ] ]]
+    | s -> [%expr `Assoc [ "anyOf", `List [ [%e s]; `Assoc [ "type", `String "null" ] ] ]]
+
+let description ~loc ~description schema =
+  match schema with
+  | [%expr `Assoc [%e? fields]] ->
+    [%expr `Assoc ([%e fields] @ [ "description", `String [%e estring ~loc description] ])]
+  | s -> s
+
+let variant_as_string ~loc constrs =
+  anyOf ~loc
+    (List.map
+       (function
+         | `Tag (name, _typs) -> const ~loc name
+         | `Inherit typ -> typ)
+       constrs)
+
+let variant_as_array ~loc constrs =
+  anyOf ~loc
+    (List.map
+       (function
+         | `Tag (name, typs) -> tuple ~loc (const ~loc name :: typs)
+         | `Inherit typ -> typ)
+       constrs)

--- a/src/schema.ml
+++ b/src/schema.ml
@@ -56,8 +56,8 @@ let enum_string ~loc values =
 
 let nullable ~loc schema =
   match schema with
-    | [%expr`Assoc [ ("type", `String [%e? t]) ]] -> [%expr `Assoc [ "type", `List [ `String [%e t]; `String "null" ] ]]
-    | s -> [%expr `Assoc [ "anyOf", `List [ [%e s]; `Assoc [ "type", `String "null" ] ] ]]
+  | [%expr `Assoc [ "type", `String [%e? t] ]] -> [%expr `Assoc [ "type", `List [ `String [%e t]; `String "null" ] ]]
+  | s -> [%expr `Assoc [ "anyOf", `List [ [%e s]; `Assoc [ "type", `String "null" ] ] ]]
 
 let description ~loc ~description schema =
   match schema with

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -15,23 +15,33 @@ module Mod1 =
     include
       struct
         let m_1_jsonschema =
-          `Assoc
-            [("anyOf",
-               (`List
-                  [`Assoc
-                     [("type", (`String "array"));
-                     ("prefixItems",
-                       (`List [`Assoc [("const", (`String "A"))]]));
-                     ("unevaluatedItems", (`Bool false));
-                     ("minItems", (`Int 1));
-                     ("maxItems", (`Int 1))];
-                  `Assoc
-                    [("type", (`String "array"));
-                    ("prefixItems",
-                      (`List [`Assoc [("const", (`String "B"))]]));
-                    ("unevaluatedItems", (`Bool false));
-                    ("minItems", (`Int 1));
-                    ("maxItems", (`Int 1))]]))][@@warning "-32-39"]
+          let ppx_eds = ref [] in
+          let ppx_result =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "A"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List [`Assoc [("const", (`String "B"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 1));
+                      ("maxItems", (`Int 1))]]))] in
+          match !ppx_eds with
+          | [] -> ppx_result
+          | ppx_defs ->
+              (match ppx_result with
+               | `Assoc ppx_pairs ->
+                   `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                     (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+               | other -> other)[@@warning "-32-39"]
       end[@@ocaml.doc "@inline"][@@merlin.hide ]
     [%%expect_test
       let "m_1" =
@@ -66,23 +76,33 @@ module Mod1 =
         include
           struct
             let m_2_jsonschema =
-              `Assoc
-                [("anyOf",
-                   (`List
-                      [`Assoc
-                         [("type", (`String "array"));
-                         ("prefixItems",
-                           (`List [`Assoc [("const", (`String "C"))]]));
-                         ("unevaluatedItems", (`Bool false));
-                         ("minItems", (`Int 1));
-                         ("maxItems", (`Int 1))];
-                      `Assoc
-                        [("type", (`String "array"));
-                        ("prefixItems",
-                          (`List [`Assoc [("const", (`String "D"))]]));
-                        ("unevaluatedItems", (`Bool false));
-                        ("minItems", (`Int 1));
-                        ("maxItems", (`Int 1))]]))][@@warning "-32-39"]
+              let ppx_eds = ref [] in
+              let ppx_result =
+                `Assoc
+                  [("anyOf",
+                     (`List
+                        [`Assoc
+                           [("type", (`String "array"));
+                           ("prefixItems",
+                             (`List [`Assoc [("const", (`String "C"))]]));
+                           ("unevaluatedItems", (`Bool false));
+                           ("minItems", (`Int 1));
+                           ("maxItems", (`Int 1))];
+                        `Assoc
+                          [("type", (`String "array"));
+                          ("prefixItems",
+                            (`List [`Assoc [("const", (`String "D"))]]));
+                          ("unevaluatedItems", (`Bool false));
+                          ("minItems", (`Int 1));
+                          ("maxItems", (`Int 1))]]))] in
+              match !ppx_eds with
+              | [] -> ppx_result
+              | ppx_defs ->
+                  (match ppx_result with
+                   | `Assoc ppx_pairs ->
+                       `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                         (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+                   | other -> other)[@@warning "-32-39"]
           end[@@ocaml.doc "@inline"][@@merlin.hide ]
         [%%expect_test
           let "m_2" =
@@ -117,26 +137,34 @@ type with_modules = {
 include
   struct
     let with_modules_jsonschema =
-      `Assoc
-        [("type", (`String "object"));
-        ("properties",
-          (`Assoc
-             [("m2",
-                ((match Mod1.Mod2.m_2_jsonschema with
-                  | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                      `Assoc
-                        (("$id", (`String "urn:jsonschema:test.ml:78:1882"))
-                        :: (List.filter (fun (k, _) -> k <> "$id") pairs))
-                  | other -> other)));
-             ("m",
-               ((match Mod1.m_1_jsonschema with
-                 | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                     `Assoc
-                       (("$id", (`String "urn:jsonschema:test.ml:77:1865"))
-                       :: (List.filter (fun (k, _) -> k <> "$id") pairs))
-                 | other -> other)))]));
-        ("required", (`List [`String "m2"; `String "m"]));
-        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("m2",
+                  ((match Mod1.Mod2.m_2_jsonschema with
+                    | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                        `Assoc (("$id", (`String "file://test.ml:78:1882"))
+                          :: (List.filter (fun (k, _) -> k <> "$id") pairs))
+                    | other -> other)));
+               ("m",
+                 ((match Mod1.m_1_jsonschema with
+                   | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                       `Assoc (("$id", (`String "file://test.ml:77:1865")) ::
+                         (List.filter (fun (k, _) -> k <> "$id") pairs))
+                   | other -> other)))]));
+          ("required", (`List [`String "m2"; `String "m"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "with_modules" =
@@ -195,30 +223,40 @@ type kind =
 include
   struct
     let kind_jsonschema =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc
-                 [("type", (`String "array"));
-                 ("prefixItems",
-                   (`List [`Assoc [("const", (`String "Success"))]]));
-                 ("unevaluatedItems", (`Bool false));
-                 ("minItems", (`Int 1));
-                 ("maxItems", (`Int 1))];
-              `Assoc
-                [("type", (`String "array"));
-                ("prefixItems",
-                  (`List [`Assoc [("const", (`String "Error"))]]));
-                ("unevaluatedItems", (`Bool false));
-                ("minItems", (`Int 1));
-                ("maxItems", (`Int 1))];
-              `Assoc
-                [("type", (`String "array"));
-                ("prefixItems",
-                  (`List [`Assoc [("const", (`String "skipped"))]]));
-                ("unevaluatedItems", (`Bool false));
-                ("minItems", (`Int 1));
-                ("maxItems", (`Int 1))]]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Success"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "Error"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "skipped"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "kind" =
@@ -259,12 +297,22 @@ type kind_as_string =
 include
   struct
     let kind_as_string_jsonschema =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc [("const", (`String "Success"))];
-              `Assoc [("const", (`String "Error"))];
-              `Assoc [("const", (`String "skipped"))]]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "Success"))];
+                `Assoc [("const", (`String "Error"))];
+                `Assoc [("const", (`String "skipped"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "kind_as_string" =
@@ -282,30 +330,40 @@ type poly_kind = [ `Aaa  | `Bbb  | `Ccc [@name "ccc"]][@@deriving jsonschema]
 include
   struct
     let poly_kind_jsonschema =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc
-                 [("type", (`String "array"));
-                 ("prefixItems",
-                   (`List [`Assoc [("const", (`String "Aaa"))]]));
-                 ("unevaluatedItems", (`Bool false));
-                 ("minItems", (`Int 1));
-                 ("maxItems", (`Int 1))];
-              `Assoc
-                [("type", (`String "array"));
-                ("prefixItems",
-                  (`List [`Assoc [("const", (`String "Bbb"))]]));
-                ("unevaluatedItems", (`Bool false));
-                ("minItems", (`Int 1));
-                ("maxItems", (`Int 1))];
-              `Assoc
-                [("type", (`String "array"));
-                ("prefixItems",
-                  (`List [`Assoc [("const", (`String "ccc"))]]));
-                ("unevaluatedItems", (`Bool false));
-                ("minItems", (`Int 1));
-                ("maxItems", (`Int 1))]]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Aaa"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "Bbb"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "ccc"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "poly_kind" =
@@ -345,12 +403,22 @@ type poly_kind_as_string = [ `Aaa  | `Bbb  | `Ccc [@name "ccc"]][@@deriving
 include
   struct
     let poly_kind_as_string_jsonschema =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc [("const", (`String "Aaa"))];
-              `Assoc [("const", (`String "Bbb"))];
-              `Assoc [("const", (`String "ccc"))]]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "Aaa"))];
+                `Assoc [("const", (`String "Bbb"))];
+                `Assoc [("const", (`String "ccc"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "poly_kind_as_string" =
@@ -368,35 +436,45 @@ type poly_kind_with_payload =
 include
   struct
     let poly_kind_with_payload_jsonschema =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc
-                 [("type", (`String "array"));
-                 ("prefixItems",
-                   (`List
-                      [`Assoc [("const", (`String "Aaa"))];
-                      `Assoc [("type", (`String "integer"))]]));
-                 ("unevaluatedItems", (`Bool false));
-                 ("minItems", (`Int 2));
-                 ("maxItems", (`Int 2))];
-              `Assoc
-                [("type", (`String "array"));
-                ("prefixItems",
-                  (`List [`Assoc [("const", (`String "Bbb"))]]));
-                ("unevaluatedItems", (`Bool false));
-                ("minItems", (`Int 1));
-                ("maxItems", (`Int 1))];
-              `Assoc
-                [("type", (`String "array"));
-                ("prefixItems",
-                  (`List
-                     [`Assoc [("const", (`String "ccc"))];
-                     `Assoc [("type", (`String "string"))];
-                     `Assoc [("type", (`String "boolean"))]]));
-                ("unevaluatedItems", (`Bool false));
-                ("minItems", (`Int 3));
-                ("maxItems", (`Int 3))]]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "Aaa"))];
+                        `Assoc [("type", (`String "integer"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "Bbb"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "ccc"))];
+                       `Assoc [("type", (`String "string"))];
+                       `Assoc [("type", (`String "boolean"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 3));
+                  ("maxItems", (`Int 3))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "poly_kind_with_payload" =
@@ -439,12 +517,22 @@ type poly_kind_with_payload_as_string =
 include
   struct
     let poly_kind_with_payload_as_string_jsonschema =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc [("const", (`String "Aaa"))];
-              `Assoc [("const", (`String "Bbb"))];
-              `Assoc [("const", (`String "ccc"))]]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "Aaa"))];
+                `Assoc [("const", (`String "Bbb"))];
+                `Assoc [("const", (`String "ccc"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "poly_kind_with_payload_as_string" =
@@ -461,31 +549,40 @@ type poly_inherit = [ `New_one  | `Second_one of int  | poly_kind][@@deriving
 include
   struct
     let poly_inherit_jsonschema =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc
-                 [("type", (`String "array"));
-                 ("prefixItems",
-                   (`List [`Assoc [("const", (`String "New_one"))]]));
-                 ("unevaluatedItems", (`Bool false));
-                 ("minItems", (`Int 1));
-                 ("maxItems", (`Int 1))];
-              `Assoc
-                [("type", (`String "array"));
-                ("prefixItems",
-                  (`List
-                     [`Assoc [("const", (`String "Second_one"))];
-                     `Assoc [("type", (`String "integer"))]]));
-                ("unevaluatedItems", (`Bool false));
-                ("minItems", (`Int 2));
-                ("maxItems", (`Int 2))];
-              (match poly_kind_jsonschema with
-               | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                   `Assoc
-                     (("$id", (`String "urn:jsonschema:test.ml:305:7119")) ::
-                     (List.filter (fun (k, _) -> k <> "$id") pairs))
-               | other -> other)]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "New_one"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Second_one"))];
+                       `Assoc [("type", (`String "integer"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))];
+                (match poly_kind_jsonschema with
+                 | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                     `Assoc (("$id", (`String "file://test.ml:305:7119")) ::
+                       (List.filter (fun (k, _) -> k <> "$id") pairs))
+                 | other -> other)]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "poly_inherit" =
@@ -544,17 +641,26 @@ type poly_inherit_as_string =
 include
   struct
     let poly_inherit_as_string_jsonschema =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc [("const", (`String "New_one"))];
-              `Assoc [("const", (`String "Second_one"))];
-              (match poly_kind_as_string_jsonschema with
-               | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                   `Assoc
-                     (("$id", (`String "urn:jsonschema:test.ml:362:8515")) ::
-                     (List.filter (fun (k, _) -> k <> "$id") pairs))
-               | other -> other)]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "New_one"))];
+                `Assoc [("const", (`String "Second_one"))];
+                (match poly_kind_as_string_jsonschema with
+                 | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                     `Assoc (("$id", (`String "file://test.ml:362:8515")) ::
+                       (List.filter (fun (k, _) -> k <> "$id") pairs))
+                 | other -> other)]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "poly_inherit_as_string" =
@@ -589,84 +695,88 @@ type event =
 include
   struct
     let event_jsonschema =
-      `Assoc
-        [("type", (`String "object"));
-        ("properties",
-          (`Assoc
-             [("native_int", (`Assoc [("type", (`String "integer"))]));
-             ("unit", (`Assoc [("type", (`String "null"))]));
-             ("string_ref", (`Assoc [("type", (`String "string"))]));
-             ("bunch_of_bytes", (`Assoc [("type", (`String "string"))]));
-             ("c",
-               (`Assoc
-                  [("type", (`String "string"));
-                  ("minLength", (`Int 1));
-                  ("maxLength", (`Int 1))]));
-             ("t",
-               (`Assoc
-                  [("anyOf",
-                     (`List
-                        [`Assoc
-                           [("type", (`String "array"));
-                           ("prefixItems",
-                             (`List [`Assoc [("const", (`String "Foo"))]]));
-                           ("unevaluatedItems", (`Bool false));
-                           ("minItems", (`Int 1));
-                           ("maxItems", (`Int 1))];
-                        `Assoc
-                          [("type", (`String "array"));
-                          ("prefixItems",
-                            (`List [`Assoc [("const", (`String "Bar"))]]));
-                          ("unevaluatedItems", (`Bool false));
-                          ("minItems", (`Int 1));
-                          ("maxItems", (`Int 1))];
-                        `Assoc
-                          [("type", (`String "array"));
-                          ("prefixItems",
-                            (`List [`Assoc [("const", (`String "Baz"))]]));
-                          ("unevaluatedItems", (`Bool false));
-                          ("minItems", (`Int 1));
-                          ("maxItems", (`Int 1))]]))]));
-             ("l",
-               (`Assoc
-                  [("type", (`String "array"));
-                  ("items", (`Assoc [("type", (`String "string"))]))]));
-             ("a",
-               (`Assoc
-                  [("type", (`String "array"));
-                  ("items", (`Assoc [("type", (`String "number"))]))]));
-             ("opt_int",
-               ((match `Assoc [("type", (`String "integer"))] with
-                 | `Assoc (("type", `String t)::[]) ->
-                     `Assoc [("type", (`List [`String t; `String "null"]))]
-                 | s ->
-                     `Assoc
-                       [("anyOf",
-                          (`List [s; `Assoc [("type", (`String "null"))]]))])));
-             ("comment", (`Assoc [("type", (`String "string"))]));
-             ("kind_f",
-               ((match kind_jsonschema with
-                 | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                     `Assoc
-                       (("$id", (`String "urn:jsonschema:test.ml:384:9016"))
-                       :: (List.filter (fun (k, _) -> k <> "$id") pairs))
-                 | other -> other)));
-             ("date", (`Assoc [("type", (`String "number"))]))]));
-        ("required",
-          (`List
-             [`String "native_int";
-             `String "unit";
-             `String "string_ref";
-             `String "bunch_of_bytes";
-             `String "c";
-             `String "t";
-             `String "l";
-             `String "a";
-             `String "opt_int";
-             `String "comment";
-             `String "kind_f";
-             `String "date"]));
-        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("native_int", (`Assoc [("type", (`String "integer"))]));
+               ("unit", (`Assoc [("type", (`String "null"))]));
+               ("string_ref", (`Assoc [("type", (`String "string"))]));
+               ("bunch_of_bytes", (`Assoc [("type", (`String "string"))]));
+               ("c",
+                 (`Assoc
+                    [("type", (`String "string"));
+                    ("minLength", (`Int 1));
+                    ("maxLength", (`Int 1))]));
+               ("t",
+                 (`Assoc
+                    [("anyOf",
+                       (`List
+                          [`Assoc
+                             [("type", (`String "array"));
+                             ("prefixItems",
+                               (`List [`Assoc [("const", (`String "Foo"))]]));
+                             ("unevaluatedItems", (`Bool false));
+                             ("minItems", (`Int 1));
+                             ("maxItems", (`Int 1))];
+                          `Assoc
+                            [("type", (`String "array"));
+                            ("prefixItems",
+                              (`List [`Assoc [("const", (`String "Bar"))]]));
+                            ("unevaluatedItems", (`Bool false));
+                            ("minItems", (`Int 1));
+                            ("maxItems", (`Int 1))];
+                          `Assoc
+                            [("type", (`String "array"));
+                            ("prefixItems",
+                              (`List [`Assoc [("const", (`String "Baz"))]]));
+                            ("unevaluatedItems", (`Bool false));
+                            ("minItems", (`Int 1));
+                            ("maxItems", (`Int 1))]]))]));
+               ("l",
+                 (`Assoc
+                    [("type", (`String "array"));
+                    ("items", (`Assoc [("type", (`String "string"))]))]));
+               ("a",
+                 (`Assoc
+                    [("type", (`String "array"));
+                    ("items", (`Assoc [("type", (`String "number"))]))]));
+               ("opt_int",
+                 (`Assoc
+                    [("type", (`List [`String "integer"; `String "null"]))]));
+               ("comment", (`Assoc [("type", (`String "string"))]));
+               ("kind_f",
+                 ((match kind_jsonschema with
+                   | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                       `Assoc (("$id", (`String "file://test.ml:384:9016"))
+                         :: (List.filter (fun (k, _) -> k <> "$id") pairs))
+                   | other -> other)));
+               ("date", (`Assoc [("type", (`String "number"))]))]));
+          ("required",
+            (`List
+               [`String "native_int";
+               `String "unit";
+               `String "string_ref";
+               `String "bunch_of_bytes";
+               `String "c";
+               `String "t";
+               `String "l";
+               `String "a";
+               `String "opt_int";
+               `String "comment";
+               `String "kind_f";
+               `String "date"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "event" =
@@ -752,7 +862,7 @@ include
   struct
     let recursive_record_jsonschema =
       let ppx_eds = ref [] in
-      let ppx_body =
+      let ppx_body_recursive_record =
         `Assoc
           [("type", (`String "object"));
           ("properties",
@@ -767,8 +877,9 @@ include
           ("required", (`List [`String "b"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
       `Assoc
-        [("$id", (`String "urn:jsonschema:recursive_record"));
-        ("$defs", (`Assoc (("recursive_record", ppx_body) :: (!ppx_eds))));
+        [("$defs",
+           (`Assoc
+              ([("recursive_record", ppx_body_recursive_record)] @ (!ppx_eds))));
         ("$ref", (`String "#/$defs/recursive_record"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -778,7 +889,6 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:recursive_record",
       "$defs": {
         "recursive_record": {
           "type": "object",
@@ -803,7 +913,7 @@ include
   struct
     let recursive_variant_jsonschema =
       let ppx_eds = ref [] in
-      let ppx_body =
+      let ppx_body_recursive_variant =
         `Assoc
           [("anyOf",
              (`List
@@ -825,8 +935,10 @@ include
                   ("minItems", (`Int 1));
                   ("maxItems", (`Int 1))]]))] in
       `Assoc
-        [("$id", (`String "urn:jsonschema:recursive_variant"));
-        ("$defs", (`Assoc (("recursive_variant", ppx_body) :: (!ppx_eds))));
+        [("$defs",
+           (`Assoc
+              ([("recursive_variant", ppx_body_recursive_variant)] @
+                 (!ppx_eds))));
         ("$ref", (`String "#/$defs/recursive_variant"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -836,7 +948,6 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:recursive_variant",
       "$defs": {
         "recursive_variant": {
           "anyOf": [
@@ -872,7 +983,7 @@ include
   struct
     let tree_jsonschema =
       let ppx_eds = ref [] in
-      let ppx_body =
+      let ppx_body_tree =
         `Assoc
           [("anyOf",
              (`List
@@ -908,8 +1019,7 @@ include
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
       `Assoc
-        [("$id", (`String "urn:jsonschema:tree"));
-        ("$defs", (`Assoc (("tree", ppx_body) :: (!ppx_eds))));
+        [("$defs", (`Assoc ([("tree", ppx_body_tree)] @ (!ppx_eds))));
         ("$ref", (`String "#/$defs/tree"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -919,7 +1029,6 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:tree",
       "$defs": {
         "tree": {
           "anyOf": [
@@ -961,14 +1070,24 @@ type non_recursive = {
 include
   struct
     let non_recursive_jsonschema =
-      `Assoc
-        [("type", (`String "object"));
-        ("properties",
-          (`Assoc
-             [("y", (`Assoc [("type", (`String "string"))]));
-             ("x", (`Assoc [("type", (`String "integer"))]))]));
-        ("required", (`List [`String "y"; `String "x"]));
-        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("y", (`Assoc [("type", (`String "string"))]));
+               ("x", (`Assoc [("type", (`String "integer"))]))]));
+          ("required", (`List [`String "y"; `String "x"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "non_recursive" =
@@ -991,81 +1110,69 @@ include
   struct
     let foo_jsonschema =
       let ppx_eds = ref [] in
-      let ppx_body_0 =
+      let ppx_body_foo =
         `Assoc
           [("type", (`String "object"));
           ("properties",
             (`Assoc
                [("bar",
-                  ((match `Assoc [("$ref", (`String "#/$defs/bar"))] with
-                    | `Assoc (("type", `String t)::[]) ->
-                        `Assoc
-                          [("type", (`List [`String t; `String "null"]))]
-                    | s ->
-                        `Assoc
-                          [("anyOf",
-                             (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+                  (`Assoc
+                     [("anyOf",
+                        (`List
+                           [`Assoc [("$ref", (`String "#/$defs/bar"))];
+                           `Assoc [("type", (`String "null"))]]))]))]));
           ("required", (`List [`String "bar"]));
           ("additionalProperties", (`Bool false))] in
-      let ppx_body_1 =
+      let ppx_body_bar =
         `Assoc
           [("type", (`String "object"));
           ("properties",
             (`Assoc
                [("foo",
-                  ((match `Assoc [("$ref", (`String "#/$defs/foo"))] with
-                    | `Assoc (("type", `String t)::[]) ->
-                        `Assoc
-                          [("type", (`List [`String t; `String "null"]))]
-                    | s ->
-                        `Assoc
-                          [("anyOf",
-                             (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+                  (`Assoc
+                     [("anyOf",
+                        (`List
+                           [`Assoc [("$ref", (`String "#/$defs/foo"))];
+                           `Assoc [("type", (`String "null"))]]))]))]));
           ("required", (`List [`String "foo"]));
           ("additionalProperties", (`Bool false))] in
       `Assoc
-        [("$id", (`String "urn:jsonschema:foo"));
-        ("$defs",
-          (`Assoc ([("foo", ppx_body_0); ("bar", ppx_body_1)] @ (!ppx_eds))));
+        [("$defs",
+           (`Assoc
+              ([("foo", ppx_body_foo); ("bar", ppx_body_bar)] @ (!ppx_eds))));
         ("$ref", (`String "#/$defs/foo"))][@@warning "-32-39"]
     let bar_jsonschema =
       let ppx_eds = ref [] in
-      let ppx_body_0 =
+      let ppx_body_foo =
         `Assoc
           [("type", (`String "object"));
           ("properties",
             (`Assoc
                [("bar",
-                  ((match `Assoc [("$ref", (`String "#/$defs/bar"))] with
-                    | `Assoc (("type", `String t)::[]) ->
-                        `Assoc
-                          [("type", (`List [`String t; `String "null"]))]
-                    | s ->
-                        `Assoc
-                          [("anyOf",
-                             (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+                  (`Assoc
+                     [("anyOf",
+                        (`List
+                           [`Assoc [("$ref", (`String "#/$defs/bar"))];
+                           `Assoc [("type", (`String "null"))]]))]))]));
           ("required", (`List [`String "bar"]));
           ("additionalProperties", (`Bool false))] in
-      let ppx_body_1 =
+      let ppx_body_bar =
         `Assoc
           [("type", (`String "object"));
           ("properties",
             (`Assoc
                [("foo",
-                  ((match `Assoc [("$ref", (`String "#/$defs/foo"))] with
-                    | `Assoc (("type", `String t)::[]) ->
-                        `Assoc
-                          [("type", (`List [`String t; `String "null"]))]
-                    | s ->
-                        `Assoc
-                          [("anyOf",
-                             (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+                  (`Assoc
+                     [("anyOf",
+                        (`List
+                           [`Assoc [("$ref", (`String "#/$defs/foo"))];
+                           `Assoc [("type", (`String "null"))]]))]))]));
           ("required", (`List [`String "foo"]));
           ("additionalProperties", (`Bool false))] in
       `Assoc
-        [("$id", (`String "urn:jsonschema:bar"));
-        ("$defs",
-          (`Assoc ([("foo", ppx_body_0); ("bar", ppx_body_1)] @ (!ppx_eds))));
+        [("$defs",
+           (`Assoc
+              ([("foo", ppx_body_foo); ("bar", ppx_body_bar)] @ (!ppx_eds))));
         ("$ref", (`String "#/$defs/bar"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -1075,7 +1182,6 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:foo",
       "$defs": {
         "foo": {
           "type": "object",
@@ -1104,7 +1210,6 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:bar",
       "$defs": {
         "foo": {
           "type": "object",
@@ -1140,7 +1245,7 @@ include
   struct
     let expr_jsonschema =
       let ppx_eds = ref [] in
-      let ppx_body_0 =
+      let ppx_body_expr =
         `Assoc
           [("anyOf",
              (`List
@@ -1175,7 +1280,7 @@ include
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
-      let ppx_body_1 =
+      let ppx_body_stmt =
         `Assoc
           [("anyOf",
              (`List
@@ -1198,22 +1303,13 @@ include
                          ("properties",
                            (`Assoc
                               [("else_",
-                                 ((match `Assoc
-                                           [("$ref",
-                                              (`String "#/$defs/stmt"))]
-                                   with
-                                   | `Assoc (("type", `String t)::[]) ->
-                                       `Assoc
-                                         [("type",
-                                            (`List
-                                               [`String t; `String "null"]))]
-                                   | s ->
-                                       `Assoc
-                                         [("anyOf",
-                                            (`List
-                                               [s;
-                                               `Assoc
-                                                 [("type", (`String "null"))]]))])));
+                                 (`Assoc
+                                    [("anyOf",
+                                       (`List
+                                          [`Assoc
+                                             [("$ref",
+                                                (`String "#/$defs/stmt"))];
+                                          `Assoc [("type", (`String "null"))]]))]));
                               ("then_",
                                 (`Assoc [("$ref", (`String "#/$defs/stmt"))]));
                               ("cond",
@@ -1228,13 +1324,14 @@ include
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
       `Assoc
-        [("$id", (`String "urn:jsonschema:expr"));
-        ("$defs",
-          (`Assoc ([("expr", ppx_body_0); ("stmt", ppx_body_1)] @ (!ppx_eds))));
+        [("$defs",
+           (`Assoc
+              ([("expr", ppx_body_expr); ("stmt", ppx_body_stmt)] @
+                 (!ppx_eds))));
         ("$ref", (`String "#/$defs/expr"))][@@warning "-32-39"]
     let stmt_jsonschema =
       let ppx_eds = ref [] in
-      let ppx_body_0 =
+      let ppx_body_expr =
         `Assoc
           [("anyOf",
              (`List
@@ -1269,7 +1366,7 @@ include
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
-      let ppx_body_1 =
+      let ppx_body_stmt =
         `Assoc
           [("anyOf",
              (`List
@@ -1292,22 +1389,13 @@ include
                          ("properties",
                            (`Assoc
                               [("else_",
-                                 ((match `Assoc
-                                           [("$ref",
-                                              (`String "#/$defs/stmt"))]
-                                   with
-                                   | `Assoc (("type", `String t)::[]) ->
-                                       `Assoc
-                                         [("type",
-                                            (`List
-                                               [`String t; `String "null"]))]
-                                   | s ->
-                                       `Assoc
-                                         [("anyOf",
-                                            (`List
-                                               [s;
-                                               `Assoc
-                                                 [("type", (`String "null"))]]))])));
+                                 (`Assoc
+                                    [("anyOf",
+                                       (`List
+                                          [`Assoc
+                                             [("$ref",
+                                                (`String "#/$defs/stmt"))];
+                                          `Assoc [("type", (`String "null"))]]))]));
                               ("then_",
                                 (`Assoc [("$ref", (`String "#/$defs/stmt"))]));
                               ("cond",
@@ -1322,9 +1410,10 @@ include
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
       `Assoc
-        [("$id", (`String "urn:jsonschema:stmt"));
-        ("$defs",
-          (`Assoc ([("expr", ppx_body_0); ("stmt", ppx_body_1)] @ (!ppx_eds))));
+        [("$defs",
+           (`Assoc
+              ([("expr", ppx_body_expr); ("stmt", ppx_body_stmt)] @
+                 (!ppx_eds))));
         ("$ref", (`String "#/$defs/stmt"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -1334,7 +1423,6 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:expr",
       "$defs": {
         "expr": {
           "anyOf": [
@@ -1413,19 +1501,39 @@ and beta = {
 include
   struct
     let alpha_jsonschema =
-      `Assoc
-        [("type", (`String "object"));
-        ("properties",
-          (`Assoc [("x", (`Assoc [("type", (`String "integer"))]))]));
-        ("required", (`List [`String "x"]));
-        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc [("x", (`Assoc [("type", (`String "integer"))]))]));
+          ("required", (`List [`String "x"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
     let beta_jsonschema =
-      `Assoc
-        [("type", (`String "object"));
-        ("properties",
-          (`Assoc [("y", (`Assoc [("type", (`String "string"))]))]));
-        ("required", (`List [`String "y"]));
-        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc [("y", (`Assoc [("type", (`String "string"))]))]));
+          ("required", (`List [`String "y"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "non_recursive_mutual_alpha" =
@@ -1466,249 +1574,201 @@ include
   struct
     let node_a_jsonschema =
       let ppx_eds = ref [] in
-      let ppx_body_0 =
+      let ppx_body_node_a =
         `Assoc
           [("type", (`String "object"));
           ("properties",
             (`Assoc
                [("c",
-                  ((match `Assoc [("$ref", (`String "#/$defs/node_c"))] with
-                    | `Assoc (("type", `String t)::[]) ->
-                        `Assoc
-                          [("type", (`List [`String t; `String "null"]))]
-                    | s ->
-                        `Assoc
-                          [("anyOf",
-                             (`List [s; `Assoc [("type", (`String "null"))]]))])));
+                  (`Assoc
+                     [("anyOf",
+                        (`List
+                           [`Assoc [("$ref", (`String "#/$defs/node_c"))];
+                           `Assoc [("type", (`String "null"))]]))]));
                ("b",
-                 ((match `Assoc [("$ref", (`String "#/$defs/node_b"))] with
-                   | `Assoc (("type", `String t)::[]) ->
-                       `Assoc [("type", (`List [`String t; `String "null"]))]
-                   | s ->
-                       `Assoc
-                         [("anyOf",
-                            (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+                 (`Assoc
+                    [("anyOf",
+                       (`List
+                          [`Assoc [("$ref", (`String "#/$defs/node_b"))];
+                          `Assoc [("type", (`String "null"))]]))]))]));
           ("required", (`List [`String "c"; `String "b"]));
           ("additionalProperties", (`Bool false))] in
-      let ppx_body_1 =
+      let ppx_body_node_b =
         `Assoc
           [("type", (`String "object"));
           ("properties",
             (`Assoc
                [("c",
-                  ((match `Assoc [("$ref", (`String "#/$defs/node_c"))] with
-                    | `Assoc (("type", `String t)::[]) ->
-                        `Assoc
-                          [("type", (`List [`String t; `String "null"]))]
-                    | s ->
-                        `Assoc
-                          [("anyOf",
-                             (`List [s; `Assoc [("type", (`String "null"))]]))])));
+                  (`Assoc
+                     [("anyOf",
+                        (`List
+                           [`Assoc [("$ref", (`String "#/$defs/node_c"))];
+                           `Assoc [("type", (`String "null"))]]))]));
                ("a",
-                 ((match `Assoc [("$ref", (`String "#/$defs/node_a"))] with
-                   | `Assoc (("type", `String t)::[]) ->
-                       `Assoc [("type", (`List [`String t; `String "null"]))]
-                   | s ->
-                       `Assoc
-                         [("anyOf",
-                            (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+                 (`Assoc
+                    [("anyOf",
+                       (`List
+                          [`Assoc [("$ref", (`String "#/$defs/node_a"))];
+                          `Assoc [("type", (`String "null"))]]))]))]));
           ("required", (`List [`String "c"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
-      let ppx_body_2 =
+      let ppx_body_node_c =
         `Assoc
           [("type", (`String "object"));
           ("properties",
             (`Assoc
                [("b",
-                  ((match `Assoc [("$ref", (`String "#/$defs/node_b"))] with
-                    | `Assoc (("type", `String t)::[]) ->
-                        `Assoc
-                          [("type", (`List [`String t; `String "null"]))]
-                    | s ->
-                        `Assoc
-                          [("anyOf",
-                             (`List [s; `Assoc [("type", (`String "null"))]]))])));
+                  (`Assoc
+                     [("anyOf",
+                        (`List
+                           [`Assoc [("$ref", (`String "#/$defs/node_b"))];
+                           `Assoc [("type", (`String "null"))]]))]));
                ("a",
-                 ((match `Assoc [("$ref", (`String "#/$defs/node_a"))] with
-                   | `Assoc (("type", `String t)::[]) ->
-                       `Assoc [("type", (`List [`String t; `String "null"]))]
-                   | s ->
-                       `Assoc
-                         [("anyOf",
-                            (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+                 (`Assoc
+                    [("anyOf",
+                       (`List
+                          [`Assoc [("$ref", (`String "#/$defs/node_a"))];
+                          `Assoc [("type", (`String "null"))]]))]))]));
           ("required", (`List [`String "b"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
       `Assoc
-        [("$id", (`String "urn:jsonschema:node_a"));
-        ("$defs",
-          (`Assoc
-             ([("node_a", ppx_body_0);
-              ("node_b", ppx_body_1);
-              ("node_c", ppx_body_2)] @ (!ppx_eds))));
+        [("$defs",
+           (`Assoc
+              ([("node_a", ppx_body_node_a);
+               ("node_b", ppx_body_node_b);
+               ("node_c", ppx_body_node_c)] @ (!ppx_eds))));
         ("$ref", (`String "#/$defs/node_a"))][@@warning "-32-39"]
     let node_b_jsonschema =
       let ppx_eds = ref [] in
-      let ppx_body_0 =
+      let ppx_body_node_a =
         `Assoc
           [("type", (`String "object"));
           ("properties",
             (`Assoc
                [("c",
-                  ((match `Assoc [("$ref", (`String "#/$defs/node_c"))] with
-                    | `Assoc (("type", `String t)::[]) ->
-                        `Assoc
-                          [("type", (`List [`String t; `String "null"]))]
-                    | s ->
-                        `Assoc
-                          [("anyOf",
-                             (`List [s; `Assoc [("type", (`String "null"))]]))])));
+                  (`Assoc
+                     [("anyOf",
+                        (`List
+                           [`Assoc [("$ref", (`String "#/$defs/node_c"))];
+                           `Assoc [("type", (`String "null"))]]))]));
                ("b",
-                 ((match `Assoc [("$ref", (`String "#/$defs/node_b"))] with
-                   | `Assoc (("type", `String t)::[]) ->
-                       `Assoc [("type", (`List [`String t; `String "null"]))]
-                   | s ->
-                       `Assoc
-                         [("anyOf",
-                            (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+                 (`Assoc
+                    [("anyOf",
+                       (`List
+                          [`Assoc [("$ref", (`String "#/$defs/node_b"))];
+                          `Assoc [("type", (`String "null"))]]))]))]));
           ("required", (`List [`String "c"; `String "b"]));
           ("additionalProperties", (`Bool false))] in
-      let ppx_body_1 =
+      let ppx_body_node_b =
         `Assoc
           [("type", (`String "object"));
           ("properties",
             (`Assoc
                [("c",
-                  ((match `Assoc [("$ref", (`String "#/$defs/node_c"))] with
-                    | `Assoc (("type", `String t)::[]) ->
-                        `Assoc
-                          [("type", (`List [`String t; `String "null"]))]
-                    | s ->
-                        `Assoc
-                          [("anyOf",
-                             (`List [s; `Assoc [("type", (`String "null"))]]))])));
+                  (`Assoc
+                     [("anyOf",
+                        (`List
+                           [`Assoc [("$ref", (`String "#/$defs/node_c"))];
+                           `Assoc [("type", (`String "null"))]]))]));
                ("a",
-                 ((match `Assoc [("$ref", (`String "#/$defs/node_a"))] with
-                   | `Assoc (("type", `String t)::[]) ->
-                       `Assoc [("type", (`List [`String t; `String "null"]))]
-                   | s ->
-                       `Assoc
-                         [("anyOf",
-                            (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+                 (`Assoc
+                    [("anyOf",
+                       (`List
+                          [`Assoc [("$ref", (`String "#/$defs/node_a"))];
+                          `Assoc [("type", (`String "null"))]]))]))]));
           ("required", (`List [`String "c"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
-      let ppx_body_2 =
+      let ppx_body_node_c =
         `Assoc
           [("type", (`String "object"));
           ("properties",
             (`Assoc
                [("b",
-                  ((match `Assoc [("$ref", (`String "#/$defs/node_b"))] with
-                    | `Assoc (("type", `String t)::[]) ->
-                        `Assoc
-                          [("type", (`List [`String t; `String "null"]))]
-                    | s ->
-                        `Assoc
-                          [("anyOf",
-                             (`List [s; `Assoc [("type", (`String "null"))]]))])));
+                  (`Assoc
+                     [("anyOf",
+                        (`List
+                           [`Assoc [("$ref", (`String "#/$defs/node_b"))];
+                           `Assoc [("type", (`String "null"))]]))]));
                ("a",
-                 ((match `Assoc [("$ref", (`String "#/$defs/node_a"))] with
-                   | `Assoc (("type", `String t)::[]) ->
-                       `Assoc [("type", (`List [`String t; `String "null"]))]
-                   | s ->
-                       `Assoc
-                         [("anyOf",
-                            (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+                 (`Assoc
+                    [("anyOf",
+                       (`List
+                          [`Assoc [("$ref", (`String "#/$defs/node_a"))];
+                          `Assoc [("type", (`String "null"))]]))]))]));
           ("required", (`List [`String "b"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
       `Assoc
-        [("$id", (`String "urn:jsonschema:node_b"));
-        ("$defs",
-          (`Assoc
-             ([("node_a", ppx_body_0);
-              ("node_b", ppx_body_1);
-              ("node_c", ppx_body_2)] @ (!ppx_eds))));
+        [("$defs",
+           (`Assoc
+              ([("node_a", ppx_body_node_a);
+               ("node_b", ppx_body_node_b);
+               ("node_c", ppx_body_node_c)] @ (!ppx_eds))));
         ("$ref", (`String "#/$defs/node_b"))][@@warning "-32-39"]
     let node_c_jsonschema =
       let ppx_eds = ref [] in
-      let ppx_body_0 =
+      let ppx_body_node_a =
         `Assoc
           [("type", (`String "object"));
           ("properties",
             (`Assoc
                [("c",
-                  ((match `Assoc [("$ref", (`String "#/$defs/node_c"))] with
-                    | `Assoc (("type", `String t)::[]) ->
-                        `Assoc
-                          [("type", (`List [`String t; `String "null"]))]
-                    | s ->
-                        `Assoc
-                          [("anyOf",
-                             (`List [s; `Assoc [("type", (`String "null"))]]))])));
+                  (`Assoc
+                     [("anyOf",
+                        (`List
+                           [`Assoc [("$ref", (`String "#/$defs/node_c"))];
+                           `Assoc [("type", (`String "null"))]]))]));
                ("b",
-                 ((match `Assoc [("$ref", (`String "#/$defs/node_b"))] with
-                   | `Assoc (("type", `String t)::[]) ->
-                       `Assoc [("type", (`List [`String t; `String "null"]))]
-                   | s ->
-                       `Assoc
-                         [("anyOf",
-                            (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+                 (`Assoc
+                    [("anyOf",
+                       (`List
+                          [`Assoc [("$ref", (`String "#/$defs/node_b"))];
+                          `Assoc [("type", (`String "null"))]]))]))]));
           ("required", (`List [`String "c"; `String "b"]));
           ("additionalProperties", (`Bool false))] in
-      let ppx_body_1 =
+      let ppx_body_node_b =
         `Assoc
           [("type", (`String "object"));
           ("properties",
             (`Assoc
                [("c",
-                  ((match `Assoc [("$ref", (`String "#/$defs/node_c"))] with
-                    | `Assoc (("type", `String t)::[]) ->
-                        `Assoc
-                          [("type", (`List [`String t; `String "null"]))]
-                    | s ->
-                        `Assoc
-                          [("anyOf",
-                             (`List [s; `Assoc [("type", (`String "null"))]]))])));
+                  (`Assoc
+                     [("anyOf",
+                        (`List
+                           [`Assoc [("$ref", (`String "#/$defs/node_c"))];
+                           `Assoc [("type", (`String "null"))]]))]));
                ("a",
-                 ((match `Assoc [("$ref", (`String "#/$defs/node_a"))] with
-                   | `Assoc (("type", `String t)::[]) ->
-                       `Assoc [("type", (`List [`String t; `String "null"]))]
-                   | s ->
-                       `Assoc
-                         [("anyOf",
-                            (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+                 (`Assoc
+                    [("anyOf",
+                       (`List
+                          [`Assoc [("$ref", (`String "#/$defs/node_a"))];
+                          `Assoc [("type", (`String "null"))]]))]))]));
           ("required", (`List [`String "c"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
-      let ppx_body_2 =
+      let ppx_body_node_c =
         `Assoc
           [("type", (`String "object"));
           ("properties",
             (`Assoc
                [("b",
-                  ((match `Assoc [("$ref", (`String "#/$defs/node_b"))] with
-                    | `Assoc (("type", `String t)::[]) ->
-                        `Assoc
-                          [("type", (`List [`String t; `String "null"]))]
-                    | s ->
-                        `Assoc
-                          [("anyOf",
-                             (`List [s; `Assoc [("type", (`String "null"))]]))])));
+                  (`Assoc
+                     [("anyOf",
+                        (`List
+                           [`Assoc [("$ref", (`String "#/$defs/node_b"))];
+                           `Assoc [("type", (`String "null"))]]))]));
                ("a",
-                 ((match `Assoc [("$ref", (`String "#/$defs/node_a"))] with
-                   | `Assoc (("type", `String t)::[]) ->
-                       `Assoc [("type", (`List [`String t; `String "null"]))]
-                   | s ->
-                       `Assoc
-                         [("anyOf",
-                            (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
+                 (`Assoc
+                    [("anyOf",
+                       (`List
+                          [`Assoc [("$ref", (`String "#/$defs/node_a"))];
+                          `Assoc [("type", (`String "null"))]]))]))]));
           ("required", (`List [`String "b"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
       `Assoc
-        [("$id", (`String "urn:jsonschema:node_c"));
-        ("$defs",
-          (`Assoc
-             ([("node_a", ppx_body_0);
-              ("node_b", ppx_body_1);
-              ("node_c", ppx_body_2)] @ (!ppx_eds))));
+        [("$defs",
+           (`Assoc
+              ([("node_a", ppx_body_node_a);
+               ("node_b", ppx_body_node_b);
+               ("node_c", ppx_body_node_c)] @ (!ppx_eds))));
         ("$ref", (`String "#/$defs/node_c"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -1718,7 +1778,6 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:node_a",
       "$defs": {
         "node_a": {
           "type": "object",
@@ -1770,7 +1829,7 @@ include
   struct
     let recursive_tuple_jsonschema =
       let ppx_eds = ref [] in
-      let ppx_body =
+      let ppx_body_recursive_tuple =
         `Assoc
           [("anyOf",
              (`List
@@ -1805,8 +1864,9 @@ include
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
       `Assoc
-        [("$id", (`String "urn:jsonschema:recursive_tuple"));
-        ("$defs", (`Assoc (("recursive_tuple", ppx_body) :: (!ppx_eds))));
+        [("$defs",
+           (`Assoc
+              ([("recursive_tuple", ppx_body_recursive_tuple)] @ (!ppx_eds))));
         ("$ref", (`String "#/$defs/recursive_tuple"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -1816,7 +1876,6 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:recursive_tuple",
       "$defs": {
         "recursive_tuple": {
           "anyOf": [
@@ -1856,11 +1915,21 @@ type int_tree = tree[@@deriving jsonschema]
 include
   struct
     let int_tree_jsonschema =
-      match tree_jsonschema with
-      | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-          `Assoc (("$id", (`String "urn:jsonschema:test.ml:920:23215")) ::
-            (List.filter (fun (k, _) -> k <> "$id") pairs))
-      | other -> other[@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match tree_jsonschema with
+        | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+            `Assoc (("$id", (`String "file://test.ml:912:22891")) ::
+              (List.filter (fun (k, _) -> k <> "$id") pairs))
+        | other -> other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "recursive_abstract_alias" =
@@ -1869,7 +1938,7 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:test/test.ml:920:23215",
+      "$id": "file://test/test.ml:912:22891",
       "$defs": {
         "tree": {
           "anyOf": [
@@ -1909,14 +1978,24 @@ type events = event list[@@deriving jsonschema]
 include
   struct
     let events_jsonschema =
-      `Assoc
-        [("type", (`String "array"));
-        ("items",
-          ((match event_jsonschema with
-            | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                `Assoc (("$id", (`String "urn:jsonschema:test.ml:965:24467"))
-                  :: (List.filter (fun (k, _) -> k <> "$id") pairs))
-            | other -> other)))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "array"));
+          ("items",
+            ((match event_jsonschema with
+              | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                  `Assoc (("$id", (`String "file://test.ml:957:24135")) ::
+                    (List.filter (fun (k, _) -> k <> "$id") pairs))
+              | other -> other)))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "events" =
@@ -2002,19 +2081,27 @@ type eventss = event list list[@@deriving jsonschema]
 include
   struct
     let eventss_jsonschema =
-      `Assoc
-        [("type", (`String "array"));
-        ("items",
-          (`Assoc
-             [("type", (`String "array"));
-             ("items",
-               ((match event_jsonschema with
-                 | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                     `Assoc
-                       (("$id",
-                          (`String "urn:jsonschema:test.ml:1047:27015"))
-                       :: (List.filter (fun (k, _) -> k <> "$id") pairs))
-                 | other -> other)))]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "array"));
+          ("items",
+            (`Assoc
+               [("type", (`String "array"));
+               ("items",
+                 ((match event_jsonschema with
+                   | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                       `Assoc (("$id", (`String "file://test.ml:1039:26683"))
+                         :: (List.filter (fun (k, _) -> k <> "$id") pairs))
+                   | other -> other)))]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "eventss" =
@@ -2103,20 +2190,29 @@ type event_comment = (event * string)[@@deriving jsonschema]
 include
   struct
     let event_comment_jsonschema =
-      `Assoc
-        [("type", (`String "array"));
-        ("prefixItems",
-          (`List
-             [(match event_jsonschema with
-               | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                   `Assoc
-                     (("$id", (`String "urn:jsonschema:test.ml:1132:29766"))
-                     :: (List.filter (fun (k, _) -> k <> "$id") pairs))
-               | other -> other);
-             `Assoc [("type", (`String "string"))]]));
-        ("unevaluatedItems", (`Bool false));
-        ("minItems", (`Int 2));
-        ("maxItems", (`Int 2))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "array"));
+          ("prefixItems",
+            (`List
+               [(match event_jsonschema with
+                 | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                     `Assoc (("$id", (`String "file://test.ml:1124:29434"))
+                       :: (List.filter (fun (k, _) -> k <> "$id") pairs))
+                 | other -> other);
+               `Assoc [("type", (`String "string"))]]));
+          ("unevaluatedItems", (`Bool false));
+          ("minItems", (`Int 2));
+          ("maxItems", (`Int 2))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "event_comment" =
@@ -2208,15 +2304,24 @@ type event_comments' = event_comment list[@@deriving jsonschema]
 include
   struct
     let event_comments'_jsonschema =
-      `Assoc
-        [("type", (`String "array"));
-        ("items",
-          ((match event_comment_jsonschema with
-            | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                `Assoc
-                  (("$id", (`String "urn:jsonschema:test.ml:1220:32607")) ::
-                  (List.filter (fun (k, _) -> k <> "$id") pairs))
-            | other -> other)))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "array"));
+          ("items",
+            ((match event_comment_jsonschema with
+              | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                  `Assoc (("$id", (`String "file://test.ml:1212:32275")) ::
+                    (List.filter (fun (k, _) -> k <> "$id") pairs))
+              | other -> other)))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "event_comments'" =
@@ -2311,24 +2416,34 @@ type event_n = (event * int) list[@@deriving jsonschema]
 include
   struct
     let event_n_jsonschema =
-      `Assoc
-        [("type", (`String "array"));
-        ("items",
-          (`Assoc
-             [("type", (`String "array"));
-             ("prefixItems",
-               (`List
-                  [(match event_jsonschema with
-                    | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                        `Assoc
-                          (("$id",
-                             (`String "urn:jsonschema:test.ml:1311:35651"))
-                          :: (List.filter (fun (k, _) -> k <> "$id") pairs))
-                    | other -> other);
-                  `Assoc [("type", (`String "integer"))]]));
-             ("unevaluatedItems", (`Bool false));
-             ("minItems", (`Int 2));
-             ("maxItems", (`Int 2))]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "array"));
+          ("items",
+            (`Assoc
+               [("type", (`String "array"));
+               ("prefixItems",
+                 (`List
+                    [(match event_jsonschema with
+                      | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                          `Assoc
+                            (("$id", (`String "file://test.ml:1303:35319"))
+                            ::
+                            (List.filter (fun (k, _) -> k <> "$id") pairs))
+                      | other -> other);
+                    `Assoc [("type", (`String "integer"))]]));
+               ("unevaluatedItems", (`Bool false));
+               ("minItems", (`Int 2));
+               ("maxItems", (`Int 2))]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "event_n" =
@@ -2423,15 +2538,24 @@ type events_array = events array[@@deriving jsonschema]
 include
   struct
     let events_array_jsonschema =
-      `Assoc
-        [("type", (`String "array"));
-        ("items",
-          ((match events_jsonschema with
-            | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                `Assoc
-                  (("$id", (`String "urn:jsonschema:test.ml:1402:38683")) ::
-                  (List.filter (fun (k, _) -> k <> "$id") pairs))
-            | other -> other)))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "array"));
+          ("items",
+            ((match events_jsonschema with
+              | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                  `Assoc (("$id", (`String "file://test.ml:1394:38351")) ::
+                    (List.filter (fun (k, _) -> k <> "$id") pairs))
+              | other -> other)))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "events_array" =
@@ -2520,10 +2644,19 @@ type numbers = int list[@@deriving jsonschema]
 include
   struct
     let numbers_jsonschema =
-      `Assoc
-        [("type", (`String "array"));
-        ("items", (`Assoc [("type", (`String "integer"))]))][@@warning
-                                                              "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "array"));
+          ("items", (`Assoc [("type", (`String "integer"))]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "numbers" =
@@ -2539,13 +2672,17 @@ type opt = int option[@@deriving jsonschema]
 include
   struct
     let opt_jsonschema =
-      match `Assoc [("type", (`String "integer"))] with
-      | `Assoc (("type", `String t)::[]) ->
-          `Assoc [("type", (`List [`String t; `String "null"]))]
-      | s ->
-          `Assoc
-            [("anyOf", (`List [s; `Assoc [("type", (`String "null"))]]))]
-      [@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc [("type", (`List [`String "integer"; `String "null"]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "opt" =
@@ -2562,20 +2699,29 @@ type using_m = {
 include
   struct
     let using_m_jsonschema =
-      `Assoc
-        [("type", (`String "object"));
-        ("properties",
-          (`Assoc
-             [("m",
-                ((match Mod1.m_1_jsonschema with
-                  | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                      `Assoc
-                        (("$id",
-                           (`String "urn:jsonschema:test.ml:1511:41955"))
-                        :: (List.filter (fun (k, _) -> k <> "$id") pairs))
-                  | other -> other)))]));
-        ("required", (`List [`String "m"]));
-        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("m",
+                  ((match Mod1.m_1_jsonschema with
+                    | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                        `Assoc
+                          (("$id", (`String "file://test.ml:1503:41623")) ::
+                          (List.filter (fun (k, _) -> k <> "$id") pairs))
+                    | other -> other)))]));
+          ("required", (`List [`String "m"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "using_m" =
@@ -2614,8 +2760,17 @@ type 'param2 poly2 =
 include
   struct
     let poly2_jsonschema _param2 =
-      `Assoc [("anyOf", (`List [`Assoc [("const", (`String "C"))]]))]
-      [@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc [("anyOf", (`List [`Assoc [("const", (`String "C"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "poly2" =
@@ -2631,31 +2786,42 @@ type tuple_with_variant = (int * [ `A  | `B [@name "second_cstr"]])[@@deriving
 include
   struct
     let tuple_with_variant_jsonschema =
-      `Assoc
-        [("type", (`String "array"));
-        ("prefixItems",
-          (`List
-             [`Assoc [("type", (`String "integer"))];
-             `Assoc
-               [("anyOf",
-                  (`List
-                     [`Assoc
-                        [("type", (`String "array"));
-                        ("prefixItems",
-                          (`List [`Assoc [("const", (`String "A"))]]));
-                        ("unevaluatedItems", (`Bool false));
-                        ("minItems", (`Int 1));
-                        ("maxItems", (`Int 1))];
-                     `Assoc
-                       [("type", (`String "array"));
-                       ("prefixItems",
-                         (`List [`Assoc [("const", (`String "second_cstr"))]]));
-                       ("unevaluatedItems", (`Bool false));
-                       ("minItems", (`Int 1));
-                       ("maxItems", (`Int 1))]]))]]));
-        ("unevaluatedItems", (`Bool false));
-        ("minItems", (`Int 2));
-        ("maxItems", (`Int 2))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "array"));
+          ("prefixItems",
+            (`List
+               [`Assoc [("type", (`String "integer"))];
+               `Assoc
+                 [("anyOf",
+                    (`List
+                       [`Assoc
+                          [("type", (`String "array"));
+                          ("prefixItems",
+                            (`List [`Assoc [("const", (`String "A"))]]));
+                          ("unevaluatedItems", (`Bool false));
+                          ("minItems", (`Int 1));
+                          ("maxItems", (`Int 1))];
+                       `Assoc
+                         [("type", (`String "array"));
+                         ("prefixItems",
+                           (`List
+                              [`Assoc [("const", (`String "second_cstr"))]]));
+                         ("unevaluatedItems", (`Bool false));
+                         ("minItems", (`Int 1));
+                         ("maxItems", (`Int 1))]]))]]));
+          ("unevaluatedItems", (`Bool false));
+          ("minItems", (`Int 2));
+          ("maxItems", (`Int 2))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "tuple_with_variant" =
@@ -2698,15 +2864,25 @@ type player_scores =
 include
   struct
     let player_scores_jsonschema =
-      `Assoc
-        [("type", (`String "object"));
-        ("properties",
-          (`Assoc
-             [("scores_ref",
-                (`Assoc [("$ref", (`String "#/$defs/numbers"))]));
-             ("player", (`Assoc [("type", (`String "string"))]))]));
-        ("required", (`List [`String "scores_ref"; `String "player"]));
-        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("scores_ref",
+                  (`Assoc [("$ref", (`String "#/$defs/numbers"))]));
+               ("player", (`Assoc [("type", (`String "string"))]))]));
+          ("required", (`List [`String "scores_ref"; `String "player"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "player_scores" =
@@ -2737,16 +2913,26 @@ type address = {
 include
   struct
     let address_jsonschema =
-      `Assoc
-        [("type", (`String "object"));
-        ("properties",
-          (`Assoc
-             [("zip", (`Assoc [("type", (`String "string"))]));
-             ("city", (`Assoc [("type", (`String "string"))]));
-             ("street", (`Assoc [("type", (`String "string"))]))]));
-        ("required",
-          (`List [`String "zip"; `String "city"; `String "street"]));
-        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("zip", (`Assoc [("type", (`String "string"))]));
+               ("city", (`Assoc [("type", (`String "string"))]));
+               ("street", (`Assoc [("type", (`String "string"))]))]));
+          ("required",
+            (`List [`String "zip"; `String "city"; `String "street"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type t = {
   name: string ;
@@ -2756,35 +2942,39 @@ type t = {
 include
   struct
     let t_jsonschema =
-      `Assoc
-        [("type", (`String "object"));
-        ("properties",
-          (`Assoc
-             [("address",
-                ((match address_jsonschema with
-                  | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                      `Assoc
-                        (("$id",
-                           (`String "urn:jsonschema:test.ml:1633:45167"))
-                        :: (List.filter (fun (k, _) -> k <> "$id") pairs))
-                  | other -> other)));
-             ("email",
-               ((match `Assoc [("type", (`String "string"))] with
-                 | `Assoc (("type", `String t)::[]) ->
-                     `Assoc [("type", (`List [`String t; `String "null"]))]
-                 | s ->
-                     `Assoc
-                       [("anyOf",
-                          (`List [s; `Assoc [("type", (`String "null"))]]))])));
-             ("age", (`Assoc [("type", (`String "integer"))]));
-             ("name", (`Assoc [("type", (`String "string"))]))]));
-        ("required",
-          (`List
-             [`String "address";
-             `String "email";
-             `String "age";
-             `String "name"]));
-        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("address",
+                  ((match address_jsonschema with
+                    | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                        `Assoc
+                          (("$id", (`String "file://test.ml:1625:44835")) ::
+                          (List.filter (fun (k, _) -> k <> "$id") pairs))
+                    | other -> other)));
+               ("email",
+                 (`Assoc
+                    [("type", (`List [`String "string"; `String "null"]))]));
+               ("age", (`Assoc [("type", (`String "integer"))]));
+               ("name", (`Assoc [("type", (`String "string"))]))]));
+          ("required",
+            (`List
+               [`String "address";
+               `String "email";
+               `String "age";
+               `String "name"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "t" =
@@ -2824,35 +3014,40 @@ type tt =
 include
   struct
     let tt_jsonschema =
-      `Assoc
-        [("type", (`String "object"));
-        ("properties",
-          (`Assoc
-             [("retreat_address",
-                (`Assoc [("$ref", (`String "#/$defs/shared_address"))]));
-             ("work_address",
-               (`Assoc [("$ref", (`String "#/$defs/shared_address"))]));
-             ("home_address",
-               (`Assoc [("$ref", (`String "#/$defs/shared_address"))]));
-             ("email",
-               ((match `Assoc [("type", (`String "string"))] with
-                 | `Assoc (("type", `String t)::[]) ->
-                     `Assoc [("type", (`List [`String t; `String "null"]))]
-                 | s ->
-                     `Assoc
-                       [("anyOf",
-                          (`List [s; `Assoc [("type", (`String "null"))]]))])));
-             ("age", (`Assoc [("type", (`String "integer"))]));
-             ("name", (`Assoc [("type", (`String "string"))]))]));
-        ("required",
-          (`List
-             [`String "retreat_address";
-             `String "work_address";
-             `String "home_address";
-             `String "email";
-             `String "age";
-             `String "name"]));
-        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("retreat_address",
+                  (`Assoc [("$ref", (`String "#/$defs/shared_address"))]));
+               ("work_address",
+                 (`Assoc [("$ref", (`String "#/$defs/shared_address"))]));
+               ("home_address",
+                 (`Assoc [("$ref", (`String "#/$defs/shared_address"))]));
+               ("email",
+                 (`Assoc
+                    [("type", (`List [`String "string"; `String "null"]))]));
+               ("age", (`Assoc [("type", (`String "integer"))]));
+               ("name", (`Assoc [("type", (`String "string"))]))]));
+          ("required",
+            (`List
+               [`String "retreat_address";
+               `String "work_address";
+               `String "home_address";
+               `String "email";
+               `String "age";
+               `String "name"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "tt" =
@@ -2893,10 +3088,20 @@ type c = char[@@deriving jsonschema]
 include
   struct
     let c_jsonschema =
-      `Assoc
-        [("type", (`String "string"));
-        ("minLength", (`Int 1));
-        ("maxLength", (`Int 1))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "string"));
+          ("minLength", (`Int 1));
+          ("maxLength", (`Int 1))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "c" =
@@ -2917,11 +3122,21 @@ type variant_inline_record =
 include
   struct
     let variant_inline_record_jsonschema =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc [("const", (`String "A"))];
-              `Assoc [("const", (`String "B"))]]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "A"))];
+                `Assoc [("const", (`String "B"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "variant_inline_record" =
@@ -2942,43 +3157,54 @@ type inline_record_with_extra_fields =
 include
   struct
     let inline_record_with_extra_fields_jsonschema =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc
-                 [("type", (`String "array"));
-                 ("prefixItems",
-                   (`List
-                      [`Assoc [("const", (`String "User"))];
-                      `Assoc
-                        [("type", (`String "object"));
-                        ("properties",
-                          (`Assoc
-                             [("email",
-                                (`Assoc [("type", (`String "string"))]));
-                             ("name",
-                               (`Assoc [("type", (`String "string"))]))]));
-                        ("required",
-                          (`List [`String "email"; `String "name"]));
-                        ("additionalProperties", (`Bool true))]]));
-                 ("unevaluatedItems", (`Bool false));
-                 ("minItems", (`Int 2));
-                 ("maxItems", (`Int 2))];
-              `Assoc
-                [("type", (`String "array"));
-                ("prefixItems",
-                  (`List
-                     [`Assoc [("const", (`String "Guest"))];
-                     `Assoc
-                       [("type", (`String "object"));
-                       ("properties",
-                         (`Assoc
-                            [("ip", (`Assoc [("type", (`String "string"))]))]));
-                       ("required", (`List [`String "ip"]));
-                       ("additionalProperties", (`Bool false))]]));
-                ("unevaluatedItems", (`Bool false));
-                ("minItems", (`Int 2));
-                ("maxItems", (`Int 2))]]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "User"))];
+                        `Assoc
+                          [("type", (`String "object"));
+                          ("properties",
+                            (`Assoc
+                               [("email",
+                                  (`Assoc [("type", (`String "string"))]));
+                               ("name",
+                                 (`Assoc [("type", (`String "string"))]))]));
+                          ("required",
+                            (`List [`String "email"; `String "name"]));
+                          ("additionalProperties", (`Bool true))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Guest"))];
+                       `Assoc
+                         [("type", (`String "object"));
+                         ("properties",
+                           (`Assoc
+                              [("ip",
+                                 (`Assoc [("type", (`String "string"))]))]));
+                         ("required", (`List [`String "ip"]));
+                         ("additionalProperties", (`Bool false))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "inline_record_with_extra_fields" =
@@ -3032,13 +3258,23 @@ type variant_with_payload =
 include
   struct
     let variant_with_payload_jsonschema =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc [("const", (`String "A"))];
-              `Assoc [("const", (`String "B"))];
-              `Assoc [("const", (`String "C"))];
-              `Assoc [("const", (`String "D"))]]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "A"))];
+                `Assoc [("const", (`String "B"))];
+                `Assoc [("const", (`String "C"))];
+                `Assoc [("const", (`String "D"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "variant_with_payload" =
@@ -3058,25 +3294,35 @@ type t1 =
 include
   struct
     let t1_jsonschema =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc
-                 [("type", (`String "array"));
-                 ("prefixItems",
-                   (`List [`Assoc [("const", (`String "Typ"))]]));
-                 ("unevaluatedItems", (`Bool false));
-                 ("minItems", (`Int 1));
-                 ("maxItems", (`Int 1))];
-              `Assoc
-                [("type", (`String "array"));
-                ("prefixItems",
-                  (`List
-                     [`Assoc [("const", (`String "Class"))];
-                     `Assoc [("type", (`String "string"))]]));
-                ("unevaluatedItems", (`Bool false));
-                ("minItems", (`Int 2));
-                ("maxItems", (`Int 2))]]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Typ"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Class"))];
+                       `Assoc [("type", (`String "string"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "t1" =
@@ -3109,11 +3355,21 @@ type t2 =
 include
   struct
     let t2_jsonschema =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc [("const", (`String "Typ"))];
-              `Assoc [("const", (`String "Class"))]]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "Typ"))];
+                `Assoc [("const", (`String "Class"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "t2" =
@@ -3131,25 +3387,35 @@ type t3 =
 include
   struct
     let t3_jsonschema =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc
-                 [("type", (`String "array"));
-                 ("prefixItems",
-                   (`List [`Assoc [("const", (`String "type"))]]));
-                 ("unevaluatedItems", (`Bool false));
-                 ("minItems", (`Int 1));
-                 ("maxItems", (`Int 1))];
-              `Assoc
-                [("type", (`String "array"));
-                ("prefixItems",
-                  (`List
-                     [`Assoc [("const", (`String "class"))];
-                     `Assoc [("type", (`String "string"))]]));
-                ("unevaluatedItems", (`Bool false));
-                ("minItems", (`Int 2));
-                ("maxItems", (`Int 2))]]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "type"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "class"))];
+                       `Assoc [("type", (`String "string"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "t3" =
@@ -3180,15 +3446,25 @@ type t4 = (int * string)[@@deriving jsonschema]
 include
   struct
     let t4_jsonschema =
-      `Assoc
-        [("type", (`String "array"));
-        ("prefixItems",
-          (`List
-             [`Assoc [("type", (`String "integer"))];
-             `Assoc [("type", (`String "string"))]]));
-        ("unevaluatedItems", (`Bool false));
-        ("minItems", (`Int 2));
-        ("maxItems", (`Int 2))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "array"));
+          ("prefixItems",
+            (`List
+               [`Assoc [("type", (`String "integer"))];
+               `Assoc [("type", (`String "string"))]]));
+          ("unevaluatedItems", (`Bool false));
+          ("minItems", (`Int 2));
+          ("maxItems", (`Int 2))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "t4" =
@@ -3207,20 +3483,30 @@ type t5 = [ `A of (int * string * bool) ][@@deriving jsonschema]
 include
   struct
     let t5_jsonschema =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc
-                 [("type", (`String "array"));
-                 ("prefixItems",
-                   (`List
-                      [`Assoc [("const", (`String "A"))];
-                      `Assoc [("type", (`String "integer"))];
-                      `Assoc [("type", (`String "string"))];
-                      `Assoc [("type", (`String "boolean"))]]));
-                 ("unevaluatedItems", (`Bool false));
-                 ("minItems", (`Int 4));
-                 ("maxItems", (`Int 4))]]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        `Assoc [("type", (`String "integer"))];
+                        `Assoc [("type", (`String "string"))];
+                        `Assoc [("type", (`String "boolean"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 4));
+                   ("maxItems", (`Int 4))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "t5" =
@@ -3249,28 +3535,38 @@ type t6 = [ `A of ((int * string * bool) * float) ][@@deriving jsonschema]
 include
   struct
     let t6_jsonschema =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc
-                 [("type", (`String "array"));
-                 ("prefixItems",
-                   (`List
-                      [`Assoc [("const", (`String "A"))];
-                      `Assoc
-                        [("type", (`String "array"));
-                        ("prefixItems",
-                          (`List
-                             [`Assoc [("type", (`String "integer"))];
-                             `Assoc [("type", (`String "string"))];
-                             `Assoc [("type", (`String "boolean"))]]));
-                        ("unevaluatedItems", (`Bool false));
-                        ("minItems", (`Int 3));
-                        ("maxItems", (`Int 3))];
-                      `Assoc [("type", (`String "number"))]]));
-                 ("unevaluatedItems", (`Bool false));
-                 ("minItems", (`Int 3));
-                 ("maxItems", (`Int 3))]]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        `Assoc
+                          [("type", (`String "array"));
+                          ("prefixItems",
+                            (`List
+                               [`Assoc [("type", (`String "integer"))];
+                               `Assoc [("type", (`String "string"))];
+                               `Assoc [("type", (`String "boolean"))]]));
+                          ("unevaluatedItems", (`Bool false));
+                          ("minItems", (`Int 3));
+                          ("maxItems", (`Int 3))];
+                        `Assoc [("type", (`String "number"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 3));
+                   ("maxItems", (`Int 3))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "t6" =
@@ -3309,20 +3605,30 @@ type t7 =
 include
   struct
     let t7_jsonschema =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc
-                 [("type", (`String "array"));
-                 ("prefixItems",
-                   (`List
-                      [`Assoc [("const", (`String "A"))];
-                      `Assoc [("type", (`String "integer"))];
-                      `Assoc [("type", (`String "string"))];
-                      `Assoc [("type", (`String "boolean"))]]));
-                 ("unevaluatedItems", (`Bool false));
-                 ("minItems", (`Int 4));
-                 ("maxItems", (`Int 4))]]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        `Assoc [("type", (`String "integer"))];
+                        `Assoc [("type", (`String "string"))];
+                        `Assoc [("type", (`String "boolean"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 4));
+                   ("maxItems", (`Int 4))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "t7" =
@@ -3352,27 +3658,37 @@ type t8 =
 include
   struct
     let t8_jsonschema =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc
-                 [("type", (`String "array"));
-                 ("prefixItems",
-                   (`List
-                      [`Assoc [("const", (`String "A"))];
-                      `Assoc
-                        [("type", (`String "array"));
-                        ("prefixItems",
-                          (`List
-                             [`Assoc [("type", (`String "integer"))];
-                             `Assoc [("type", (`String "string"))];
-                             `Assoc [("type", (`String "boolean"))]]));
-                        ("unevaluatedItems", (`Bool false));
-                        ("minItems", (`Int 3));
-                        ("maxItems", (`Int 3))]]));
-                 ("unevaluatedItems", (`Bool false));
-                 ("minItems", (`Int 2));
-                 ("maxItems", (`Int 2))]]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        `Assoc
+                          [("type", (`String "array"));
+                          ("prefixItems",
+                            (`List
+                               [`Assoc [("type", (`String "integer"))];
+                               `Assoc [("type", (`String "string"))];
+                               `Assoc [("type", (`String "boolean"))]]));
+                          ("unevaluatedItems", (`Bool false));
+                          ("minItems", (`Int 3));
+                          ("maxItems", (`Int 3))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "t8" =
@@ -3410,28 +3726,38 @@ type t9 =
 include
   struct
     let t9_jsonschema =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc
-                 [("type", (`String "array"));
-                 ("prefixItems",
-                   (`List
-                      [`Assoc [("const", (`String "A"))];
-                      `Assoc
-                        [("type", (`String "array"));
-                        ("prefixItems",
-                          (`List
-                             [`Assoc [("type", (`String "integer"))];
-                             `Assoc [("type", (`String "string"))];
-                             `Assoc [("type", (`String "boolean"))]]));
-                        ("unevaluatedItems", (`Bool false));
-                        ("minItems", (`Int 3));
-                        ("maxItems", (`Int 3))];
-                      `Assoc [("type", (`String "number"))]]));
-                 ("unevaluatedItems", (`Bool false));
-                 ("minItems", (`Int 3));
-                 ("maxItems", (`Int 3))]]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        `Assoc
+                          [("type", (`String "array"));
+                          ("prefixItems",
+                            (`List
+                               [`Assoc [("type", (`String "integer"))];
+                               `Assoc [("type", (`String "string"))];
+                               `Assoc [("type", (`String "boolean"))]]));
+                          ("unevaluatedItems", (`Bool false));
+                          ("minItems", (`Int 3));
+                          ("maxItems", (`Int 3))];
+                        `Assoc [("type", (`String "number"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 3));
+                   ("maxItems", (`Int 3))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "t9" =
@@ -3469,20 +3795,30 @@ type t10 = [ `A of (int * string * bool) ][@@deriving jsonschema]
 include
   struct
     let t10_jsonschema =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc
-                 [("type", (`String "array"));
-                 ("prefixItems",
-                   (`List
-                      [`Assoc [("const", (`String "A"))];
-                      `Assoc [("type", (`String "integer"))];
-                      `Assoc [("type", (`String "string"))];
-                      `Assoc [("type", (`String "boolean"))]]));
-                 ("unevaluatedItems", (`Bool false));
-                 ("minItems", (`Int 4));
-                 ("maxItems", (`Int 4))]]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        `Assoc [("type", (`String "integer"))];
+                        `Assoc [("type", (`String "string"))];
+                        `Assoc [("type", (`String "boolean"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 4));
+                   ("maxItems", (`Int 4))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "t10" =
@@ -3513,27 +3849,37 @@ type t11 = [ `B of (int * string * bool) ][@@deriving
 include
   struct
     let t11_jsonschema =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc
-                 [("type", (`String "array"));
-                 ("prefixItems",
-                   (`List
-                      [`Assoc [("const", (`String "B"))];
-                      `Assoc
-                        [("type", (`String "array"));
-                        ("prefixItems",
-                          (`List
-                             [`Assoc [("type", (`String "integer"))];
-                             `Assoc [("type", (`String "string"))];
-                             `Assoc [("type", (`String "boolean"))]]));
-                        ("unevaluatedItems", (`Bool false));
-                        ("minItems", (`Int 3));
-                        ("maxItems", (`Int 3))]]));
-                 ("unevaluatedItems", (`Bool false));
-                 ("minItems", (`Int 2));
-                 ("maxItems", (`Int 2))]]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "B"))];
+                        `Assoc
+                          [("type", (`String "array"));
+                          ("prefixItems",
+                            (`List
+                               [`Assoc [("type", (`String "integer"))];
+                               `Assoc [("type", (`String "string"))];
+                               `Assoc [("type", (`String "boolean"))]]));
+                          ("unevaluatedItems", (`Bool false));
+                          ("minItems", (`Int 3));
+                          ("maxItems", (`Int 3))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "t11" =
@@ -3571,52 +3917,80 @@ type obj2 = {
 include
   struct
     let obj2_jsonschema =
-      `Assoc
-        [("type", (`String "object"));
-        ("properties",
-          (`Assoc [("x", (`Assoc [("type", (`String "integer"))]))]));
-        ("required", (`List [`String "x"]));
-        ("additionalProperties", (`Bool true))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc [("x", (`Assoc [("type", (`String "integer"))]))]));
+          ("required", (`List [`String "x"]));
+          ("additionalProperties", (`Bool true))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type obj1 = {
   obj2: obj2 }[@@deriving jsonschema]
 include
   struct
     let obj1_jsonschema =
-      `Assoc
-        [("type", (`String "object"));
-        ("properties",
-          (`Assoc
-             [("obj2",
-                ((match obj2_jsonschema with
-                  | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                      `Assoc
-                        (("$id",
-                           (`String "urn:jsonschema:test.ml:2107:56585"))
-                        :: (List.filter (fun (k, _) -> k <> "$id") pairs))
-                  | other -> other)))]));
-        ("required", (`List [`String "obj2"]));
-        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("obj2",
+                  ((match obj2_jsonschema with
+                    | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                        `Assoc
+                          (("$id", (`String "file://test.ml:2099:56253")) ::
+                          (List.filter (fun (k, _) -> k <> "$id") pairs))
+                    | other -> other)))]));
+          ("required", (`List [`String "obj2"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type nested_obj = {
   obj1: obj1 }[@@deriving jsonschema][@@allow_extra_fields ]
 include
   struct
     let nested_obj_jsonschema =
-      `Assoc
-        [("type", (`String "object"));
-        ("properties",
-          (`Assoc
-             [("obj1",
-                ((match obj1_jsonschema with
-                  | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                      `Assoc
-                        (("$id",
-                           (`String "urn:jsonschema:test.ml:2108:56643"))
-                        :: (List.filter (fun (k, _) -> k <> "$id") pairs))
-                  | other -> other)))]));
-        ("required", (`List [`String "obj1"]));
-        ("additionalProperties", (`Bool true))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("obj1",
+                  ((match obj1_jsonschema with
+                    | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                        `Assoc
+                          (("$id", (`String "file://test.ml:2100:56311")) ::
+                          (List.filter (fun (k, _) -> k <> "$id") pairs))
+                    | other -> other)))]));
+          ("required", (`List [`String "obj1"]));
+          ("additionalProperties", (`Bool true))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "nested_obj" =
@@ -3653,12 +4027,22 @@ include
     [%%ocaml.error
       "Ppxlib.Deriving: 'json' is not a supported type deriving generator"]
     let x_without_extra_jsonschema =
-      `Assoc
-        [("type", (`String "object"));
-        ("properties",
-          (`Assoc [("x", (`Assoc [("type", (`String "integer"))]))]));
-        ("required", (`List [`String "x"]));
-        ("additionalProperties", (`Bool true))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc [("x", (`Assoc [("type", (`String "integer"))]))]));
+          ("required", (`List [`String "x"]));
+          ("additionalProperties", (`Bool true))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type x_with_extra = {
   x: int ;
@@ -3668,14 +4052,24 @@ include
     [%%ocaml.error
       "Ppxlib.Deriving: 'json' is not a supported type deriving generator"]
     let x_with_extra_jsonschema =
-      `Assoc
-        [("type", (`String "object"));
-        ("properties",
-          (`Assoc
-             [("y", (`Assoc [("type", (`String "integer"))]));
-             ("x", (`Assoc [("type", (`String "integer"))]))]));
-        ("required", (`List [`String "y"; `String "x"]));
-        ("additionalProperties", (`Bool true))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("y", (`Assoc [("type", (`String "integer"))]));
+               ("x", (`Assoc [("type", (`String "integer"))]))]));
+          ("required", (`List [`String "y"; `String "x"]));
+          ("additionalProperties", (`Bool true))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "extra_fields" =
@@ -3690,21 +4084,26 @@ type 'url generic_link_traffic = {
 include
   struct
     let generic_link_traffic_jsonschema url =
-      `Assoc
-        [("type", (`String "object"));
-        ("properties",
-          (`Assoc
-             [("url", url);
-             ("title",
-               ((match `Assoc [("type", (`String "string"))] with
-                 | `Assoc (("type", `String t)::[]) ->
-                     `Assoc [("type", (`List [`String t; `String "null"]))]
-                 | s ->
-                     `Assoc
-                       [("anyOf",
-                          (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
-        ("required", (`List [`String "url"; `String "title"]));
-        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("url", url);
+               ("title",
+                 (`Assoc
+                    [("type", (`List [`String "string"; `String "null"]))]))]));
+          ("required", (`List [`String "url"; `String "title"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "parameterized_record" =
@@ -3726,13 +4125,23 @@ type string_link_traffic = string generic_link_traffic[@@deriving jsonschema]
 include
   struct
     let string_link_traffic_jsonschema =
-      match generic_link_traffic_jsonschema
-              (`Assoc [("type", (`String "string"))])
-      with
-      | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-          `Assoc (("$id", (`String "urn:jsonschema:test.ml:2182:58623")) ::
-            (List.filter (fun (k, _) -> k <> "$id") pairs))
-      | other -> other[@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match generic_link_traffic_jsonschema
+                (`Assoc [("type", (`String "string"))])
+        with
+        | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+            `Assoc (("$id", (`String "file://test.ml:2174:58291")) ::
+              (List.filter (fun (k, _) -> k <> "$id") pairs))
+        | other -> other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "instantiated_parameterized_record" =
@@ -3756,22 +4165,33 @@ type 'a poly_variant =
 include
   struct
     let poly_variant_jsonschema a =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc
-                 [("type", (`String "array"));
-                 ("prefixItems", (`List [`Assoc [("const", (`String "A"))]]));
-                 ("unevaluatedItems", (`Bool false));
-                 ("minItems", (`Int 1));
-                 ("maxItems", (`Int 1))];
-              `Assoc
-                [("type", (`String "array"));
-                ("prefixItems",
-                  (`List [`Assoc [("const", (`String "B"))]; a]));
-                ("unevaluatedItems", (`Bool false));
-                ("minItems", (`Int 2));
-                ("maxItems", (`Int 2))]]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "A"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "B"))]; a]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "parameterized_variant" =
@@ -3804,16 +4224,26 @@ type ('a, 'b) multi_param = {
 include
   struct
     let multi_param_jsonschema a b =
-      `Assoc
-        [("type", (`String "object"));
-        ("properties",
-          (`Assoc
-             [("label", (`Assoc [("type", (`String "string"))]));
-             ("second", b);
-             ("first", a)]));
-        ("required",
-          (`List [`String "label"; `String "second"; `String "first"]));
-        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("label", (`Assoc [("type", (`String "string"))]));
+               ("second", b);
+               ("first", a)]));
+          ("required",
+            (`List [`String "label"; `String "second"; `String "first"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "multi_param" =
@@ -3835,7 +4265,16 @@ type 'a param_list = 'a list[@@deriving jsonschema]
 include
   struct
     let param_list_jsonschema a =
-      `Assoc [("type", (`String "array")); ("items", a)][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result = `Assoc [("type", (`String "array")); ("items", a)] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "parameterized_abstract" =
@@ -3853,23 +4292,33 @@ type ('a, 'b) either =
 include
   struct
     let either_jsonschema a b =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc
-                 [("type", (`String "array"));
-                 ("prefixItems",
-                   (`List [`Assoc [("const", (`String "Left"))]; a]));
-                 ("unevaluatedItems", (`Bool false));
-                 ("minItems", (`Int 2));
-                 ("maxItems", (`Int 2))];
-              `Assoc
-                [("type", (`String "array"));
-                ("prefixItems",
-                  (`List [`Assoc [("const", (`String "Right"))]; b]));
-                ("unevaluatedItems", (`Bool false));
-                ("minItems", (`Int 2));
-                ("maxItems", (`Int 2))]]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Left"))]; a]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "Right"))]; b]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "multi_param_variant" =
@@ -3900,11 +4349,21 @@ type ('a, 'b) either_alias = ('a, 'b) either[@@deriving jsonschema]
 include
   struct
     let either_alias_jsonschema a b =
-      match either_jsonschema a b with
-      | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-          `Assoc (("$id", (`String "urn:jsonschema:test.ml:2294:61412")) ::
-            (List.filter (fun (k, _) -> k <> "$id") pairs))
-      | other -> other[@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match either_jsonschema a b with
+        | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+            `Assoc (("$id", (`String "file://test.ml:2286:61080")) ::
+              (List.filter (fun (k, _) -> k <> "$id") pairs))
+        | other -> other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "multi_param_abstract" =
@@ -3937,11 +4396,21 @@ type ('a, 'b) direction =
 include
   struct
     let direction_jsonschema _a _b =
-      `Assoc
-        [("anyOf",
-           (`List
-              [`Assoc [("const", (`String "North"))];
-              `Assoc [("const", (`String "South"))]]))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "North"))];
+                `Assoc [("const", (`String "South"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "multi_param_variant_as_string" =
@@ -3961,39 +4430,37 @@ type nullable_fields =
 include
   struct
     let nullable_fields_jsonschema =
-      `Assoc
-        [("type", (`String "object"));
-        ("properties",
-          (`Assoc
-             [("drop_complex",
-                ((match `Assoc
-                          [("type", (`String "array"));
-                          ("items", (`Assoc [("type", (`String "integer"))]))]
-                  with
-                  | `Assoc (("type", `String t)::[]) ->
-                      `Assoc [("type", (`List [`String t; `String "null"]))]
-                  | s ->
-                      `Assoc
-                        [("anyOf",
-                           (`List [s; `Assoc [("type", (`String "null"))]]))])));
-             ("drop_simple",
-               ((match `Assoc [("type", (`String "string"))] with
-                 | `Assoc (("type", `String t)::[]) ->
-                     `Assoc [("type", (`List [`String t; `String "null"]))]
-                 | s ->
-                     `Assoc
-                       [("anyOf",
-                          (`List [s; `Assoc [("type", (`String "null"))]]))])));
-             ("plain",
-               ((match `Assoc [("type", (`String "string"))] with
-                 | `Assoc (("type", `String t)::[]) ->
-                     `Assoc [("type", (`List [`String t; `String "null"]))]
-                 | s ->
-                     `Assoc
-                       [("anyOf",
-                          (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
-        ("required", (`List [`String "plain"]));
-        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("drop_complex",
+                  (`Assoc
+                     [("anyOf",
+                        (`List
+                           [`Assoc
+                              [("type", (`String "array"));
+                              ("items",
+                                (`Assoc [("type", (`String "integer"))]))];
+                           `Assoc [("type", (`String "null"))]]))]));
+               ("drop_simple",
+                 (`Assoc
+                    [("type", (`List [`String "string"; `String "null"]))]));
+               ("plain",
+                 (`Assoc
+                    [("type", (`List [`String "string"; `String "null"]))]))]));
+          ("required", (`List [`String "plain"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "nullable_fields" =
@@ -4028,28 +4495,37 @@ type composing_record =
 include
   struct
     let composing_record_jsonschema =
-      `Assoc
-        [("type", (`String "object"));
-        ("properties",
-          (`Assoc
-             [("composing_type",
-                ((match match composing_type_jsonschema with
-                        | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                            `Assoc
-                              (("$id",
-                                 (`String "urn:jsonschema:test.ml:2368:63427"))
-                              ::
-                              (List.filter (fun (k, _) -> k <> "$id") pairs))
-                        | other -> other
-                  with
-                  | `Assoc (("type", `String t)::[]) ->
-                      `Assoc [("type", (`List [`String t; `String "null"]))]
-                  | s ->
-                      `Assoc
-                        [("anyOf",
-                           (`List [s; `Assoc [("type", (`String "null"))]]))])))]));
-        ("required", (`List []));
-        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("composing_type",
+                  (`Assoc
+                     [("anyOf",
+                        (`List
+                           [(match composing_type_jsonschema with
+                             | `Assoc pairs when List.mem_assoc "$defs" pairs
+                                 ->
+                                 `Assoc
+                                   (("$id",
+                                      (`String "file://test.ml:2360:63095"))
+                                   ::
+                                   (List.filter (fun (k, _) -> k <> "$id")
+                                      pairs))
+                             | other -> other);
+                           `Assoc [("type", (`String "null"))]]))]))]));
+          ("required", (`List []));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "nullable_option_composing" =
@@ -4082,7 +4558,7 @@ include
   struct
     let grade_jsonschema a =
       let ppx_eds = ref [] in
-      let ppx_body =
+      let ppx_body_grade =
         `Assoc
           [("anyOf",
              (`List
@@ -4118,8 +4594,7 @@ include
                   ("minItems", (`Int 1));
                   ("maxItems", (`Int 1))]]))] in
       `Assoc
-        [("$id", (`String "urn:jsonschema:grade"));
-        ("$defs", (`Assoc (("grade", ppx_body) :: (!ppx_eds))));
+        [("$defs", (`Assoc ([("grade", ppx_body_grade)] @ (!ppx_eds))));
         ("$ref", (`String "#/$defs/grade"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -4129,7 +4604,6 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:grade",
       "$defs": {
         "grade": {
           "anyOf": [
@@ -4177,7 +4651,7 @@ include
   struct
     let self_ref_jsonschema =
       let ppx_eds = ref [] in
-      let ppx_body =
+      let ppx_body_self_ref =
         `Assoc
           [("type", (`String "object"));
           ("properties",
@@ -4190,8 +4664,7 @@ include
           ("required", (`List [`String "children"]));
           ("additionalProperties", (`Bool false))] in
       `Assoc
-        [("$id", (`String "urn:jsonschema:self_ref"));
-        ("$defs", (`Assoc (("self_ref", ppx_body) :: (!ppx_eds))));
+        [("$defs", (`Assoc ([("self_ref", ppx_body_self_ref)] @ (!ppx_eds))));
         ("$ref", (`String "#/$defs/self_ref"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type two_self_refs = {
@@ -4200,28 +4673,35 @@ type two_self_refs = {
 include
   struct
     let two_self_refs_jsonschema =
-      `Assoc
-        [("type", (`String "object"));
-        ("properties",
-          (`Assoc
-             [("b",
-                ((match self_ref_jsonschema with
-                  | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                      `Assoc
-                        (("$id",
-                           (`String "urn:jsonschema:test.ml:2455:65717"))
-                        :: (List.filter (fun (k, _) -> k <> "$id") pairs))
-                  | other -> other)));
-             ("a",
-               ((match self_ref_jsonschema with
-                 | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                     `Assoc
-                       (("$id",
-                          (`String "urn:jsonschema:test.ml:2454:65701"))
-                       :: (List.filter (fun (k, _) -> k <> "$id") pairs))
-                 | other -> other)))]));
-        ("required", (`List [`String "b"; `String "a"]));
-        ("additionalProperties", (`Bool false))][@@warning "-32-39"]
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("b",
+                  ((match self_ref_jsonschema with
+                    | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                        `Assoc
+                          (("$id", (`String "file://test.ml:2446:65348")) ::
+                          (List.filter (fun (k, _) -> k <> "$id") pairs))
+                    | other -> other)));
+               ("a",
+                 ((match self_ref_jsonschema with
+                   | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                       `Assoc (("$id", (`String "file://test.ml:2445:65332"))
+                         :: (List.filter (fun (k, _) -> k <> "$id") pairs))
+                   | other -> other)))]));
+          ("required", (`List [`String "b"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "no_duplicate_id_when_recursive_type_used_twice" =
@@ -4233,7 +4713,7 @@ include
       "type": "object",
       "properties": {
         "b": {
-          "$id": "urn:jsonschema:test/test.ml:2455:65717",
+          "$id": "file://test/test.ml:2446:65348",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -4250,7 +4730,7 @@ include
           "$ref": "#/$defs/self_ref"
         },
         "a": {
-          "$id": "urn:jsonschema:test/test.ml:2454:65701",
+          "$id": "file://test/test.ml:2445:65332",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -4279,7 +4759,7 @@ include
   struct
     let filter_jsonschema atom group_atom =
       let ppx_eds = ref [] in
-      let ppx_body =
+      let ppx_body_filter =
         `Assoc
           [("anyOf",
              (`List
@@ -4304,8 +4784,7 @@ include
                   ("minItems", (`Int 3));
                   ("maxItems", (`Int 3))]]))] in
       `Assoc
-        [("$id", (`String "urn:jsonschema:filter"));
-        ("$defs", (`Assoc (("filter", ppx_body) :: (!ppx_eds))));
+        [("$defs", (`Assoc ([("filter", ppx_body_filter)] @ (!ppx_eds))));
         ("$ref", (`String "#/$defs/filter"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type ('atom, 'group_atom) bool_filter =
@@ -4316,7 +4795,7 @@ include
   struct
     let bool_filter_jsonschema atom group_atom =
       let ppx_eds = ref [] in
-      let ppx_body =
+      let ppx_body_bool_filter =
         `Assoc
           [("anyOf",
              (`List
@@ -4329,8 +4808,7 @@ include
                          | `Assoc pairs when List.mem_assoc "$defs" pairs ->
                              `Assoc
                                (("$id",
-                                  (`String
-                                     "urn:jsonschema:test.ml:2514:67367"))
+                                  (`String "file://test.ml:2505:66982"))
                                ::
                                (List.filter (fun (k, _) -> k <> "$id") pairs))
                          | other -> other)]));
@@ -4351,8 +4829,8 @@ include
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
       `Assoc
-        [("$id", (`String "urn:jsonschema:bool_filter"));
-        ("$defs", (`Assoc (("bool_filter", ppx_body) :: (!ppx_eds))));
+        [("$defs",
+           (`Assoc ([("bool_filter", ppx_body_bool_filter)] @ (!ppx_eds))));
         ("$ref", (`String "#/$defs/bool_filter"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -4362,7 +4840,6 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:filter",
       "$defs": {
         "filter": {
           "anyOf": [
@@ -4397,7 +4874,7 @@ include
   struct
     let rec_wrapper_jsonschema a =
       let ppx_eds = ref [] in
-      let ppx_body =
+      let ppx_body_rec_wrapper =
         `Assoc
           [("anyOf",
              (`List
@@ -4418,8 +4895,8 @@ include
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
       `Assoc
-        [("$id", (`String "urn:jsonschema:rec_wrapper"));
-        ("$defs", (`Assoc (("rec_wrapper", ppx_body) :: (!ppx_eds))));
+        [("$defs",
+           (`Assoc ([("rec_wrapper", ppx_body_rec_wrapper)] @ (!ppx_eds))));
         ("$ref", (`String "#/$defs/rec_wrapper"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type outer_rec =
@@ -4429,7 +4906,7 @@ include
   struct
     let outer_rec_jsonschema =
       let ppx_eds = ref [] in
-      let ppx_body =
+      let ppx_body_outer_rec =
         `Assoc
           [("anyOf",
              (`List
@@ -4452,28 +4929,26 @@ include
                                    [("$ref", (`String "#/$defs/outer_rec"))])
                         with
                         | `Assoc ppx_pairs ->
-                            (match List.assoc_opt "$defs" ppx_pairs with
-                             | Some (`Assoc ppx_defs) ->
-                                 (ppx_eds :=
+                            ((match List.assoc_opt "$defs" ppx_pairs with
+                              | Some (`Assoc ppx_defs) ->
+                                  ppx_eds :=
                                     ((!ppx_eds) @
                                        (List.filter
                                           (fun (n, _) ->
                                              not
                                                (List.mem_assoc n (!ppx_eds)))
-                                          ppx_defs));
-                                  `Assoc
-                                    (List.filter
-                                       (fun (k, _) ->
-                                          (k <> "$id") && (k <> "$defs"))
-                                       ppx_pairs))
-                             | _ -> `Assoc ppx_pairs)
+                                          ppx_defs))
+                              | _ -> ());
+                             `Assoc
+                               (List.filter (fun (k, _) -> k <> "$defs")
+                                  ppx_pairs))
                         | ppx_other -> ppx_other)]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
       `Assoc
-        [("$id", (`String "urn:jsonschema:outer_rec"));
-        ("$defs", (`Assoc (("outer_rec", ppx_body) :: (!ppx_eds))));
+        [("$defs",
+           (`Assoc ([("outer_rec", ppx_body_outer_rec)] @ (!ppx_eds))));
         ("$ref", (`String "#/$defs/outer_rec"))][@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
@@ -4483,7 +4958,6 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:outer_rec",
       "$defs": {
         "outer_rec": {
           "anyOf": [
@@ -4538,7 +5012,6 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:bool_filter",
       "$defs": {
         "bool_filter": {
           "anyOf": [
@@ -4547,7 +5020,7 @@ include
               "prefixItems": [
                 { "const": "BoolAtom" },
                 {
-                  "$id": "urn:jsonschema:test/test.ml:2514:67367",
+                  "$id": "file://test/test.ml:2505:66982",
                   "$defs": {
                     "filter": {
                       "anyOf": [

--- a/test/test.ml
+++ b/test/test.ml
@@ -484,7 +484,6 @@ let%expect_test "recursive_record" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:recursive_record",
       "$defs": {
         "recursive_record": {
           "type": "object",
@@ -514,7 +513,6 @@ let%expect_test "recursive_variant" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:recursive_variant",
       "$defs": {
         "recursive_variant": {
           "anyOf": [
@@ -557,7 +555,6 @@ let%expect_test "tree" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:tree",
       "$defs": {
         "tree": {
           "anyOf": [
@@ -624,7 +621,6 @@ let%expect_test "mutually_recursive_foo" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:foo",
       "$defs": {
         "foo": {
           "type": "object",
@@ -653,7 +649,6 @@ let%expect_test "mutually_recursive_bar" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:bar",
       "$defs": {
         "foo": {
           "type": "object",
@@ -697,7 +692,6 @@ let%expect_test "mutually_recursive_expr" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:expr",
       "$defs": {
         "expr": {
           "anyOf": [
@@ -821,7 +815,6 @@ let%expect_test "three_way_mutual_recursion" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:node_a",
       "$defs": {
         "node_a": {
           "type": "object",
@@ -879,7 +872,6 @@ let%expect_test "recursive_tuple" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:recursive_tuple",
       "$defs": {
         "recursive_tuple": {
           "anyOf": [
@@ -925,7 +917,7 @@ let%expect_test "recursive_abstract_alias" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:test/test.ml:920:23215",
+      "$id": "file://test/test.ml:912:22891",
       "$defs": {
         "tree": {
           "anyOf": [
@@ -2404,7 +2396,6 @@ let%expect_test "grade" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:grade",
       "$defs": {
         "grade": {
           "anyOf": [
@@ -2465,7 +2456,7 @@ let%expect_test "no_duplicate_id_when_recursive_type_used_twice" =
       "type": "object",
       "properties": {
         "b": {
-          "$id": "urn:jsonschema:test/test.ml:2455:65717",
+          "$id": "file://test/test.ml:2446:65348",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -2482,7 +2473,7 @@ let%expect_test "no_duplicate_id_when_recursive_type_used_twice" =
           "$ref": "#/$defs/self_ref"
         },
         "a": {
-          "$id": "urn:jsonschema:test/test.ml:2454:65701",
+          "$id": "file://test/test.ml:2445:65332",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -2521,7 +2512,6 @@ let%expect_test "polymorphic_recursive_ref" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:filter",
       "$defs": {
         "filter": {
           "anyOf": [
@@ -2568,7 +2558,6 @@ let%expect_test "parametric_recursive_cross_ref" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:outer_rec",
       "$defs": {
         "outer_rec": {
           "anyOf": [
@@ -2623,7 +2612,6 @@ let%expect_test "polymorphic_recursive_ref_bool_filter" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "urn:jsonschema:bool_filter",
       "$defs": {
         "bool_filter": {
           "anyOf": [
@@ -2632,7 +2620,7 @@ let%expect_test "polymorphic_recursive_ref_bool_filter" =
               "prefixItems": [
                 { "const": "BoolAtom" },
                 {
-                  "$id": "urn:jsonschema:test/test.ml:2514:67367",
+                  "$id": "file://test/test.ml:2505:66982",
                   "$defs": {
                     "filter": {
                       "anyOf": [


### PR DESCRIPTION
## Summary

- Restructures the PPX driver from large functions to split well-named ones.
- Extracts attribute declarations and deriver args into a new `Attrs` module ([src/attrs.ml](src/attrs.ml)) and schema construction helpers into a new `Schema` module ([src/schema.ml](src/schema.ml)), reducing the size of the main deriver file and improving separation of concerns.
