### PR TITLE
Refactor schema annotation helpers and add format/description on core types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,7 @@
 # Next release
+- add `[@@jsonschema.format]` attribute to add a format to a type or a field; now also supported on core types (e.g. variant payloads: `A of (string[@jsonschema.format "date-time"])`); validated to only apply to `string` and `bytes` types
+- add `[@@jsonschema.description]` attribute to add a description to a type or a field; now also supported on core types (e.g. variant payloads and inline type annotations)
+- add `[@jsonschema.attrs]` composite attribute to bundle multiple schema annotations in a single record expression (e.g. `[@jsonschema.attrs { maximum = 100; minimum = 0; description = "Score out of 100" }]`); supported on core types, label declarations, and type declarations
 - make option types nullable in generated JSON Schema (e.g. `int option` → `{"type":["integer","null"]}`); add `[@@jsonschema.option]` attribute to opt a field out of `required` without making its type nullable
 - fix schema generation for parametric recursive types (e.g. `type 'a t = ... | B of 'a t`)
 - fix broken `$ref` scoping when a recursive type uses a parametric recursive type with itself as a type argument (e.g. `type t = ... | N of t wrapper` where `wrapper` is also recursive); inner `$defs` are now hoisted into the root schema's `$defs` namespace

--- a/README.md
+++ b/README.md
@@ -553,3 +553,123 @@ The secondary type `stmt_jsonschema` is also a self-contained schema, with the s
   "$ref": "#/$defs/stmt"
 }
 ```
+
+
+### Annotations
+
+#### `[@@jsonschema.description]` ([REF](https://www.learnjsonschema.com/2020-12/meta-data/description/))
+
+Add a description to a type or a field. It can be used on a type, a field, a variant constructor, or directly on a core type (e.g. a variant payload).
+
+```ocaml
+type t = {
+  name : string [@jsonschema.description "The user's full name"];
+} [@@deriving jsonschema]
+```
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": { "description": "The user's full name", "type": "string" }
+  },
+  "required": [ "name" ],
+  "additionalProperties": false
+}
+```
+
+#### `[@@jsonschema.format]` ([REF](https://www.learnjsonschema.com/2020-12/format-annotation/))
+
+Add a format annotation to a string-typed field. It can be used on a type, a field, or directly on a core type (e.g. a variant payload). Only applies to `string` and `bytes` types.
+
+```ocaml
+type t = {
+  name : string [@jsonschema.format "date-time"]; 
+} [@@deriving jsonschema]
+```
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": { "format": "date-time", "type": "string" }
+  },
+  "required": [ "name" ],
+  "additionalProperties": false
+}
+```
+
+#### `[@@jsonschema.maximum]` ([REF](https://www.learnjsonschema.com/2020-12/validation/maximum/))
+
+Add a maximum value to a type or a field. It can be used on a type, a field, or a variant payload. Only applies to numeric types (`int`, `int32`, `nativeint`, `float`).
+
+```ocaml
+type t = {
+  score : int [@jsonschema.maximum 100];
+} [@@deriving jsonschema]
+```
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "score": { "maximum": 100, "type": "integer" }
+  },
+  "required": [ "score" ],
+  "additionalProperties": false
+}
+```
+
+#### `[@@jsonschema.minimum]` ([REF](https://www.learnjsonschema.com/2020-12/validation/minimum/))
+
+Add a minimum value to a type or a field. It can be used on a type, a field, or a variant payload. Only applies to numeric types (`int`, `int32`, `nativeint`, `float`).
+
+```ocaml
+type t = {
+  score : int [@jsonschema.minimum 0];
+} [@@deriving jsonschema]
+```
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "score": { "minimum": 0, "type": "integer" }
+  },
+  "required": [ "score" ],
+  "additionalProperties": false
+}
+```
+
+#### `[@jsonschema.attrs]`
+
+A composite annotation that bundles multiple schema attributes into a single record expression. Supported fields: `description`, `format`, `maximum`, `minimum`. Type-sensitive fields (`format`, `maximum`, `minimum`) are validated against the annotated type.
+
+Can be used on core types, label declarations, and type declarations.
+
+```ocaml
+type t = {
+  score : int [@jsonschema.attrs { maximum = 100; minimum = 0; description = "Score out of 100" }];
+  created_at : string [@jsonschema.attrs { format = "date-time"; description = "Creation timestamp" }];
+} [@@deriving jsonschema]
+```
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "score": { "minimum": 0, "maximum": 100, "description": "Score out of 100", "type": "integer" },
+    "created_at": { "format": "date-time", "description": "Creation timestamp", "type": "string" }
+  },
+  "required": [ "score", "created_at" ],
+  "additionalProperties": false
+}
+```
+
+It can also be applied directly to a core type in a variant payload:
+
+```ocaml
+type t =
+  | Score of (int [@jsonschema.attrs { maximum = 100; minimum = 0; description = "Percentage" }])
+[@@deriving jsonschema]
+```

--- a/src/attrs.ml
+++ b/src/attrs.ml
@@ -57,6 +57,26 @@ let jsonschema_cd_description =
     Ast_pattern.(single_expr_payload (estring __'))
     (fun x -> x)
 
+let jsonschema_ct_description =
+  Attribute.declare "jsonschema.description" Attribute.Context.core_type
+    Ast_pattern.(single_expr_payload (estring __'))
+    (fun x -> x)
+
+let jsonschema_td_format =
+  Attribute.declare "jsonschema.format" Attribute.Context.type_declaration
+    Ast_pattern.(single_expr_payload (estring __'))
+    (fun x -> x)
+
+let jsonschema_ld_format =
+  Attribute.declare "jsonschema.format" Attribute.Context.label_declaration
+    Ast_pattern.(single_expr_payload (estring __'))
+    (fun x -> x)
+
+let jsonschema_ct_format =
+  Attribute.declare "jsonschema.format" Attribute.Context.core_type
+    Ast_pattern.(single_expr_payload (estring __'))
+    (fun x -> x)
+
 let attributes =
   [
     Attribute.T jsonschema_key;
@@ -69,6 +89,10 @@ let attributes =
     Attribute.T jsonschema_ld_description;
     Attribute.T jsonschema_td_description;
     Attribute.T jsonschema_cd_description;
+    Attribute.T jsonschema_td_format;
+    Attribute.T jsonschema_ld_format;
+    Attribute.T jsonschema_ct_format;
+    Attribute.T jsonschema_ct_description;
   ]
 
 let args () = Deriving.Args.(empty +> flag "variant_as_string" +> flag "polymorphic_variant_tuple")

--- a/src/attrs.ml
+++ b/src/attrs.ml
@@ -10,25 +10,14 @@ type config = {
         This option breaks compatibility with yojson derivers. *)
 }
 
-let jsonschema_key =
-  Attribute.declare "jsonschema.key" Attribute.Context.label_declaration
-    Ast_pattern.(single_expr_payload (estring __'))
-    (fun x -> x)
+let string_attr name ctx = Attribute.declare name ctx Ast_pattern.(single_expr_payload (estring __')) (fun x -> x)
 
-let jsonschema_ref =
-  Attribute.declare "jsonschema.ref" Attribute.Context.label_declaration
-    Ast_pattern.(single_expr_payload (estring __'))
-    (fun x -> x)
+let expr_attr name ctx = Attribute.declare name ctx Ast_pattern.(single_expr_payload __) (fun x -> x)
 
-let jsonschema_variant_name =
-  Attribute.declare "jsonschema.name" Attribute.Context.constructor_declaration
-    Ast_pattern.(single_expr_payload (estring __'))
-    (fun x -> x)
-
-let jsonschema_polymorphic_variant_name =
-  Attribute.declare "jsonschema.name" Attribute.Context.rtag
-    Ast_pattern.(single_expr_payload (estring __'))
-    (fun x -> x)
+let jsonschema_key = string_attr "jsonschema.key" Attribute.Context.label_declaration
+let jsonschema_ref = string_attr "jsonschema.ref" Attribute.Context.label_declaration
+let jsonschema_variant_name = string_attr "jsonschema.name" Attribute.Context.constructor_declaration
+let jsonschema_polymorphic_variant_name = string_attr "jsonschema.name" Attribute.Context.rtag
 
 let jsonschema_td_allow_extra_fields =
   Attribute.declare "jsonschema.allow_extra_fields" Attribute.Context.type_declaration
@@ -42,40 +31,22 @@ let jsonschema_cd_allow_extra_fields =
 
 let jsonschema_option = Attribute.declare_flag "jsonschema.option" Attribute.Context.label_declaration
 
-let jsonschema_ld_description =
-  Attribute.declare "jsonschema.description" Attribute.Context.label_declaration
-    Ast_pattern.(single_expr_payload (estring __'))
-    (fun x -> x)
+let jsonschema_ld_description = string_attr "jsonschema.description" Attribute.Context.label_declaration
+let jsonschema_td_description = string_attr "jsonschema.description" Attribute.Context.type_declaration
+let jsonschema_cd_description = string_attr "jsonschema.description" Attribute.Context.constructor_declaration
+let jsonschema_ct_description = string_attr "jsonschema.description" Attribute.Context.core_type
 
-let jsonschema_td_description =
-  Attribute.declare "jsonschema.description" Attribute.Context.type_declaration
-    Ast_pattern.(single_expr_payload (estring __'))
-    (fun x -> x)
+let jsonschema_td_format = string_attr "jsonschema.format" Attribute.Context.type_declaration
+let jsonschema_ld_format = string_attr "jsonschema.format" Attribute.Context.label_declaration
+let jsonschema_ct_format = string_attr "jsonschema.format" Attribute.Context.core_type
 
-let jsonschema_cd_description =
-  Attribute.declare "jsonschema.description" Attribute.Context.constructor_declaration
-    Ast_pattern.(single_expr_payload (estring __'))
-    (fun x -> x)
+let jsonschema_td_maximum = expr_attr "jsonschema.maximum" Attribute.Context.type_declaration
+let jsonschema_ld_maximum = expr_attr "jsonschema.maximum" Attribute.Context.label_declaration
+let jsonschema_ct_maximum = expr_attr "jsonschema.maximum" Attribute.Context.core_type
 
-let jsonschema_ct_description =
-  Attribute.declare "jsonschema.description" Attribute.Context.core_type
-    Ast_pattern.(single_expr_payload (estring __'))
-    (fun x -> x)
-
-let jsonschema_td_format =
-  Attribute.declare "jsonschema.format" Attribute.Context.type_declaration
-    Ast_pattern.(single_expr_payload (estring __'))
-    (fun x -> x)
-
-let jsonschema_ld_format =
-  Attribute.declare "jsonschema.format" Attribute.Context.label_declaration
-    Ast_pattern.(single_expr_payload (estring __'))
-    (fun x -> x)
-
-let jsonschema_ct_format =
-  Attribute.declare "jsonschema.format" Attribute.Context.core_type
-    Ast_pattern.(single_expr_payload (estring __'))
-    (fun x -> x)
+let jsonschema_td_minimum = expr_attr "jsonschema.minimum" Attribute.Context.type_declaration
+let jsonschema_ld_minimum = expr_attr "jsonschema.minimum" Attribute.Context.label_declaration
+let jsonschema_ct_minimum = expr_attr "jsonschema.minimum" Attribute.Context.core_type
 
 let attributes =
   [
@@ -89,10 +60,16 @@ let attributes =
     Attribute.T jsonschema_ld_description;
     Attribute.T jsonschema_td_description;
     Attribute.T jsonschema_cd_description;
+    Attribute.T jsonschema_ct_description;
     Attribute.T jsonschema_td_format;
     Attribute.T jsonschema_ld_format;
     Attribute.T jsonschema_ct_format;
-    Attribute.T jsonschema_ct_description;
+    Attribute.T jsonschema_td_maximum;
+    Attribute.T jsonschema_ld_maximum;
+    Attribute.T jsonschema_ct_maximum;
+    Attribute.T jsonschema_td_minimum;
+    Attribute.T jsonschema_ld_minimum;
+    Attribute.T jsonschema_ct_minimum;
   ]
 
 let args () = Deriving.Args.(empty +> flag "variant_as_string" +> flag "polymorphic_variant_tuple")

--- a/src/attrs.ml
+++ b/src/attrs.ml
@@ -48,6 +48,10 @@ let jsonschema_td_minimum = expr_attr "jsonschema.minimum" Attribute.Context.typ
 let jsonschema_ld_minimum = expr_attr "jsonschema.minimum" Attribute.Context.label_declaration
 let jsonschema_ct_minimum = expr_attr "jsonschema.minimum" Attribute.Context.core_type
 
+let jsonschema_ct_attrs = expr_attr "jsonschema.attrs" Attribute.Context.core_type
+let jsonschema_td_attrs = expr_attr "jsonschema.attrs" Attribute.Context.type_declaration
+let jsonschema_ld_attrs = expr_attr "jsonschema.attrs" Attribute.Context.label_declaration
+
 let attributes =
   [
     Attribute.T jsonschema_key;
@@ -70,6 +74,9 @@ let attributes =
     Attribute.T jsonschema_td_minimum;
     Attribute.T jsonschema_ld_minimum;
     Attribute.T jsonschema_ct_minimum;
+    Attribute.T jsonschema_ct_attrs;
+    Attribute.T jsonschema_td_attrs;
+    Attribute.T jsonschema_ld_attrs;
   ]
 
 let args () = Deriving.Args.(empty +> flag "variant_as_string" +> flag "polymorphic_variant_tuple")

--- a/src/attrs.mli
+++ b/src/attrs.mli
@@ -1,0 +1,35 @@
+type config = {
+  variant_as_string : bool;
+    (** Encode variants as string instead of string array.
+        This option breaks compatibility with yojson derivers and
+        doesn't support constructors with a payload. *)
+  polymorphic_variant_tuple : bool;
+    (** Preserve the implicit tuple in a polymorphic variant.
+        This option breaks compatibility with yojson derivers. *)
+}
+
+val jsonschema_key : (Ppxlib.label_declaration, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_ref : (Ppxlib.label_declaration, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_variant_name : (Ppxlib.constructor_declaration, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_polymorphic_variant_name : (Ppxlib.row_field, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_td_allow_extra_fields : (Ppxlib.type_declaration, unit -> unit) Ppxlib.Attribute.t
+val jsonschema_cd_allow_extra_fields : (Ppxlib.constructor_declaration, unit -> unit) Ppxlib.Attribute.t
+val jsonschema_option : Ppxlib.label_declaration Ppxlib.Attribute.flag
+val jsonschema_ld_description : (Ppxlib.label_declaration, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_td_description : (Ppxlib.type_declaration, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_cd_description : (Ppxlib.constructor_declaration, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_ct_description : (Ppxlib.core_type, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_td_format : (Ppxlib.type_declaration, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_ld_format : (Ppxlib.label_declaration, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_ct_format : (Ppxlib.core_type, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_td_maximum : (Ppxlib.type_declaration, Ppxlib.expression) Ppxlib.Attribute.t
+val jsonschema_ld_maximum : (Ppxlib.label_declaration, Ppxlib.expression) Ppxlib.Attribute.t
+val jsonschema_ct_maximum : (Ppxlib.core_type, Ppxlib.expression) Ppxlib.Attribute.t
+val jsonschema_td_minimum : (Ppxlib.type_declaration, Ppxlib.expression) Ppxlib.Attribute.t
+val jsonschema_ld_minimum : (Ppxlib.label_declaration, Ppxlib.expression) Ppxlib.Attribute.t
+val jsonschema_ct_minimum : (Ppxlib.core_type, Ppxlib.expression) Ppxlib.Attribute.t
+val jsonschema_ct_attrs : (Ppxlib.core_type, Ppxlib.expression) Ppxlib.Attribute.t
+val jsonschema_td_attrs : (Ppxlib.type_declaration, Ppxlib.expression) Ppxlib.Attribute.t
+val jsonschema_ld_attrs : (Ppxlib.label_declaration, Ppxlib.expression) Ppxlib.Attribute.t
+val attributes : Ppxlib.Attribute.packed list
+val args : unit -> (bool -> bool -> 'a, 'a) Ppxlib.Deriving.Args.t

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -16,73 +16,88 @@ let wrap_type_params ~loc ?(prefix = "") params body =
     (fun param body -> [%expr fun [%p ppat_var ~loc { txt = prefix ^ param; loc }] -> [%e body]])
     params body
 
+let apply_attr attr node f schema =
+  match Attribute.get attr node with
+  | Some v -> f v schema
+  | None -> schema
+
 (* schema_of_core_type and schema_of_poly_variant are mutually recursive.
    All other functions only call downward and use plain let. *)
 let rec schema_of_core_type ~(config : Attrs.config) ?(recursive_types = []) core_type =
   let loc = core_type.ptyp_loc in
-  match core_type with
-  | [%type: int] | [%type: int32] | [%type: nativeint] -> Schema.type_def ~loc "integer", false
-  | [%type: int64] ->
-    Schema.type_def ~loc "string" |> Schema.description ~loc ~description:"int64 is represented as a string", false
-  | [%type: float] -> Schema.type_def ~loc "number", false
-  | [%type: string] | [%type: bytes] -> Schema.type_def ~loc "string", false
-  | [%type: bool] -> Schema.type_def ~loc "boolean", false
-  | [%type: char] -> Schema.char ~loc, false
-  | [%type: unit] -> Schema.null ~loc, false
-  | [%type: [%t? t] option] ->
-    let s, is_rec = schema_of_core_type ~config ~recursive_types t in
-    Schema.nullable ~loc s, is_rec
-  | [%type: [%t? t] ref] -> schema_of_core_type ~config ~recursive_types t
-  | [%type: [%t? t] list] | [%type: [%t? t] array] ->
-    let t, is_rec = schema_of_core_type ~config ~recursive_types t in
-    Schema.array_ ~loc t, is_rec
-  | _ ->
-  match core_type.ptyp_desc with
-  | Ptyp_var name -> evar ~loc name, false
-  | Ptyp_constr (id, args) ->
-    (match id.txt with
-    | Lident name when List.mem name recursive_types ->
-      (* Recursive reference: emit $ref regardless of type arguments. *)
-      Schema.type_ref ~loc name, true
+  let schema, is_rec =
+    match core_type with
+    | [%type: int] | [%type: int32] | [%type: nativeint] -> Schema.type_def ~loc "integer", false
+    | [%type: int64] ->
+      ( Schema.type_def ~loc "string"
+        |> Schema.annotation ~loc ("description", [%expr `String [%e estring ~loc "int64 is represented as a string"]]),
+        false )
+    | [%type: float] -> Schema.type_def ~loc "number", false
+    | [%type: string] | [%type: bytes] -> Schema.type_def ~loc "string", false
+    | [%type: bool] -> Schema.type_def ~loc "boolean", false
+    | [%type: char] -> Schema.char ~loc, false
+    | [%type: unit] -> Schema.null ~loc, false
+    | [%type: [%t? t] option] ->
+      let s, is_rec = schema_of_core_type ~config ~recursive_types t in
+      Schema.nullable ~loc s, is_rec
+    | [%type: [%t? t] ref] -> schema_of_core_type ~config ~recursive_types t
+    | [%type: [%t? t] list] | [%type: [%t? t] array] ->
+      let t, is_rec = schema_of_core_type ~config ~recursive_types t in
+      Schema.array_ ~loc t, is_rec
     | _ ->
-      let results = List.map (schema_of_core_type ~config ~recursive_types) args in
-      let args = List.map fst results in
+    match core_type.ptyp_desc with
+    | Ptyp_var name -> evar ~loc name, false
+    | Ptyp_constr (id, args) ->
+      (match id.txt with
+      | Lident name when List.mem name recursive_types ->
+        (* Recursive reference: emit $ref regardless of type arguments. *)
+        Schema.type_ref ~loc name, true
+      | _ ->
+        let results = List.map (schema_of_core_type ~config ~recursive_types) args in
+        let args = List.map fst results in
+        let is_rec = List.exists snd results in
+        let schema = type_constr_conv ~loc id ~f:(fun s -> s ^ "_jsonschema") args in
+        let edv = evar ~loc "ppx_eds" in
+        (match is_rec with
+        | true ->
+          (* Hoist $defs from the sub-schema into the parent accumulator and strip
+             resource boundary markers ($defs), leaving just the $ref. *)
+          ( [%expr
+              match [%e schema] with
+              | `Assoc ppx_pairs ->
+                (match List.assoc_opt "$defs" ppx_pairs with
+                | Some (`Assoc ppx_defs) ->
+                  [%e edv] := ![%e edv] @ List.filter (fun (n, _) -> not (List.mem_assoc n ![%e edv])) ppx_defs
+                | _ -> ());
+                `Assoc (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs)
+              | ppx_other -> ppx_other],
+            is_rec )
+        | false ->
+          (* Non-recursive arg (or no accumulator): add a location-based $id to mark
+             the resource boundary so that any internal $defs refs resolve correctly. *)
+          let unique_id = estring ~loc (Printf.sprintf "file://%s:%d" loc.loc_start.pos_fname loc.loc_start.pos_lnum) in
+          ( [%expr
+              match [%e schema] with
+              | `Assoc pairs when List.mem_assoc "$defs" pairs ->
+                `Assoc (("$id", `String [%e unique_id]) :: List.filter (fun (k, _) -> k <> "$id") pairs)
+              | other -> other],
+            is_rec )))
+    | Ptyp_tuple types ->
+      let results = List.map (schema_of_core_type ~config ~recursive_types) types in
+      let ts = List.map fst results in
       let is_rec = List.exists snd results in
-      let schema = type_constr_conv ~loc id ~f:(fun s -> s ^ "_jsonschema") args in
-      let edv = evar ~loc "ppx_eds" in
-      (match is_rec with
-      | true ->
-        (* Hoist $defs from the sub-schema into the parent accumulator and strip
-           resource boundary markers ($defs), leaving just the $ref. *)
-        ( [%expr
-            match [%e schema] with
-            | `Assoc ppx_pairs ->
-              (match List.assoc_opt "$defs" ppx_pairs with
-              | Some (`Assoc ppx_defs) ->
-                [%e edv] := ![%e edv] @ List.filter (fun (n, _) -> not (List.mem_assoc n ![%e edv])) ppx_defs
-              | _ -> ());
-              `Assoc (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs)
-            | ppx_other -> ppx_other],
-          is_rec )
-      | false ->
-        (* Non-recursive arg (or no accumulator): add a location-based $id to mark
-           the resource boundary so that any internal $defs refs resolve correctly. *)
-        let unique_id = estring ~loc (Printf.sprintf "file://%s:%d" loc.loc_start.pos_fname loc.loc_start.pos_lnum) in
-        ( [%expr
-            match [%e schema] with
-            | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-              `Assoc (("$id", `String [%e unique_id]) :: List.filter (fun (k, _) -> k <> "$id") pairs)
-            | other -> other],
-          is_rec )))
-  | Ptyp_tuple types ->
-    let results = List.map (schema_of_core_type ~config ~recursive_types) types in
-    let ts = List.map fst results in
-    let is_rec = List.exists snd results in
-    Schema.tuple ~loc ts, is_rec
-  | Ptyp_variant (row_fields, _, _) -> schema_of_poly_variant ~loc ~config ~recursive_types row_fields
-  | _ ->
-    let msg = Format.asprintf "ppx_deriving_jsonschema: unsupported type %a" Astlib.Pprintast.core_type core_type in
-    [%expr [%ocaml.error [%e estring ~loc msg]]], false
+      Schema.tuple ~loc ts, is_rec
+    | Ptyp_variant (row_fields, _, _) -> schema_of_poly_variant ~loc ~config ~recursive_types row_fields
+    | _ ->
+      let msg = Format.asprintf "ppx_deriving_jsonschema: unsupported type %a" Astlib.Pprintast.core_type core_type in
+      [%expr [%ocaml.error [%e estring ~loc msg]]], false
+  in
+  let schema =
+    schema
+    |> apply_attr Attrs.jsonschema_ct_format core_type (fun fmt -> Schema.format ~loc fmt.txt)
+    |> apply_attr Attrs.jsonschema_ct_description core_type (fun desc -> Schema.description ~loc desc.txt)
+  in
+  schema, is_rec
 
 and schema_of_poly_variant ~loc ~(config : Attrs.config) ?(recursive_types = []) row_fields =
   let constrs, is_rec =
@@ -123,11 +138,7 @@ and schema_of_poly_variant ~loc ~(config : Attrs.config) ?(recursive_types = [])
       ([], false) row_fields
   in
   let constrs = List.rev constrs in
-  let v =
-    match config.Attrs.variant_as_string with
-    | true -> Schema.variant_as_string ~loc constrs
-    | false -> Schema.variant_as_array ~loc constrs
-  in
+  let v = Schema.variant ~loc ~as_string:config.Attrs.variant_as_string constrs in
   v, is_rec
 
 (* Returns (schema_expression, is_recursive) *)
@@ -152,9 +163,9 @@ let schema_of_record ~loc ~(config : Attrs.config) ?(recursive_types = []) field
           | _ -> schema_of_core_type ~config ~recursive_types pld_type
         in
         let type_def =
-          match Attribute.get Attrs.jsonschema_ld_description field with
-          | Some desc -> Schema.description ~loc ~description:desc.txt type_def
-          | None -> type_def
+          type_def
+          |> apply_attr Attrs.jsonschema_ld_description field (fun desc -> Schema.description ~loc desc.txt)
+          |> apply_attr Attrs.jsonschema_ld_format field (fun fmt -> Schema.format ~loc fmt.txt)
         in
         ( [%expr [%e estring ~loc name], [%e type_def]] :: fields,
           (if drop_required then required else { txt = name; loc } :: required),
@@ -204,8 +215,8 @@ let schema_of_variants ~loc ~(config : Attrs.config) ?(recursive_types = []) var
   let variants = List.rev variants in
   let schema, params_prefix =
     match config.Attrs.variant_as_string with
-    | true -> Schema.variant_as_string ~loc variants, "_"
-    | false -> Schema.variant_as_array ~loc variants, ""
+    | true -> Schema.variant ~loc ~as_string:true variants, "_"
+    | false -> Schema.variant ~loc variants, ""
   in
   schema, is_rec, params_prefix
 
@@ -277,6 +288,11 @@ let str_type_decl ~ctxt ast flag_variant_as_string flag_polymorphic_variant_tupl
     let _, raw_schema, is_rec, params, params_prefix =
       schema_of_type_decl ~loc ~config ~recursive_types:[ type_name ] type_decl
     in
+    let raw_schema =
+      raw_schema
+      |> apply_attr Attrs.jsonschema_td_description type_decl (fun desc -> Schema.description ~loc desc.txt)
+      |> apply_attr Attrs.jsonschema_td_format type_decl (fun fmt -> Schema.format ~loc fmt.txt)
+    in
     let schema =
       if is_rec then
         [%expr
@@ -290,7 +306,7 @@ let str_type_decl ~ctxt ast flag_variant_as_string flag_polymorphic_variant_tupl
     let schema = wrap_type_params ~loc ~prefix:params_prefix params schema in
     let schema =
       match Attribute.get Attrs.jsonschema_td_description type_decl with
-      | Some desc -> Schema.description ~loc ~description:desc.txt schema
+      | Some desc -> Schema.description ~loc desc.txt schema
       | None -> schema
     in
     [ create_value ~loc type_name schema ]
@@ -299,24 +315,24 @@ let str_type_decl ~ctxt ast flag_variant_as_string flag_polymorphic_variant_tupl
     let recursive_types = List.map (fun td -> td.ptype_name.txt) type_decls in
     let raw_results = List.map (schema_of_type_decl ~loc ~config ~recursive_types) type_decls in
     let any_recursive = List.exists (fun (_, _, is_rec, _, _) -> is_rec) raw_results in
-    if any_recursive then (
-      let defs = List.map (fun (name, raw, _, _, _) -> name, raw) raw_results in
+    if any_recursive then
       List.map
-        (fun (name, _, _, params, prefix) ->
+        (fun (name, raw, _, params, prefix) ->
           let td = List.find (fun td -> td.ptype_name.txt = name) type_decls in
+          let raw =
+            raw
+            |> apply_attr Attrs.jsonschema_td_description td (fun desc -> Schema.description ~loc desc.txt)
+            |> apply_attr Attrs.jsonschema_td_format td (fun fmt -> Schema.format ~loc fmt.txt)
+          in
+          let defs = List.map (fun (n, r, _, _, _) -> n, if n = name then raw else r) raw_results in
           let schema =
             wrap_type_params ~loc ~prefix params
               [%expr
                 let ppx_eds = ref [] in
                 [%e apply_defs ~loc (`Rec (name, defs))]]
           in
-          let schema =
-            match Attribute.get Attrs.jsonschema_td_description td with
-            | Some desc -> Schema.description ~loc ~description:desc.txt schema
-            | None -> schema
-          in
           create_value ~loc name schema)
-        raw_results)
+        raw_results
     else
       List.map
         (fun (name, raw, _, params, prefix) ->
@@ -328,9 +344,7 @@ let str_type_decl ~ctxt ast flag_variant_as_string flag_polymorphic_variant_tupl
                 [%e apply_defs ~loc (`NonRec raw)]]
           in
           let schema =
-            match Attribute.get Attrs.jsonschema_td_description td with
-            | Some desc -> Schema.description ~loc ~description:desc.txt schema
-            | None -> schema
+            schema |> apply_attr Attrs.jsonschema_td_description td (fun desc -> Schema.description ~loc desc.txt)
           in
           create_value ~loc name schema)
         raw_results

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -75,7 +75,8 @@ let rec schema_of_core_type ~(config : Attrs.config) ?(recursive_types = []) cor
               match [%e schema] with
               | `Assoc pairs when List.mem_assoc "$defs" pairs ->
                 `Assoc
-                  (("$id", `String [%e unique_id]) :: List.filter (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs)
+                  (("$id", `String [%e unique_id])
+                  :: List.filter (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs)
               | other -> other],
             is_rec )))
     | Ptyp_tuple types ->

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -16,11 +16,6 @@ let wrap_type_params ~loc ?(prefix = "") params body =
     (fun param body -> [%expr fun [%p ppat_var ~loc { txt = prefix ^ param; loc }] -> [%e body]])
     params body
 
-let apply_attr attr node f schema =
-  match Attribute.get attr node with
-  | Some v -> f v schema
-  | None -> schema
-
 (* schema_of_core_type and schema_of_poly_variant are mutually recursive.
    All other functions only call downward and use plain let. *)
 let rec schema_of_core_type ~(config : Attrs.config) ?(recursive_types = []) core_type =
@@ -94,8 +89,10 @@ let rec schema_of_core_type ~(config : Attrs.config) ?(recursive_types = []) cor
   in
   let schema =
     schema
-    |> apply_attr Attrs.jsonschema_ct_format core_type (fun fmt -> Schema.format ~loc fmt.txt)
-    |> apply_attr Attrs.jsonschema_ct_description core_type (fun desc -> Schema.description ~loc desc.txt)
+    |> Schema.Annotation.add_description ~loc (Attrs.jsonschema_ct_description, core_type)
+    |> Schema.Annotation.add_format ~loc (Attrs.jsonschema_ct_format, core_type) core_type
+    |> Schema.Annotation.add_maximum ~loc (Attrs.jsonschema_ct_maximum, core_type) core_type
+    |> Schema.Annotation.add_minimum ~loc (Attrs.jsonschema_ct_minimum, core_type) core_type
   in
   schema, is_rec
 
@@ -138,7 +135,7 @@ and schema_of_poly_variant ~loc ~(config : Attrs.config) ?(recursive_types = [])
       ([], false) row_fields
   in
   let constrs = List.rev constrs in
-  let v = Schema.variant ~loc ~as_string:config.Attrs.variant_as_string constrs in
+  let v = Schema.variants ~loc ~as_string:config.Attrs.variant_as_string constrs in
   v, is_rec
 
 (* Returns (schema_expression, is_recursive) *)
@@ -164,8 +161,10 @@ let schema_of_record ~loc ~(config : Attrs.config) ?(recursive_types = []) field
         in
         let type_def =
           type_def
-          |> apply_attr Attrs.jsonschema_ld_description field (fun desc -> Schema.description ~loc desc.txt)
-          |> apply_attr Attrs.jsonschema_ld_format field (fun fmt -> Schema.format ~loc fmt.txt)
+          |> Schema.Annotation.add_description ~loc (Attrs.jsonschema_ld_description, field)
+          |> Schema.Annotation.add_format ~loc (Attrs.jsonschema_ld_format, field) pld_type
+          |> Schema.Annotation.add_maximum ~loc (Attrs.jsonschema_ld_maximum, field) pld_type
+          |> Schema.Annotation.add_minimum ~loc (Attrs.jsonschema_ld_minimum, field) pld_type
         in
         ( [%expr [%e estring ~loc name], [%e type_def]] :: fields,
           (if drop_required then required else { txt = name; loc } :: required),
@@ -215,8 +214,8 @@ let schema_of_variants ~loc ~(config : Attrs.config) ?(recursive_types = []) var
   let variants = List.rev variants in
   let schema, params_prefix =
     match config.Attrs.variant_as_string with
-    | true -> Schema.variant ~loc ~as_string:true variants, "_"
-    | false -> Schema.variant ~loc variants, ""
+    | true -> Schema.variants ~loc ~as_string:true variants, "_"
+    | false -> Schema.variants ~loc variants, ""
   in
   schema, is_rec, params_prefix
 
@@ -290,8 +289,15 @@ let str_type_decl ~ctxt ast flag_variant_as_string flag_polymorphic_variant_tupl
     in
     let raw_schema =
       raw_schema
-      |> apply_attr Attrs.jsonschema_td_description type_decl (fun desc -> Schema.description ~loc desc.txt)
-      |> apply_attr Attrs.jsonschema_td_format type_decl (fun fmt -> Schema.format ~loc fmt.txt)
+      |> Schema.Annotation.add_description ~loc (Attrs.jsonschema_td_description, type_decl)
+    in
+    let raw_schema =
+      Option.fold ~none:raw_schema
+        ~some:(fun core_type ->
+          Schema.Annotation.add_format ~loc (Attrs.jsonschema_td_format, type_decl) core_type raw_schema
+          |> Schema.Annotation.add_maximum ~loc (Attrs.jsonschema_td_maximum, type_decl) core_type
+          |> Schema.Annotation.add_minimum ~loc (Attrs.jsonschema_td_minimum, type_decl) core_type)
+        type_decl.ptype_manifest
     in
     let schema =
       if is_rec then
@@ -319,10 +325,14 @@ let str_type_decl ~ctxt ast flag_variant_as_string flag_polymorphic_variant_tupl
       List.map
         (fun (name, raw, _, params, prefix) ->
           let td = List.find (fun td -> td.ptype_name.txt = name) type_decls in
+          let raw = raw |> Schema.Annotation.add_description ~loc (Attrs.jsonschema_td_description, td) in
           let raw =
-            raw
-            |> apply_attr Attrs.jsonschema_td_description td (fun desc -> Schema.description ~loc desc.txt)
-            |> apply_attr Attrs.jsonschema_td_format td (fun fmt -> Schema.format ~loc fmt.txt)
+            Option.fold ~none:raw
+              ~some:(fun core_type ->
+                Schema.Annotation.add_format ~loc (Attrs.jsonschema_td_format, td) core_type raw
+                |> Schema.Annotation.add_maximum ~loc (Attrs.jsonschema_td_maximum, td) core_type
+                |> Schema.Annotation.add_minimum ~loc (Attrs.jsonschema_td_minimum, td) core_type)
+              td.ptype_manifest
           in
           let defs = List.map (fun (n, r, _, _, _) -> n, if n = name then raw else r) raw_results in
           let schema =
@@ -343,9 +353,7 @@ let str_type_decl ~ctxt ast flag_variant_as_string flag_polymorphic_variant_tupl
                 let ppx_eds = ref [] in
                 [%e apply_defs ~loc (`NonRec raw)]]
           in
-          let schema =
-            schema |> apply_attr Attrs.jsonschema_td_description td (fun desc -> Schema.description ~loc desc.txt)
-          in
+          let schema = schema |> Schema.Annotation.add_description ~loc (Attrs.jsonschema_td_description, td) in
           create_value ~loc name schema)
         raw_results
   | _, _ -> [%str [%ocaml.error "ppx_deriving_jsonschema: unsupported type"]]

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -93,6 +93,7 @@ let rec schema_of_core_type ~(config : Attrs.config) ?(recursive_types = []) cor
     |> Schema.Annotation.add_format ~loc (Attrs.jsonschema_ct_format, core_type) core_type
     |> Schema.Annotation.add_maximum ~loc (Attrs.jsonschema_ct_maximum, core_type) core_type
     |> Schema.Annotation.add_minimum ~loc (Attrs.jsonschema_ct_minimum, core_type) core_type
+    |> Schema.Annotation.add_annotations ~loc ~core_type (Attribute.get Attrs.jsonschema_ct_attrs core_type)
   in
   schema, is_rec
 
@@ -165,6 +166,7 @@ let schema_of_record ~loc ~(config : Attrs.config) ?(recursive_types = []) field
           |> Schema.Annotation.add_format ~loc (Attrs.jsonschema_ld_format, field) pld_type
           |> Schema.Annotation.add_maximum ~loc (Attrs.jsonschema_ld_maximum, field) pld_type
           |> Schema.Annotation.add_minimum ~loc (Attrs.jsonschema_ld_minimum, field) pld_type
+          |> Schema.Annotation.add_annotations ~loc ~core_type:pld_type (Attribute.get Attrs.jsonschema_ld_attrs field)
         in
         ( [%expr [%e estring ~loc name], [%e type_def]] :: fields,
           (if drop_required then required else { txt = name; loc } :: required),
@@ -290,6 +292,7 @@ let str_type_decl ~ctxt ast flag_variant_as_string flag_polymorphic_variant_tupl
     let raw_schema =
       raw_schema
       |> Schema.Annotation.add_description ~loc (Attrs.jsonschema_td_description, type_decl)
+      |> Schema.Annotation.add_annotations ~loc (Attribute.get Attrs.jsonschema_td_attrs type_decl)
     in
     let raw_schema =
       Option.fold ~none:raw_schema

--- a/src/schema.ml
+++ b/src/schema.ml
@@ -123,4 +123,58 @@ module Annotation = struct
 
   let add_description ~loc attr = add_schema_attr attr (fun desc schema -> description ~loc desc.txt schema)
 
+  let add_annotations ~loc ?core_type attrs schema =
+    let require_core_type field =
+      match core_type with
+      | Some t -> t
+      | None ->
+        Location.raise_errorf ~loc
+          "[@jsonschema.attrs] '%s' requires a type context (use the individual [@jsonschema.%s] attribute instead)"
+          field field
+    in
+    match attrs with
+    | None -> schema
+    | Some expr ->
+    match expr.pexp_desc with
+    | Pexp_record (fields, None) ->
+      List.fold_left
+        (fun schema ({ txt = label; loc = label_loc }, value) ->
+          match label with
+          | Lident "description" ->
+            (match value.pexp_desc with
+            | Pexp_constant (Pconst_string (s, _, _)) -> description ~loc s schema
+            | _ ->
+              Location.raise_errorf ~loc:value.pexp_loc "[@jsonschema.attrs] 'description' must be a string literal")
+          | Lident "format" ->
+            let ct = require_core_type "format" in
+            (match value.pexp_desc with
+            | Pexp_constant (Pconst_string (s, _, _)) ->
+              (match ct with
+              | [%type: string] | [%type: bytes] | [%type: string option] | [%type: bytes option] ->
+                format ~loc s schema
+              | _ ->
+                Location.raise_errorf ~loc:ct.ptyp_loc
+                  "[@jsonschema.attrs] 'format' can only be applied to string types")
+            | _ -> Location.raise_errorf ~loc:value.pexp_loc "[@jsonschema.attrs] 'format' must be a string literal")
+          | Lident "maximum" ->
+            let ct = require_core_type "maximum" in
+            (match ct with
+            | [%type: int] | [%type: int32] | [%type: nativeint] -> maximum ~loc [%expr `Int [%e value]] schema
+            | [%type: float] -> maximum ~loc [%expr `Float [%e value]] schema
+            | _ ->
+              Location.raise_errorf ~loc:ct.ptyp_loc
+                "[@jsonschema.attrs] 'maximum' can only be applied to numeric types")
+          | Lident "minimum" ->
+            let ct = require_core_type "minimum" in
+            (match ct with
+            | [%type: int] | [%type: int32] | [%type: nativeint] -> minimum ~loc [%expr `Int [%e value]] schema
+            | [%type: float] -> minimum ~loc [%expr `Float [%e value]] schema
+            | _ ->
+              Location.raise_errorf ~loc:ct.ptyp_loc
+                "[@jsonschema.attrs] 'minimum' can only be applied to numeric types")
+          | Lident name -> Location.raise_errorf ~loc:label_loc "[@jsonschema.attrs] unknown field: '%s'" name
+          | _ -> Location.raise_errorf ~loc:label_loc "[@jsonschema.attrs] expected a simple field name")
+        schema fields
+    | _ ->
+      Location.raise_errorf ~loc:expr.pexp_loc "[@jsonschema.attrs] expects a record expression: { field = value; ... }"
 end

--- a/src/schema.ml
+++ b/src/schema.ml
@@ -59,30 +59,24 @@ let nullable ~loc schema =
   | [%expr `Assoc [ "type", `String [%e? t] ]] -> [%expr `Assoc [ "type", `List [ `String [%e t]; `String "null" ] ]]
   | s -> [%expr `Assoc [ "anyOf", `List [ [%e s]; `Assoc [ "type", `String "null" ] ] ]]
 
-let description ~loc ~description:d schema_expr =
-  [%expr
-    match [%e schema_expr] with
-    | `Assoc fields -> `Assoc (("description", `String [%e estring ~loc d]) :: fields)
-    | s -> s]
+let annotation ~loc (name, value) schema =
+  match schema with
+  | [%expr `Assoc [%e? fields]] -> [%expr `Assoc (([%e estring ~loc name], [%e value]) :: [%e fields])]
+  | s -> s
 
-let variant_branch ~loc ~description_opt name typs ~as_string =
-  let branch = if as_string then const ~loc name else tuple ~loc (const ~loc name :: typs) in
-  match description_opt with
-  | Some d -> description ~loc ~description:d branch
-  | None -> branch
-
-let variant_as_string ~loc constrs =
+let format ~loc format schema = annotation ~loc ("format", [%expr `String [%e estring ~loc format]]) schema
+let description ~loc description schema_expr =
+  annotation ~loc ("description", [%expr `String [%e estring ~loc description]]) schema_expr
+let variant ~loc ?(as_string = false) constrs =
+  let opt_description ~loc desc schema =
+    match desc with
+    | Some d -> description ~loc d schema
+    | None -> schema
+  in
   anyOf ~loc
     (List.map
        (function
-         | `Tag (name, _typs, desc) -> variant_branch ~loc ~description_opt:desc name [] ~as_string:true
-         | `Inherit typ -> typ)
-       constrs)
-
-let variant_as_array ~loc constrs =
-  anyOf ~loc
-    (List.map
-       (function
-         | `Tag (name, typs, desc) -> variant_branch ~loc ~description_opt:desc name typs ~as_string:false
+         | `Tag (name, typs, desc) ->
+           opt_description ~loc desc (if as_string then const ~loc name else tuple ~loc (const ~loc name :: typs))
          | `Inherit typ -> typ)
        constrs)

--- a/src/schema.ml
+++ b/src/schema.ml
@@ -64,10 +64,13 @@ let annotation ~loc (name, value) schema =
   | [%expr `Assoc [%e? fields]] -> [%expr `Assoc (([%e estring ~loc name], [%e value]) :: [%e fields])]
   | s -> s
 
-let format ~loc format schema = annotation ~loc ("format", [%expr `String [%e estring ~loc format]]) schema
+let format ~loc format = annotation ~loc ("format", [%expr `String [%e estring ~loc format]])
+let maximum ~loc maximum = annotation ~loc ("maximum", maximum)
+let minimum ~loc minimum = annotation ~loc ("minimum", minimum)
 let description ~loc description schema_expr =
   annotation ~loc ("description", [%expr `String [%e estring ~loc description]]) schema_expr
-let variant ~loc ?(as_string = false) constrs =
+
+let variants ~loc ?(as_string = false) constrs =
   let opt_description ~loc desc schema =
     match desc with
     | Some d -> description ~loc d schema
@@ -80,3 +83,44 @@ let variant ~loc ?(as_string = false) constrs =
            opt_description ~loc desc (if as_string then const ~loc name else tuple ~loc (const ~loc name :: typs))
          | `Inherit typ -> typ)
        constrs)
+
+module Annotation = struct
+  let add_schema_attr (attr, node) f schema =
+    match Attribute.get attr node with
+    | Some v -> f v schema
+    | None -> schema
+
+  let add_format ~loc attr core_type =
+    add_schema_attr attr (fun fmt schema ->
+        match core_type with
+        | [%type: string] | [%type: bytes] | [%type: string option] | [%type: bytes option] ->
+          format ~loc fmt.txt schema
+        | _ ->
+          Location.raise_errorf ~loc:core_type.ptyp_loc
+            "[@jsonschema.format] can only be applied to string or bytes types")
+
+  let add_maximum ~loc attr core_type =
+    add_schema_attr attr (fun expr schema ->
+        match core_type, expr.pexp_desc with
+        | [%type: int], Pexp_constant (Pconst_integer _)
+        | [%type: int32], Pexp_constant (Pconst_integer _)
+        | [%type: nativeint], Pexp_constant (Pconst_integer _) ->
+          maximum ~loc [%expr `Int [%e expr]] schema
+        | [%type: float], Pexp_constant (Pconst_float _) -> maximum ~loc [%expr `Float [%e expr]] schema
+        | _ ->
+          Location.raise_errorf ~loc:core_type.ptyp_loc "[@jsonschema.maximum] can only be applied to numeric types")
+
+  let add_minimum ~loc attr core_type =
+    add_schema_attr attr (fun expr schema ->
+        match core_type, expr.pexp_desc with
+        | [%type: int], Pexp_constant (Pconst_integer _)
+        | [%type: int32], Pexp_constant (Pconst_integer _)
+        | [%type: nativeint], Pexp_constant (Pconst_integer _) ->
+          minimum ~loc [%expr `Int [%e expr]] schema
+        | [%type: float], Pexp_constant (Pconst_float _) -> minimum ~loc [%expr `Float [%e expr]] schema
+        | _ ->
+          Location.raise_errorf ~loc:core_type.ptyp_loc "[@jsonschema.minimum] can only be applied to numeric types")
+
+  let add_description ~loc attr = add_schema_attr attr (fun desc schema -> description ~loc desc.txt schema)
+
+end

--- a/src/schema.mli
+++ b/src/schema.mli
@@ -1,0 +1,51 @@
+val const : loc:Warnings.loc -> string -> Ppxlib.expression
+val type_ref : loc:Warnings.loc -> string -> Ppxlib.expression
+val type_def : loc:Warnings.loc -> string -> Ppxlib.expression
+val null : loc:Warnings.loc -> Ppxlib.expression
+val char : loc:Warnings.loc -> Ppxlib.expression
+val oneOf : loc:Warnings.loc -> Ppxlib.expression list -> Ppxlib.expression
+val anyOf : loc:Warnings.loc -> Ppxlib.expression list -> Ppxlib.expression
+val array_ : loc:Warnings.loc -> ?min_items:int -> ?max_items:int -> Ppxlib.expression -> Ppxlib.expression
+val tuple : loc:Warnings.loc -> Ppxlib.expression list -> Ppxlib.expression
+val enum : loc:Warnings.loc -> string option -> Ppxlib.expression list -> Ppxlib.expression
+val enum_string : loc:Warnings.loc -> string list -> Ppxlib.expression
+val nullable : loc:Warnings.loc -> Ppxlib.expression -> Ppxlib.expression
+val annotation : loc:Warnings.loc -> string * Ppxlib.expression -> Ppxlib.expression -> Ppxlib.expression
+val format : loc:Warnings.loc -> string -> Ppxlib.expression -> Ppxlib.expression
+val maximum : loc:Warnings.loc -> Ppxlib.expression -> Ppxlib.expression -> Ppxlib.expression
+val minimum : loc:Warnings.loc -> Ppxlib.expression -> Ppxlib.expression -> Ppxlib.expression
+val description : loc:Warnings.loc -> string -> Ppxlib.expression -> Ppxlib.expression
+val variants :
+  loc:Warnings.loc ->
+  ?as_string:bool ->
+  [< `Inherit of Ppxlib.expression | `Tag of string * Ppxlib.expression list * string option ] list ->
+  Ppxlib.expression
+
+module Annotation : sig
+  val add_format :
+    loc:Warnings.loc ->
+    ('a, string Location.loc) Ppxlib.Attribute.t * 'a ->
+    Ppxlib.core_type ->
+    Ppxlib.expression ->
+    Ppxlib.expression
+  val add_maximum :
+    loc:Warnings.loc ->
+    ('a, Ppxlib.expression) Ppxlib.Attribute.t * 'a ->
+    Ppxlib.core_type ->
+    Ppxlib.expression ->
+    Ppxlib.expression
+  val add_minimum :
+    loc:Warnings.loc ->
+    ('a, Ppxlib.expression) Ppxlib.Attribute.t * 'a ->
+    Ppxlib.core_type ->
+    Ppxlib.expression ->
+    Ppxlib.expression
+  val add_description :
+    loc:Warnings.loc -> ('a, string Location.loc) Ppxlib.Attribute.t * 'a -> Ppxlib.expression -> Ppxlib.expression
+  val add_annotations :
+    loc:Warnings.loc ->
+    ?core_type:Ppxlib.core_type ->
+    Ppxlib.expression option ->
+    Ppxlib.expression ->
+    Ppxlib.expression
+end

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -5653,3 +5653,68 @@ include
       "$ref": "#/$defs/bool_filter"
     }
     |}]]
+type with_maximum = int[@@jsonschema.maximum 100][@@deriving jsonschema]
+include
+  struct
+    let with_maximum_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc [("maximum", (`Int 100)); ("type", (`String "integer"))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "with_maximum" =
+    print_schema with_maximum_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "maximum": 100,
+      "type": "integer"
+    }
+    |}]]
+type with_maximum_record = {
+  field: int [@jsonschema.maximum 100]}[@@deriving jsonschema]
+include
+  struct
+    let with_maximum_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("field",
+                  (`Assoc
+                     [("maximum", (`Int 100)); ("type", (`String "integer"))]))]));
+          ("required", (`List [`String "field"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "with_maximum" =
+    print_schema with_maximum_record_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": { "field": { "maximum": 100, "type": "integer" } },
+      "required": [ "field" ],
+      "additionalProperties": false
+    }
+    |}]]

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -5075,8 +5075,8 @@ include
                      (`List
                         [`Assoc [("const", (`String "A"))];
                         `Assoc
-                          [("description", (`String "A date-time string"));
-                          ("format", (`String "date-time"));
+                          [("format", (`String "date-time"));
+                          ("description", (`String "A date-time string"));
                           ("type", (`String "string"))]]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 2));
@@ -5110,8 +5110,8 @@ include
           "prefixItems": [
             { "const": "A" },
             {
-              "description": "A date-time string",
               "format": "date-time",
+              "description": "A date-time string",
               "type": "string"
             }
           ],
@@ -5852,5 +5852,263 @@ include
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "A plain integer",
       "type": "integer"
+    }
+    |}]]
+type minimum_core_type_int =
+  ((int)[@jsonschema.minimum 0][@jsonschema.maximum 100])[@@deriving
+                                                           jsonschema]
+include
+  struct
+    let minimum_core_type_int_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("minimum", (`Int 0));
+          ("maximum", (`Int 100));
+          ("type", (`String "integer"))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "minimum_maximum_core_type_int" =
+    print_schema minimum_core_type_int_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "minimum": 0,
+      "maximum": 100,
+      "type": "integer"
+    }
+    |}]]
+type minimum_core_type_float =
+  ((float)[@jsonschema.minimum 0.0][@jsonschema.maximum 1.0])[@@deriving
+                                                               jsonschema]
+include
+  struct
+    let minimum_core_type_float_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("minimum", (`Float 0.0));
+          ("maximum", (`Float 1.0));
+          ("type", (`String "number"))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "minimum_maximum_core_type_float" =
+    print_schema minimum_core_type_float_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "minimum": 0.0,
+      "maximum": 1.0,
+      "type": "number"
+    }
+    |}]]
+type minimum_maximum_record =
+  {
+  score: int [@jsonschema.minimum 0][@jsonschema.maximum 100];
+  ratio: float [@jsonschema.minimum 0.0][@jsonschema.maximum 1.0]}[@@deriving
+                                                                    jsonschema]
+include
+  struct
+    let minimum_maximum_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("ratio",
+                  (`Assoc
+                     [("minimum", (`Float 0.0));
+                     ("maximum", (`Float 1.0));
+                     ("type", (`String "number"))]));
+               ("score",
+                 (`Assoc
+                    [("minimum", (`Int 0));
+                    ("maximum", (`Int 100));
+                    ("type", (`String "integer"))]))]));
+          ("required", (`List [`String "ratio"; `String "score"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "minimum_maximum_record" =
+    print_schema minimum_maximum_record_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "ratio": { "minimum": 0.0, "maximum": 1.0, "type": "number" },
+        "score": { "minimum": 0, "maximum": 100, "type": "integer" }
+      },
+      "required": [ "ratio", "score" ],
+      "additionalProperties": false
+    }
+    |}]]
+type minimum_maximum_type_decl_int = int[@@jsonschema.minimum 0][@@jsonschema.maximum
+                                                                  255]
+[@@deriving jsonschema]
+include
+  struct
+    let minimum_maximum_type_decl_int_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("minimum", (`Int 0));
+          ("maximum", (`Int 255));
+          ("type", (`String "integer"))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "minimum_maximum_type_decl_int" =
+    print_schema minimum_maximum_type_decl_int_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "minimum": 0,
+      "maximum": 255,
+      "type": "integer"
+    }
+    |}]]
+type minimum_maximum_type_decl_float = float[@@jsonschema.minimum 0.0]
+[@@jsonschema.maximum 1.0][@@deriving jsonschema]
+include
+  struct
+    let minimum_maximum_type_decl_float_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("minimum", (`Float 0.0));
+          ("maximum", (`Float 1.0));
+          ("type", (`String "number"))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "minimum_maximum_type_decl_float" =
+    print_schema minimum_maximum_type_decl_float_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "minimum": 0.0,
+      "maximum": 1.0,
+      "type": "number"
+    }
+    |}]]
+type minimum_maximum_variant =
+  | Percentage of ((int)[@jsonschema.minimum 0][@jsonschema.maximum 100]) 
+  | Factor of ((float)[@jsonschema.minimum 0.0][@jsonschema.maximum 1.0]) 
+[@@deriving jsonschema]
+include
+  struct
+    let minimum_maximum_variant_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "Percentage"))];
+                        `Assoc
+                          [("minimum", (`Int 0));
+                          ("maximum", (`Int 100));
+                          ("type", (`String "integer"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Factor"))];
+                       `Assoc
+                         [("minimum", (`Float 0.0));
+                         ("maximum", (`Float 1.0));
+                         ("type", (`String "number"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "minimum_maximum_variant" =
+    print_schema minimum_maximum_variant_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "Percentage" },
+            { "minimum": 0, "maximum": 100, "type": "integer" }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        },
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "Factor" },
+            { "minimum": 0.0, "maximum": 1.0, "type": "number" }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
     }
     |}]]

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -4432,21 +4432,14 @@ include
           ("properties",
             (`Assoc
                [("max_results",
-                  ((match `Assoc [("type", (`String "integer"))] with
-                    | `Assoc fields ->
-                        `Assoc
-                          (("description",
-                             (`String "Maximum number of results to return"))
-                          :: fields)
-                    | s -> s)));
+                  (`Assoc
+                     [("description",
+                        (`String "Maximum number of results to return"));
+                     ("type", (`String "integer"))]));
                ("query",
-                 ((match `Assoc [("type", (`String "string"))] with
-                   | `Assoc fields ->
-                       `Assoc
-                         (("description",
-                            (`String "The search query to execute"))
-                         :: fields)
-                   | s -> s)))]));
+                 (`Assoc
+                    [("description", (`String "The search query to execute"));
+                    ("type", (`String "string"))]))]));
           ("required", (`List [`String "max_results"; `String "query"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -4478,7 +4471,8 @@ include
       },
       "required": [ "max_results", "query" ],
       "additionalProperties": false
-    } |}]]
+    }
+    |}]]
 type described_record =
   {
   name: string [@jsonschema.description "The user's full name"];
@@ -4489,45 +4483,31 @@ type described_record =
 include
   struct
     let described_record_jsonschema =
-      match let ppx_eds = ref [] in
-            let ppx_result =
-              `Assoc
-                [("type", (`String "object"));
-                ("properties",
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("description", (`String "A user object"));
+          ("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("age",
                   (`Assoc
-                     [("age",
-                        ((match `Assoc
-                                  [("type",
-                                     (`List
-                                        [`String "integer"; `String "null"]))]
-                          with
-                          | `Assoc fields ->
-                              `Assoc
-                                (("description", (`String "The user's age"))
-                                :: fields)
-                          | s -> s)));
-                     ("name",
-                       ((match `Assoc [("type", (`String "string"))] with
-                         | `Assoc fields ->
-                             `Assoc
-                               (("description",
-                                  (`String "The user's full name"))
-                               :: fields)
-                         | s -> s)))]));
-                ("required", (`List [`String "name"]));
-                ("additionalProperties", (`Bool false))] in
-            match !ppx_eds with
-            | [] -> ppx_result
-            | ppx_defs ->
-                (match ppx_result with
-                 | `Assoc ppx_pairs ->
-                     `Assoc (("$defs", (`Assoc ppx_defs)) ::
-                       (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
-                 | other -> other)
-      with
-      | `Assoc fields ->
-          `Assoc (("description", (`String "A user object")) :: fields)
-      | s -> s[@@warning "-32-39"]
+                     [("description", (`String "The user's age"));
+                     ("type", (`List [`String "integer"; `String "null"]))]));
+               ("name",
+                 (`Assoc
+                    [("description", (`String "The user's full name"));
+                    ("type", (`String "string"))]))]));
+          ("required", (`List [`String "name"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "type_and_field_description" =
@@ -4544,7 +4524,8 @@ include
       },
       "required": [ "name" ],
       "additionalProperties": false
-    } |}]]
+    }
+    |}]]
 type with_key_and_desc =
   {
   opt: int option
@@ -4561,15 +4542,9 @@ include
           ("properties",
             (`Assoc
                [("opt_int",
-                  ((match `Assoc
-                            [("type",
-                               (`List [`String "integer"; `String "null"]))]
-                    with
-                    | `Assoc fields ->
-                        `Assoc
-                          (("description", (`String "An optional integer"))
-                          :: fields)
-                    | s -> s)))]));
+                  (`Assoc
+                     [("description", (`String "An optional integer"));
+                     ("type", (`List [`String "integer"; `String "null"]))]))]));
           ("required", (`List []));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -4597,12 +4572,14 @@ include
       },
       "required": [],
       "additionalProperties": false
-    } |}]]
+    }
+    |}]]
 type described_variant =
   | Plain [@jsonschema.description "No payload"]
   | With_int of int [@jsonschema.description "Single integer tag"]
-  | Pair of string * int [@jsonschema.description "String and int"][@@deriving
-                                                                    jsonschema]
+  | Pair of string * int [@jsonschema.description "String and int"]
+  | Description_value of ((string)[@jsonschema.description "A string value"]) 
+[@@deriving jsonschema]
 include
   struct
     let described_variant_jsonschema =
@@ -4611,47 +4588,46 @@ include
         `Assoc
           [("anyOf",
              (`List
-                [(match `Assoc
-                          [("type", (`String "array"));
-                          ("prefixItems",
-                            (`List [`Assoc [("const", (`String "Plain"))]]));
-                          ("unevaluatedItems", (`Bool false));
-                          ("minItems", (`Int 1));
-                          ("maxItems", (`Int 1))]
-                  with
-                  | `Assoc fields ->
-                      `Assoc (("description", (`String "No payload")) ::
-                        fields)
-                  | s -> s);
-                (match `Assoc
-                         [("type", (`String "array"));
-                         ("prefixItems",
-                           (`List
-                              [`Assoc [("const", (`String "With_int"))];
-                              `Assoc [("type", (`String "integer"))]]));
-                         ("unevaluatedItems", (`Bool false));
-                         ("minItems", (`Int 2));
-                         ("maxItems", (`Int 2))]
-                 with
-                 | `Assoc fields ->
-                     `Assoc (("description", (`String "Single integer tag"))
-                       :: fields)
-                 | s -> s);
-                (match `Assoc
-                         [("type", (`String "array"));
-                         ("prefixItems",
-                           (`List
-                              [`Assoc [("const", (`String "Pair"))];
-                              `Assoc [("type", (`String "string"))];
-                              `Assoc [("type", (`String "integer"))]]));
-                         ("unevaluatedItems", (`Bool false));
-                         ("minItems", (`Int 3));
-                         ("maxItems", (`Int 3))]
-                 with
-                 | `Assoc fields ->
-                     `Assoc (("description", (`String "String and int")) ::
-                       fields)
-                 | s -> s)]))] in
+                [`Assoc
+                   [("description", (`String "No payload"));
+                   ("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Plain"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("description", (`String "Single integer tag"));
+                  ("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "With_int"))];
+                       `Assoc [("type", (`String "integer"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))];
+                `Assoc
+                  [("description", (`String "String and int"));
+                  ("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Pair"))];
+                       `Assoc [("type", (`String "string"))];
+                       `Assoc [("type", (`String "integer"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 3));
+                  ("maxItems", (`Int 3))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Description_value"))];
+                       `Assoc
+                         [("description", (`String "A string value"));
+                         ("type", (`String "string"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -4694,9 +4670,20 @@ include
           "unevaluatedItems": false,
           "minItems": 3,
           "maxItems": 3
+        },
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "Description_value" },
+            { "description": "A string value", "type": "string" }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
         }
       ]
-    } |}]]
+    }
+    |}]]
 type described_variant_inline_record =
   | Point of {
   x: int ;
@@ -4709,32 +4696,25 @@ include
         `Assoc
           [("anyOf",
              (`List
-                [(match `Assoc
-                          [("type", (`String "array"));
-                          ("prefixItems",
-                            (`List
-                               [`Assoc [("const", (`String "Point"))];
-                               `Assoc
-                                 [("type", (`String "object"));
-                                 ("properties",
-                                   (`Assoc
-                                      [("y",
-                                         (`Assoc
-                                            [("type", (`String "integer"))]));
-                                      ("x",
-                                        (`Assoc
-                                           [("type", (`String "integer"))]))]));
-                                 ("required",
-                                   (`List [`String "y"; `String "x"]));
-                                 ("additionalProperties", (`Bool false))]]));
-                          ("unevaluatedItems", (`Bool false));
-                          ("minItems", (`Int 2));
-                          ("maxItems", (`Int 2))]
-                  with
-                  | `Assoc fields ->
-                      `Assoc (("description", (`String "A 2D point")) ::
-                        fields)
-                  | s -> s)]))] in
+                [`Assoc
+                   [("description", (`String "A 2D point"));
+                   ("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "Point"))];
+                        `Assoc
+                          [("type", (`String "object"));
+                          ("properties",
+                            (`Assoc
+                               [("y",
+                                  (`Assoc [("type", (`String "integer"))]));
+                               ("x",
+                                 (`Assoc [("type", (`String "integer"))]))]));
+                          ("required", (`List [`String "y"; `String "x"]));
+                          ("additionalProperties", (`Bool false))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))]]))] in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -4772,7 +4752,8 @@ include
           "maxItems": 2
         }
       ]
-    } |}]]
+    }
+    |}]]
 type described_variant_string =
   | A [@jsonschema.description "First choice"]
   | B [@jsonschema.description "Second choice"][@@deriving
@@ -4786,16 +4767,12 @@ include
         `Assoc
           [("anyOf",
              (`List
-                [(match `Assoc [("const", (`String "A"))] with
-                  | `Assoc fields ->
-                      `Assoc (("description", (`String "First choice")) ::
-                        fields)
-                  | s -> s);
-                (match `Assoc [("const", (`String "B"))] with
-                 | `Assoc fields ->
-                     `Assoc (("description", (`String "Second choice")) ::
-                       fields)
-                 | s -> s)]))] in
+                [`Assoc
+                   [("description", (`String "First choice"));
+                   ("const", (`String "A"))];
+                `Assoc
+                  [("description", (`String "Second choice"));
+                  ("const", (`String "B"))]]))] in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -4816,7 +4793,8 @@ include
         { "description": "First choice", "const": "A" },
         { "description": "Second choice", "const": "B" }
       ]
-    } |}]]
+    }
+    |}]]
 type computation_result =
   | Ok 
   | Err of string [@@deriving jsonschema][@@jsonschema.description
@@ -4824,42 +4802,37 @@ type computation_result =
 include
   struct
     let computation_result_jsonschema =
-      match let ppx_eds = ref [] in
-            let ppx_result =
-              `Assoc
-                [("anyOf",
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("description",
+             (`String "Either success or an error message string"));
+          ("anyOf",
+            (`List
+               [`Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "Ok"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))];
+               `Assoc
+                 [("type", (`String "array"));
+                 ("prefixItems",
                    (`List
-                      [`Assoc
-                         [("type", (`String "array"));
-                         ("prefixItems",
-                           (`List [`Assoc [("const", (`String "Ok"))]]));
-                         ("unevaluatedItems", (`Bool false));
-                         ("minItems", (`Int 1));
-                         ("maxItems", (`Int 1))];
-                      `Assoc
-                        [("type", (`String "array"));
-                        ("prefixItems",
-                          (`List
-                             [`Assoc [("const", (`String "Err"))];
-                             `Assoc [("type", (`String "string"))]]));
-                        ("unevaluatedItems", (`Bool false));
-                        ("minItems", (`Int 2));
-                        ("maxItems", (`Int 2))]]))] in
-            match !ppx_eds with
-            | [] -> ppx_result
-            | ppx_defs ->
-                (match ppx_result with
-                 | `Assoc ppx_pairs ->
-                     `Assoc (("$defs", (`Assoc ppx_defs)) ::
-                       (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
-                 | other -> other)
-      with
-      | `Assoc fields ->
-          `Assoc
-            (("description",
-               (`String "Either success or an error message string"))
-            :: fields)
-      | s -> s[@@warning "-32-39"]
+                      [`Assoc [("const", (`String "Err"))];
+                      `Assoc [("type", (`String "string"))]]));
+                 ("unevaluatedItems", (`Bool false));
+                 ("minItems", (`Int 2));
+                 ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 [%%expect_test
   let "variant_type_level_description" =
@@ -4885,7 +4858,8 @@ include
           "maxItems": 2
         }
       ]
-    } |}]]
+    }
+    |}]]
 type nullable_fields =
   {
   plain: string option ;
@@ -4973,7 +4947,7 @@ include
                              | `Assoc pairs when List.mem_assoc "$defs" pairs
                                  ->
                                  `Assoc
-                                   (("$id", (`String "file://test.ml:2559"))
+                                   (("$id", (`String "file://test.ml:2577"))
                                    ::
                                    (List.filter (fun (k, _) -> k <> "$id")
                                       pairs))
@@ -5007,6 +4981,152 @@ include
       },
       "required": [],
       "additionalProperties": false
+    }
+    |}]]
+type with_format = string[@@jsonschema.format "date-time"][@@deriving
+                                                            jsonschema]
+include
+  struct
+    let with_format_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("format", (`String "date-time")); ("type", (`String "string"))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "with_format" =
+    print_schema with_format_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "format": "date-time",
+      "type": "string"
+    }
+    |}]]
+type with_format_record =
+  {
+  with_format: string [@jsonschema.format "date-time"]}[@@deriving
+                                                         jsonschema]
+include
+  struct
+    let with_format_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("with_format",
+                  (`Assoc
+                     [("format", (`String "date-time"));
+                     ("type", (`String "string"))]))]));
+          ("required", (`List [`String "with_format"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "with_format_record" =
+    print_schema with_format_record_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "with_format": { "format": "date-time", "type": "string" }
+      },
+      "required": [ "with_format" ],
+      "additionalProperties": false
+    }
+    |}]]
+type with_format_variant =
+  | A of
+  ((string)[@jsonschema.format "date-time"][@jsonschema.description
+                                             "A date-time string"])
+  
+  | B [@@deriving jsonschema]
+include
+  struct
+    let with_format_variant_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        `Assoc
+                          [("description", (`String "A date-time string"));
+                          ("format", (`String "date-time"));
+                          ("type", (`String "string"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "B"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "with_format_variant" =
+    print_schema with_format_variant_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "A" },
+            {
+              "description": "A date-time string",
+              "format": "date-time",
+              "type": "string"
+            }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "B" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        }
+      ]
     }
     |}]]
 type 'a grade' =
@@ -5145,13 +5265,13 @@ include
                [("b",
                   ((match self_ref_jsonschema with
                     | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                        `Assoc (("$id", (`String "file://test.ml:2645")) ::
+                        `Assoc (("$id", (`String "file://test.ml:2730")) ::
                           (List.filter (fun (k, _) -> k <> "$id") pairs))
                     | other -> other)));
                ("a",
                  ((match self_ref_jsonschema with
                    | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                       `Assoc (("$id", (`String "file://test.ml:2644")) ::
+                       `Assoc (("$id", (`String "file://test.ml:2729")) ::
                          (List.filter (fun (k, _) -> k <> "$id") pairs))
                    | other -> other)))]));
           ("required", (`List [`String "b"; `String "a"]));
@@ -5175,7 +5295,7 @@ include
       "type": "object",
       "properties": {
         "b": {
-          "$id": "file://test/test.ml:2645",
+          "$id": "file://test/test.ml:2730",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -5192,7 +5312,7 @@ include
           "$ref": "#/$defs/self_ref"
         },
         "a": {
-          "$id": "file://test/test.ml:2644",
+          "$id": "file://test/test.ml:2729",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -5268,7 +5388,7 @@ include
                         [`Assoc [("const", (`String "BoolAtom"))];
                         (match filter_jsonschema atom group_atom with
                          | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                             `Assoc (("$id", (`String "file://test.ml:2704"))
+                             `Assoc (("$id", (`String "file://test.ml:2789"))
                                ::
                                (List.filter (fun (k, _) -> k <> "$id") pairs))
                          | other -> other)]));
@@ -5480,7 +5600,7 @@ include
               "prefixItems": [
                 { "const": "BoolAtom" },
                 {
-                  "$id": "file://test/test.ml:2704",
+                  "$id": "file://test/test.ml:2789",
                   "$defs": {
                     "filter": {
                       "anyOf": [

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -5718,3 +5718,139 @@ include
       "additionalProperties": false
     }
     |}]]
+type attrs_core_type =
+  ((int)[@jsonschema.attrs
+          {
+            maximum = 100;
+            minimum = 0;
+            description = "Integer percentage value (0-100 inclusive)"
+          }])[@@deriving jsonschema]
+include
+  struct
+    let attrs_core_type_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("description",
+             (`String "Integer percentage value (0-100 inclusive)"));
+          ("minimum", (`Int 0));
+          ("maximum", (`Int 100));
+          ("type", (`String "integer"))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "attrs_core_type" =
+    print_schema attrs_core_type_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Integer percentage value (0-100 inclusive)",
+      "minimum": 0,
+      "maximum": 100,
+      "type": "integer"
+    }
+    |}]]
+type attrs_record =
+  {
+  score: int
+    [@jsonschema.attrs
+      { maximum = 100; minimum = 0; description = "Score out of 100" }];
+  label: string
+    [@jsonschema.attrs
+      { format = "date-time"; description = "An ISO date-time" }]}[@@deriving
+                                                                    jsonschema]
+include
+  struct
+    let attrs_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("label",
+                  (`Assoc
+                     [("description", (`String "An ISO date-time"));
+                     ("format", (`String "date-time"));
+                     ("type", (`String "string"))]));
+               ("score",
+                 (`Assoc
+                    [("description", (`String "Score out of 100"));
+                    ("minimum", (`Int 0));
+                    ("maximum", (`Int 100));
+                    ("type", (`String "integer"))]))]));
+          ("required", (`List [`String "label"; `String "score"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "attrs_record" =
+    print_schema attrs_record_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "label": {
+          "description": "An ISO date-time",
+          "format": "date-time",
+          "type": "string"
+        },
+        "score": {
+          "description": "Score out of 100",
+          "minimum": 0,
+          "maximum": 100,
+          "type": "integer"
+        }
+      },
+      "required": [ "label", "score" ],
+      "additionalProperties": false
+    }
+    |}]]
+type attrs_type_decl = int[@@jsonschema.attrs
+                            { description = "A plain integer" }][@@deriving
+                                                                  jsonschema]
+include
+  struct
+    let attrs_type_decl_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("description", (`String "A plain integer"));
+          ("type", (`String "integer"))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter (fun (k, _) -> k <> "$defs") ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "attrs_type_decl" =
+    print_schema attrs_type_decl_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "A plain integer",
+      "type": "integer"
+    }
+    |}]]

--- a/test/test.ml
+++ b/test/test.ml
@@ -2352,7 +2352,8 @@ let%expect_test "field_description" =
       },
       "required": [ "max_results", "query" ],
       "additionalProperties": false
-    } |}]
+    }
+    |}]
 
 type described_record = {
   name : string; [@jsonschema.description "The user's full name"]
@@ -2374,7 +2375,8 @@ let%expect_test "type_and_field_description" =
       },
       "required": [ "name" ],
       "additionalProperties": false
-    } |}]
+    }
+    |}]
 
 type with_key_and_desc = {
   opt : int option; [@key "opt_int"] [@jsonschema.option] [@jsonschema.description "An optional integer"]
@@ -2396,12 +2398,14 @@ let%expect_test "field_description_with_key" =
       },
       "required": [],
       "additionalProperties": false
-    } |}]
+    }
+    |}]
 
 type described_variant =
   | Plain [@jsonschema.description "No payload"]
   | With_int of int [@jsonschema.description "Single integer tag"]
   | Pair of string * int [@jsonschema.description "String and int"]
+  | Description_value of (string[@jsonschema.description "A string value"])
 [@@deriving jsonschema]
 
 let%expect_test "variant_constructor_description" =
@@ -2436,9 +2440,20 @@ let%expect_test "variant_constructor_description" =
           "unevaluatedItems": false,
           "minItems": 3,
           "maxItems": 3
+        },
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "Description_value" },
+            { "description": "A string value", "type": "string" }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
         }
       ]
-    } |}]
+    }
+    |}]
 
 type described_variant_inline_record =
   | Point of {
@@ -2474,7 +2489,8 @@ let%expect_test "variant_inline_record_constructor_description" =
           "maxItems": 2
         }
       ]
-    } |}]
+    }
+    |}]
 
 type described_variant_string =
   | A [@jsonschema.description "First choice"]
@@ -2491,7 +2507,8 @@ let%expect_test "variant_constructor_description_variant_as_string" =
         { "description": "First choice", "const": "A" },
         { "description": "Second choice", "const": "B" }
       ]
-    } |}]
+    }
+    |}]
 
 (* Top-level @@jsonschema.description on a variant (whole anyOf schema). *)
 type computation_result =
@@ -2522,7 +2539,8 @@ let%expect_test "variant_type_level_description" =
           "maxItems": 2
         }
       ]
-    } |}]
+    }
+    |}]
 
 type nullable_fields = {
   plain : string option;
@@ -2574,6 +2592,73 @@ let%expect_test "nullable_option_composing" =
       },
       "required": [],
       "additionalProperties": false
+    }
+    |}]
+
+type with_format = string [@@jsonschema.format "date-time"] [@@deriving jsonschema]
+
+let%expect_test "with_format" =
+  print_schema with_format_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "format": "date-time",
+      "type": "string"
+    }
+    |}]
+
+type with_format_record = { with_format : string [@jsonschema.format "date-time"] } [@@deriving jsonschema]
+
+let%expect_test "with_format_record" =
+  print_schema with_format_record_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "with_format": { "format": "date-time", "type": "string" }
+      },
+      "required": [ "with_format" ],
+      "additionalProperties": false
+    }
+    |}]
+
+type with_format_variant =
+  | A of (string[@jsonschema.format "date-time"] [@jsonschema.description "A date-time string"])
+  | B
+[@@deriving jsonschema]
+
+let%expect_test "with_format_variant" =
+  print_schema with_format_variant_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "A" },
+            {
+              "description": "A date-time string",
+              "format": "date-time",
+              "type": "string"
+            }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "B" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        }
+      ]
     }
     |}]
 
@@ -2655,7 +2740,7 @@ let%expect_test "no_duplicate_id_when_recursive_type_used_twice" =
       "type": "object",
       "properties": {
         "b": {
-          "$id": "file://test/test.ml:2645",
+          "$id": "file://test/test.ml:2730",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -2672,7 +2757,7 @@ let%expect_test "no_duplicate_id_when_recursive_type_used_twice" =
           "$ref": "#/$defs/self_ref"
         },
         "a": {
-          "$id": "file://test/test.ml:2644",
+          "$id": "file://test/test.ml:2729",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -2819,7 +2904,7 @@ let%expect_test "polymorphic_recursive_ref_bool_filter" =
               "prefixItems": [
                 { "const": "BoolAtom" },
                 {
-                  "$id": "file://test/test.ml:2704",
+                  "$id": "file://test/test.ml:2789",
                   "$defs": {
                     "filter": {
                       "anyOf": [

--- a/test/test.ml
+++ b/test/test.ml
@@ -2957,3 +2957,31 @@ let%expect_test "polymorphic_recursive_ref_bool_filter" =
       "$ref": "#/$defs/bool_filter"
     }
     |}]
+
+type with_maximum = int [@@jsonschema.maximum 100] [@@deriving jsonschema]
+
+let%expect_test "with_maximum" =
+  print_schema with_maximum_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "maximum": 100,
+      "type": "integer"
+    }
+    |}]
+
+type with_maximum_record = { field : int [@jsonschema.maximum 100] } [@@deriving jsonschema]
+
+let%expect_test "with_maximum" =
+  print_schema with_maximum_record_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": { "field": { "maximum": 100, "type": "integer" } },
+      "required": [ "field" ],
+      "additionalProperties": false
+    }
+    |}]

--- a/test/test.ml
+++ b/test/test.ml
@@ -2642,8 +2642,8 @@ let%expect_test "with_format_variant" =
           "prefixItems": [
             { "const": "A" },
             {
-              "description": "A date-time string",
               "format": "date-time",
+              "description": "A date-time string",
               "type": "string"
             }
           ],
@@ -3048,5 +3048,135 @@ let%expect_test "attrs_type_decl" =
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "A plain integer",
       "type": "integer"
+    }
+    |}]
+
+(* [@jsonschema.minimum] and [@jsonschema.maximum] — all annotation contexts *)
+
+(* core type: int *)
+type minimum_core_type_int =
+  (int[@jsonschema.minimum 0] [@jsonschema.maximum 100])
+[@@deriving jsonschema]
+
+let%expect_test "minimum_maximum_core_type_int" =
+  print_schema minimum_core_type_int_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "minimum": 0,
+      "maximum": 100,
+      "type": "integer"
+    }
+    |}]
+
+(* core type: float *)
+type minimum_core_type_float =
+  (float[@jsonschema.minimum 0.0] [@jsonschema.maximum 1.0])
+[@@deriving jsonschema]
+
+let%expect_test "minimum_maximum_core_type_float" =
+  print_schema minimum_core_type_float_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "minimum": 0.0,
+      "maximum": 1.0,
+      "type": "number"
+    }
+    |}]
+
+(* label declaration: int and float fields *)
+type minimum_maximum_record = {
+  score : int; [@jsonschema.minimum 0] [@jsonschema.maximum 100]
+  ratio : float; [@jsonschema.minimum 0.0] [@jsonschema.maximum 1.0]
+}
+[@@deriving jsonschema]
+
+let%expect_test "minimum_maximum_record" =
+  print_schema minimum_maximum_record_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "ratio": { "minimum": 0.0, "maximum": 1.0, "type": "number" },
+        "score": { "minimum": 0, "maximum": 100, "type": "integer" }
+      },
+      "required": [ "ratio", "score" ],
+      "additionalProperties": false
+    }
+    |}]
+
+(* type declaration: int *)
+type minimum_maximum_type_decl_int = int
+[@@jsonschema.minimum 0] [@@jsonschema.maximum 255]
+[@@deriving jsonschema]
+
+let%expect_test "minimum_maximum_type_decl_int" =
+  print_schema minimum_maximum_type_decl_int_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "minimum": 0,
+      "maximum": 255,
+      "type": "integer"
+    }
+    |}]
+
+(* type declaration: float *)
+type minimum_maximum_type_decl_float = float
+[@@jsonschema.minimum 0.0] [@@jsonschema.maximum 1.0]
+[@@deriving jsonschema]
+
+let%expect_test "minimum_maximum_type_decl_float" =
+  print_schema minimum_maximum_type_decl_float_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "minimum": 0.0,
+      "maximum": 1.0,
+      "type": "number"
+    }
+    |}]
+
+(* variant payload: core type annotation *)
+type minimum_maximum_variant =
+  | Percentage of (int[@jsonschema.minimum 0] [@jsonschema.maximum 100])
+  | Factor of (float[@jsonschema.minimum 0.0] [@jsonschema.maximum 1.0])
+[@@deriving jsonschema]
+
+let%expect_test "minimum_maximum_variant" =
+  print_schema minimum_maximum_variant_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "Percentage" },
+            { "minimum": 0, "maximum": 100, "type": "integer" }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        },
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "Factor" },
+            { "minimum": 0.0, "maximum": 1.0, "type": "number" }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
     }
     |}]

--- a/test/test.ml
+++ b/test/test.ml
@@ -2989,9 +2989,7 @@ let%expect_test "with_maximum" =
 (* [@jsonschema.attrs] — composite attribute bundling multiple annotations *)
 
 type attrs_core_type =
-  (int
-  [@jsonschema.attrs
-    { maximum = 100; minimum = 0; description = "Integer percentage value (0-100 inclusive)" }])
+  (int[@jsonschema.attrs { maximum = 100; minimum = 0; description = "Integer percentage value (0-100 inclusive)" }])
 [@@deriving jsonschema]
 
 let%expect_test "attrs_core_type" =
@@ -3054,9 +3052,7 @@ let%expect_test "attrs_type_decl" =
 (* [@jsonschema.minimum] and [@jsonschema.maximum] — all annotation contexts *)
 
 (* core type: int *)
-type minimum_core_type_int =
-  (int[@jsonschema.minimum 0] [@jsonschema.maximum 100])
-[@@deriving jsonschema]
+type minimum_core_type_int = (int[@jsonschema.minimum 0] [@jsonschema.maximum 100]) [@@deriving jsonschema]
 
 let%expect_test "minimum_maximum_core_type_int" =
   print_schema minimum_core_type_int_jsonschema;
@@ -3071,9 +3067,7 @@ let%expect_test "minimum_maximum_core_type_int" =
     |}]
 
 (* core type: float *)
-type minimum_core_type_float =
-  (float[@jsonschema.minimum 0.0] [@jsonschema.maximum 1.0])
-[@@deriving jsonschema]
+type minimum_core_type_float = (float[@jsonschema.minimum 0.0] [@jsonschema.maximum 1.0]) [@@deriving jsonschema]
 
 let%expect_test "minimum_maximum_core_type_float" =
   print_schema minimum_core_type_float_jsonschema;
@@ -3111,9 +3105,7 @@ let%expect_test "minimum_maximum_record" =
     |}]
 
 (* type declaration: int *)
-type minimum_maximum_type_decl_int = int
-[@@jsonschema.minimum 0] [@@jsonschema.maximum 255]
-[@@deriving jsonschema]
+type minimum_maximum_type_decl_int = int [@@jsonschema.minimum 0] [@@jsonschema.maximum 255] [@@deriving jsonschema]
 
 let%expect_test "minimum_maximum_type_decl_int" =
   print_schema minimum_maximum_type_decl_int_jsonschema;
@@ -3129,8 +3121,7 @@ let%expect_test "minimum_maximum_type_decl_int" =
 
 (* type declaration: float *)
 type minimum_maximum_type_decl_float = float
-[@@jsonschema.minimum 0.0] [@@jsonschema.maximum 1.0]
-[@@deriving jsonschema]
+[@@jsonschema.minimum 0.0] [@@jsonschema.maximum 1.0] [@@deriving jsonschema]
 
 let%expect_test "minimum_maximum_type_decl_float" =
   print_schema minimum_maximum_type_decl_float_jsonschema;

--- a/test/test.ml
+++ b/test/test.ml
@@ -2985,3 +2985,68 @@ let%expect_test "with_maximum" =
       "additionalProperties": false
     }
     |}]
+
+(* [@jsonschema.attrs] — composite attribute bundling multiple annotations *)
+
+type attrs_core_type =
+  (int
+  [@jsonschema.attrs
+    { maximum = 100; minimum = 0; description = "Integer percentage value (0-100 inclusive)" }])
+[@@deriving jsonschema]
+
+let%expect_test "attrs_core_type" =
+  print_schema attrs_core_type_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Integer percentage value (0-100 inclusive)",
+      "minimum": 0,
+      "maximum": 100,
+      "type": "integer"
+    }
+    |}]
+
+type attrs_record = {
+  score : int; [@jsonschema.attrs { maximum = 100; minimum = 0; description = "Score out of 100" }]
+  label : string; [@jsonschema.attrs { format = "date-time"; description = "An ISO date-time" }]
+}
+[@@deriving jsonschema]
+
+let%expect_test "attrs_record" =
+  print_schema attrs_record_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "label": {
+          "description": "An ISO date-time",
+          "format": "date-time",
+          "type": "string"
+        },
+        "score": {
+          "description": "Score out of 100",
+          "minimum": 0,
+          "maximum": 100,
+          "type": "integer"
+        }
+      },
+      "required": [ "label", "score" ],
+      "additionalProperties": false
+    }
+    |}]
+
+type attrs_type_decl = int [@@jsonschema.attrs { description = "A plain integer" }] [@@deriving jsonschema]
+
+let%expect_test "attrs_type_decl" =
+  print_schema attrs_type_decl_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "A plain integer",
+      "type": "integer"
+    }
+    |}]


### PR DESCRIPTION
## Summary

- Introduce `Schema.Annotation` module with compile-time helpers (`add_description`, `add_format`, `add_maximum`, `add_minimum`), replacing repetitive `match Attribute.get ... with` blocks throughout the PPX
- Add `[@jsonschema.format]` and `[@jsonschema.description]` support on core types (e.g. variant payloads: `A of (string[@jsonschema.format "date-time"])`); `format` is validated to only apply to `string`/`bytes` types
- Add `[@jsonschema.maximum]` and `[@jsonschema.minimum]` annotations on type declarations, label declarations, and core types; validated to only apply to numeric types (`int`, `int32`, `nativeint`, `float`)
- Add `[@jsonschema.attrs]` composite attribute to bundle multiple schema annotations in a single record expression (e.g. `[@jsonschema.attrs { maximum = 100; minimum = 0; description = "Score" }]`); supported on core types, label declarations, and type declarations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
