### PR TITLE
Fix jsonschema typing on main without ocamldoc changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ type t = {
 let schema = Ppx_deriving_jsonschema_runtime.json_schema t_jsonschema
 ```
 
+`Ppx_deriving_jsonschema_runtime.t` is the runtime JSON type produced by the PPX.
+On native OCaml it is structurally compatible with `Yojson.Basic.t`, so if a
+consumer expects `Yojson.Basic.t`, use a coercion:
+
+```ocaml
+let schema : Yojson.Basic.t =
+  (Ppx_deriving_jsonschema_runtime.json_schema t_jsonschema :> Yojson.Basic.t)
+```
+
+Do not use `Yojson.Safe.to_basic` here: the runtime type is not `Yojson.Safe.t`.
+
 Such a type will be turned into a JSON schema like this:
 ```json
 {
@@ -645,7 +656,7 @@ type t = {
 
 Set a default value for a record field. Fields with a default are excluded from `required`.
 
-Primitive literals (`int`, `int32`, `nativeint`, `float`, `string`, `bytes`, `bool`) and their `option`, `list`, and `array` variants are serialized automatically. For non-primitive types (custom variants, records, etc.) a `<type>_to_json : <type> -> Yojson.Basic.t` function must be in scope — e.g. via `[@@deriving json]` from melange-json.
+Primitive literals (`int`, `int32`, `nativeint`, `float`, `string`, `bytes`, `bool`) and their `option`, `list`, and `array` variants are serialized automatically. For non-primitive types (custom variants, records, etc.) a `<type>_to_json` function must be in scope and return Melange-json-compatible JSON. On native that is typically `Yojson.Basic.t`; with Melange this is naturally satisfied by `[@@deriving json]` from melange-json.
 
 ```ocaml
 type status = Active | Inactive [@@deriving jsonschema]

--- a/runtime/ppx_deriving_jsonschema_runtime.ml
+++ b/runtime/ppx_deriving_jsonschema_runtime.ml
@@ -14,7 +14,7 @@ include struct
     ]
 end
 
-let json_schema ?id ?title ?description ?definitions types =
+let json_schema ?id ?title ?description ?definitions (types : t) : t =
   match types with
   | `Assoc types ->
     let metadata =
@@ -37,3 +37,4 @@ let json_schema ?id ?title ?description ?definitions types =
         ]
     in
     `Assoc (metadata @ types)
+  | _ -> invalid_arg "json_schema expects an object schema"

--- a/runtime/ppx_deriving_jsonschema_runtime.ml
+++ b/runtime/ppx_deriving_jsonschema_runtime.ml
@@ -1,6 +1,10 @@
 let schema_version = "https://json-schema.org/draft/2020-12/schema"
 
-(* There is no Yojson.Basic.t in Melange and the Melange_json.t is not compatible with Yojson.Basic.t, so we use our own type to support universal API *)
+(* Melange does not expose Yojson.Basic.t, and Melange_json.t is not directly
+   compatible with it, so the runtime exposes its own JSON type [t]. On native,
+   [t] is structurally compatible with [Yojson.Basic.t], so callers can coerce
+   with [(schema :> Yojson.Basic.t)] when needed. Do not use
+   [Yojson.Safe.to_basic] here: [t] is not a [Yojson.Safe.t]. *)
 
 include struct
   type t =

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -5,6 +5,10 @@ let deriver_name = "jsonschema"
 
 let value_name_pattern ~loc type_name = ppat_var ~loc { txt = type_name ^ "_jsonschema"; loc }
 
+let jsonschema_t ~loc = ptyp_constr ~loc { txt = Ldot (Lident "Ppx_deriving_jsonschema_runtime", "t"); loc } []
+
+let jsonschema_value_type td = combinator_type_of_type_declaration td ~f:(fun ~loc _core_type -> jsonschema_t ~loc)
+
 let create_value ~loc name value = [%stri let[@warning "-32-39"] [%p value_name_pattern ~loc name] = [%e value]]
 
 (* Wraps [body] in nested lambdas, one per type parameter.
@@ -52,6 +56,7 @@ let rec schema_of_core_type ~(config : Attrs.config) ?(recursive_types = []) cor
         let args = List.map fst results in
         let is_rec = List.exists snd results in
         let schema = type_constr_conv ~loc id ~f:(fun s -> s ^ "_jsonschema") args in
+        let schema = [%expr ([%e schema] : Ppx_deriving_jsonschema_runtime.t)] in
         let edv = evar ~loc "ppx_eds" in
         (match is_rec with
         | true ->
@@ -373,13 +378,13 @@ let sig_type_decl ~ctxt ast _flag_variant_as_string _flag_polymorphic_variant_tu
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
   match ast with
   | _, [ td ] ->
-    let typ = combinator_type_of_type_declaration td ~f:(fun ~loc _core_type -> jsonschema_t ~loc) in
+    let typ = jsonschema_value_type td in
     let name = { txt = td.ptype_name.txt ^ "_jsonschema"; loc } in
     [ psig_value ~loc (value_description ~loc ~name ~type_:typ ~prim:[]) ]
   | _, type_decls when List.length type_decls > 1 ->
     List.map
       (fun td ->
-        let typ = combinator_type_of_type_declaration td ~f:(fun ~loc _core_type -> jsonschema_t ~loc) in
+        let typ = jsonschema_value_type td in
         let name = { txt = td.ptype_name.txt ^ "_jsonschema"; loc } in
         psig_value ~loc (value_description ~loc ~name ~type_:typ ~prim:[]))
       type_decls

--- a/src/schema.ml
+++ b/src/schema.ml
@@ -85,6 +85,21 @@ let variants ~loc ?(as_string = false) constrs =
          | `Inherit typ -> typ)
        constrs)
 
+let json_like_to_runtime ~loc json_expr =
+  [%expr
+    let rec ppx_deriving_jsonschema_runtime_of_json_like json =
+      match Melange_json.classify json with
+      | `Null -> `Null
+      | `String s -> `String s
+      | `Float f -> `Float f
+      | `Int i -> `Int i
+      | `Bool b -> `Bool b
+      | `List xs -> `List (List.map ppx_deriving_jsonschema_runtime_of_json_like xs)
+      | `Assoc fields ->
+        `Assoc (List.map (fun (k, v) -> k, ppx_deriving_jsonschema_runtime_of_json_like v) fields)
+    in
+    ppx_deriving_jsonschema_runtime_of_json_like [%e json_expr]]
+
 module Annotation = struct
   let add_schema_attr (attr, node) f schema =
     match Attribute.get attr node with
@@ -144,11 +159,14 @@ module Annotation = struct
     | { ptyp_desc = Ptyp_var name; _ } -> evar ~loc name
     | { ptyp_desc = Ptyp_constr (id, args); _ } ->
       let arg_serializers = List.map (serializer_of_core_type ~loc) args in
-      type_constr_conv ~loc id ~f:(fun s -> if String.equal s "t" then "to_json" else s ^ "_to_json") arg_serializers
+      let to_json =
+        type_constr_conv ~loc id ~f:(fun s -> if String.equal s "t" then "to_json" else s ^ "_to_json") arg_serializers
+      in
+      [%expr fun x -> [%e json_like_to_runtime ~loc [%expr [%e to_json] x]]]
     | _ ->
       Location.raise_errorf ~loc:ct.ptyp_loc
         "[@jsonschema.default] cannot serialize this type. For non-primitive types, ensure a '<type>_to_json' function \
-         is in scope (e.g., add [@@deriving json] to the type definition)"
+         is in scope and returns Melange_json-compatible JSON (e.g., add [@@deriving json] to the type definition)"
 
   let add_default ~loc attr core_type =
     add_schema_attr attr (fun expr schema ->

--- a/src/schema.ml
+++ b/src/schema.ml
@@ -95,8 +95,7 @@ let json_like_to_runtime ~loc json_expr =
       | `Int i -> `Int i
       | `Bool b -> `Bool b
       | `List xs -> `List (List.map ppx_deriving_jsonschema_runtime_of_json_like xs)
-      | `Assoc fields ->
-        `Assoc (List.map (fun (k, v) -> k, ppx_deriving_jsonschema_runtime_of_json_like v) fields)
+      | `Assoc fields -> `Assoc (List.map (fun (k, v) -> k, ppx_deriving_jsonschema_runtime_of_json_like v) fields)
     in
     ppx_deriving_jsonschema_runtime_of_json_like [%e json_expr]]
 

--- a/test/generate_schemas.ml
+++ b/test/generate_schemas.ml
@@ -37,4 +37,4 @@ let schemas =
 
 let schema = `Assoc [ "$schema", `String "https://json-schema.org/draft/2020-12/schema"; "oneOf", `List schemas ]
 
-let () = print_endline (Yojson.Basic.pretty_to_string schema)
+let () = print_endline (Yojson.Basic.pretty_to_string (runtime_to_yojson schema))

--- a/test/generate_schemas.ml
+++ b/test/generate_schemas.ml
@@ -35,6 +35,8 @@ let schemas =
     json_schema variant_with_payload_jsonschema;
   ]
 
-let schema : Yojson.Basic.t = (`Assoc [ "$schema", `String "https://json-schema.org/draft/2020-12/schema"; "oneOf", `List schemas ] :> Yojson.Basic.t)
+let schema : Yojson.Basic.t =
+  (`Assoc [ "$schema", `String "https://json-schema.org/draft/2020-12/schema"; "oneOf", `List schemas ]
+    :> Yojson.Basic.t)
 
 let () = print_endline (Yojson.Basic.pretty_to_string schema)

--- a/test/generate_schemas.ml
+++ b/test/generate_schemas.ml
@@ -35,6 +35,6 @@ let schemas =
     json_schema variant_with_payload_jsonschema;
   ]
 
-let schema = `Assoc [ "$schema", `String "https://json-schema.org/draft/2020-12/schema"; "oneOf", `List schemas ]
+let schema : Yojson.Basic.t = (`Assoc [ "$schema", `String "https://json-schema.org/draft/2020-12/schema"; "oneOf", `List schemas ] :> Yojson.Basic.t)
 
-let () = print_endline (Yojson.Basic.pretty_to_string (runtime_to_yojson schema))
+let () = print_endline (Yojson.Basic.pretty_to_string schema)

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -1,22 +1,9 @@
 [@@@ocaml.warning "-37-69"]
-let rec runtime_to_yojson :
-  Ppx_deriving_jsonschema_runtime.t -> Yojson.Basic.t =
-  function
-  | `Null -> `Null
-  | `String s -> `String s
-  | `Float f -> `Float f
-  | `Int i -> `Int i
-  | `Bool b -> `Bool b
-  | `List xs -> `List (List.map runtime_to_yojson xs)
-  | `Assoc fields ->
-      `Assoc (List.map (fun (k, v) -> (k, (runtime_to_yojson v))) fields)
 let print_schema ?definitions ?id ?title ?description s =
-  let s =
-    Ppx_deriving_jsonschema_runtime.json_schema ?definitions ?id ?title
-      ?description s in
-  let () =
-    print_endline (Yojson.Basic.pretty_to_string (runtime_to_yojson s)) in
-  ()
+  let s : Yojson.Basic.t =
+    (Ppx_deriving_jsonschema_runtime.json_schema ?definitions ?id ?title
+       ?description s :> Yojson.Basic.t) in
+  let () = print_endline (Yojson.Basic.pretty_to_string s) in ()
 let string_jsonschema = `Assoc [("type", (`String "string"))]
 let int_jsonschema = `Assoc [("type", (`String "integer"))]
 let bool_jsonschema = `Assoc [("type", (`String "boolean"))]
@@ -164,7 +151,7 @@ include
                   ((match (Mod1.Mod2.m_2_jsonschema : Ppx_deriving_jsonschema_runtime.t)
                     with
                     | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                        `Assoc (("$id", (`String "file://test.ml:87")) ::
+                        `Assoc (("$id", (`String "file://test.ml:78")) ::
                           (List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -173,7 +160,7 @@ include
                  ((match (Mod1.m_1_jsonschema : Ppx_deriving_jsonschema_runtime.t)
                    with
                    | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                       `Assoc (("$id", (`String "file://test.ml:86")) ::
+                       `Assoc (("$id", (`String "file://test.ml:77")) ::
                          (List.filter
                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                             pairs))
@@ -610,7 +597,7 @@ include
                 (match (poly_kind_jsonschema : Ppx_deriving_jsonschema_runtime.t)
                  with
                  | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                     `Assoc (("$id", (`String "file://test.ml:314")) ::
+                     `Assoc (("$id", (`String "file://test.ml:305")) ::
                        (List.filter
                           (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                           pairs))
@@ -693,7 +680,7 @@ include
                 (match (poly_kind_as_string_jsonschema : Ppx_deriving_jsonschema_runtime.t)
                  with
                  | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                     `Assoc (("$id", (`String "file://test.ml:371")) ::
+                     `Assoc (("$id", (`String "file://test.ml:362")) ::
                        (List.filter
                           (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                           pairs))
@@ -798,7 +785,7 @@ include
                  ((match (kind_jsonschema : Ppx_deriving_jsonschema_runtime.t)
                    with
                    | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                       `Assoc (("$id", (`String "file://test.ml:393")) ::
+                       `Assoc (("$id", (`String "file://test.ml:384")) ::
                          (List.filter
                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                             pairs))
@@ -1977,7 +1964,7 @@ include
       let ppx_result =
         match (tree_jsonschema : Ppx_deriving_jsonschema_runtime.t) with
         | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-            `Assoc (("$id", (`String "file://test.ml:921")) ::
+            `Assoc (("$id", (`String "file://test.ml:912")) ::
               (List.filter (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                  pairs))
         | other -> other in
@@ -1999,7 +1986,7 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "file://test/test.ml:921",
+      "$id": "file://test/test.ml:912",
       "$defs": {
         "tree": {
           "anyOf": [
@@ -2047,7 +2034,7 @@ include
             ((match (event_jsonschema : Ppx_deriving_jsonschema_runtime.t)
               with
               | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                  `Assoc (("$id", (`String "file://test.ml:966")) ::
+                  `Assoc (("$id", (`String "file://test.ml:957")) ::
                     (List.filter
                        (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                        pairs))
@@ -2158,7 +2145,7 @@ include
                  ((match (event_jsonschema : Ppx_deriving_jsonschema_runtime.t)
                    with
                    | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                       `Assoc (("$id", (`String "file://test.ml:1048")) ::
+                       `Assoc (("$id", (`String "file://test.ml:1039")) ::
                          (List.filter
                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                             pairs))
@@ -2270,7 +2257,7 @@ include
                [(match (event_jsonschema : Ppx_deriving_jsonschema_runtime.t)
                  with
                  | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                     `Assoc (("$id", (`String "file://test.ml:1133")) ::
+                     `Assoc (("$id", (`String "file://test.ml:1124")) ::
                        (List.filter
                           (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                           pairs))
@@ -2388,7 +2375,7 @@ include
             ((match (event_comment_jsonschema : Ppx_deriving_jsonschema_runtime.t)
               with
               | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                  `Assoc (("$id", (`String "file://test.ml:1221")) ::
+                  `Assoc (("$id", (`String "file://test.ml:1212")) ::
                     (List.filter
                        (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                        pairs))
@@ -2509,7 +2496,7 @@ include
                     [(match (event_jsonschema : Ppx_deriving_jsonschema_runtime.t)
                       with
                       | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                          `Assoc (("$id", (`String "file://test.ml:1312")) ::
+                          `Assoc (("$id", (`String "file://test.ml:1303")) ::
                             (List.filter
                                (fun (k, _) ->
                                   not (Stdlib.String.equal k "$id")) pairs))
@@ -2630,7 +2617,7 @@ include
             ((match (events_jsonschema : Ppx_deriving_jsonschema_runtime.t)
               with
               | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                  `Assoc (("$id", (`String "file://test.ml:1403")) ::
+                  `Assoc (("$id", (`String "file://test.ml:1394")) ::
                     (List.filter
                        (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                        pairs))
@@ -2802,7 +2789,7 @@ include
                   ((match (Mod1.m_1_jsonschema : Ppx_deriving_jsonschema_runtime.t)
                     with
                     | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                        `Assoc (("$id", (`String "file://test.ml:1512")) ::
+                        `Assoc (("$id", (`String "file://test.ml:1503")) ::
                           (List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -3057,7 +3044,7 @@ include
                   ((match (address_jsonschema : Ppx_deriving_jsonschema_runtime.t)
                     with
                     | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                        `Assoc (("$id", (`String "file://test.ml:1634")) ::
+                        `Assoc (("$id", (`String "file://test.ml:1625")) ::
                           (List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -4092,7 +4079,7 @@ include
                   ((match (obj2_jsonschema : Ppx_deriving_jsonschema_runtime.t)
                     with
                     | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                        `Assoc (("$id", (`String "file://test.ml:2108")) ::
+                        `Assoc (("$id", (`String "file://test.ml:2099")) ::
                           (List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -4125,7 +4112,7 @@ include
                   ((match (obj1_jsonschema : Ppx_deriving_jsonschema_runtime.t)
                     with
                     | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                        `Assoc (("$id", (`String "file://test.ml:2109")) ::
+                        `Assoc (("$id", (`String "file://test.ml:2100")) ::
                           (List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -4281,7 +4268,7 @@ include
                  (`Assoc [("type", (`String "string"))]) : Ppx_deriving_jsonschema_runtime.t)
         with
         | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-            `Assoc (("$id", (`String "file://test.ml:2180")) ::
+            `Assoc (("$id", (`String "file://test.ml:2171")) ::
               (List.filter (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                  pairs))
         | other -> other in
@@ -4515,7 +4502,7 @@ include
         match (either_jsonschema a b : Ppx_deriving_jsonschema_runtime.t)
         with
         | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-            `Assoc (("$id", (`String "file://test.ml:2292")) ::
+            `Assoc (("$id", (`String "file://test.ml:2283")) ::
               (List.filter (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                  pairs))
         | other -> other in
@@ -5618,7 +5605,7 @@ include
                              | `Assoc pairs when List.mem_assoc "$defs" pairs
                                  ->
                                  `Assoc
-                                   (("$id", (`String "file://test.ml:2805"))
+                                   (("$id", (`String "file://test.ml:2796"))
                                    ::
                                    (List.filter
                                       (fun (k, _) ->
@@ -5947,7 +5934,7 @@ include
                   ((match (self_ref_jsonschema : Ppx_deriving_jsonschema_runtime.t)
                     with
                     | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                        `Assoc (("$id", (`String "file://test.ml:2958")) ::
+                        `Assoc (("$id", (`String "file://test.ml:2949")) ::
                           (List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -5956,7 +5943,7 @@ include
                  ((match (self_ref_jsonschema : Ppx_deriving_jsonschema_runtime.t)
                    with
                    | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                       `Assoc (("$id", (`String "file://test.ml:2957")) ::
+                       `Assoc (("$id", (`String "file://test.ml:2948")) ::
                          (List.filter
                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                             pairs))
@@ -5984,7 +5971,7 @@ include
       "type": "object",
       "properties": {
         "b": {
-          "$id": "file://test/test.ml:2958",
+          "$id": "file://test/test.ml:2949",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -6001,7 +5988,7 @@ include
           "$ref": "#/$defs/self_ref"
         },
         "a": {
-          "$id": "file://test/test.ml:2957",
+          "$id": "file://test/test.ml:2948",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -6078,7 +6065,7 @@ include
                         (match (filter_jsonschema atom group_atom : Ppx_deriving_jsonschema_runtime.t)
                          with
                          | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                             `Assoc (("$id", (`String "file://test.ml:3017"))
+                             `Assoc (("$id", (`String "file://test.ml:3008"))
                                ::
                                (List.filter
                                   (fun (k, _) ->
@@ -6295,7 +6282,7 @@ include
               "prefixItems": [
                 { "const": "BoolAtom" },
                 {
-                  "$id": "file://test/test.ml:3017",
+                  "$id": "file://test/test.ml:3008",
                   "$defs": {
                     "filter": {
                       "anyOf": [
@@ -6925,7 +6912,7 @@ include
                  ((match match (record_for_default_jsonschema : Ppx_deriving_jsonschema_runtime.t)
                          with
                          | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                             `Assoc (("$id", (`String "file://test.ml:3429"))
+                             `Assoc (("$id", (`String "file://test.ml:3420"))
                                ::
                                (List.filter
                                   (fun (k, _) ->
@@ -6965,7 +6952,7 @@ include
                  ((match match (variant_for_default_jsonschema : Ppx_deriving_jsonschema_runtime.t)
                          with
                          | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                             `Assoc (("$id", (`String "file://test.ml:3428"))
+                             `Assoc (("$id", (`String "file://test.ml:3419"))
                                ::
                                (List.filter
                                   (fun (k, _) ->
@@ -7139,7 +7126,7 @@ include
                           with
                           | `Assoc pairs when List.mem_assoc "$defs" pairs ->
                               `Assoc
-                                (("$id", (`String "file://test.ml:3494")) ::
+                                (("$id", (`String "file://test.ml:3485")) ::
                                 (List.filter
                                    (fun (k, _) ->
                                       not (Stdlib.String.equal k "$id"))

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -1,9 +1,22 @@
 [@@@ocaml.warning "-37-69"]
-let print_schema ?definitions  ?id  ?title  ?description  s =
+let rec runtime_to_yojson :
+  Ppx_deriving_jsonschema_runtime.t -> Yojson.Basic.t =
+  function
+  | `Null -> `Null
+  | `String s -> `String s
+  | `Float f -> `Float f
+  | `Int i -> `Int i
+  | `Bool b -> `Bool b
+  | `List xs -> `List (List.map runtime_to_yojson xs)
+  | `Assoc fields ->
+      `Assoc (List.map (fun (k, v) -> (k, (runtime_to_yojson v))) fields)
+let print_schema ?definitions ?id ?title ?description s =
   let s =
     Ppx_deriving_jsonschema_runtime.json_schema ?definitions ?id ?title
       ?description s in
-  let () = print_endline (Yojson.Basic.pretty_to_string s) in ()
+  let () =
+    print_endline (Yojson.Basic.pretty_to_string (runtime_to_yojson s)) in
+  ()
 let string_jsonschema = `Assoc [("type", (`String "string"))]
 let int_jsonschema = `Assoc [("type", (`String "integer"))]
 let bool_jsonschema = `Assoc [("type", (`String "boolean"))]
@@ -148,17 +161,19 @@ include
           ("properties",
             (`Assoc
                [("m2",
-                  ((match Mod1.Mod2.m_2_jsonschema with
+                  ((match (Mod1.Mod2.m_2_jsonschema : Ppx_deriving_jsonschema_runtime.t)
+                    with
                     | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                        `Assoc (("$id", (`String "file://test.ml:78")) ::
+                        `Assoc (("$id", (`String "file://test.ml:87")) ::
                           (List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
                     | other -> other)));
                ("m",
-                 ((match Mod1.m_1_jsonschema with
+                 ((match (Mod1.m_1_jsonschema : Ppx_deriving_jsonschema_runtime.t)
+                   with
                    | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                       `Assoc (("$id", (`String "file://test.ml:77")) ::
+                       `Assoc (("$id", (`String "file://test.ml:86")) ::
                          (List.filter
                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                             pairs))
@@ -592,9 +607,10 @@ include
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))];
-                (match poly_kind_jsonschema with
+                (match (poly_kind_jsonschema : Ppx_deriving_jsonschema_runtime.t)
+                 with
                  | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                     `Assoc (("$id", (`String "file://test.ml:305")) ::
+                     `Assoc (("$id", (`String "file://test.ml:314")) ::
                        (List.filter
                           (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                           pairs))
@@ -674,9 +690,10 @@ include
              (`List
                 [`Assoc [("const", (`String "New_one"))];
                 `Assoc [("const", (`String "Second_one"))];
-                (match poly_kind_as_string_jsonschema with
+                (match (poly_kind_as_string_jsonschema : Ppx_deriving_jsonschema_runtime.t)
+                 with
                  | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                     `Assoc (("$id", (`String "file://test.ml:362")) ::
+                     `Assoc (("$id", (`String "file://test.ml:371")) ::
                        (List.filter
                           (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                           pairs))
@@ -778,9 +795,10 @@ include
                     [("type", (`List [`String "integer"; `String "null"]))]));
                ("comment", (`Assoc [("type", (`String "string"))]));
                ("kind_f",
-                 ((match kind_jsonschema with
+                 ((match (kind_jsonschema : Ppx_deriving_jsonschema_runtime.t)
+                   with
                    | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                       `Assoc (("$id", (`String "file://test.ml:384")) ::
+                       `Assoc (("$id", (`String "file://test.ml:393")) ::
                          (List.filter
                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                             pairs))
@@ -1957,9 +1975,9 @@ include
     let int_tree_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        match tree_jsonschema with
+        match (tree_jsonschema : Ppx_deriving_jsonschema_runtime.t) with
         | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-            `Assoc (("$id", (`String "file://test.ml:912")) ::
+            `Assoc (("$id", (`String "file://test.ml:921")) ::
               (List.filter (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                  pairs))
         | other -> other in
@@ -1981,7 +1999,7 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "file://test/test.ml:912",
+      "$id": "file://test/test.ml:921",
       "$defs": {
         "tree": {
           "anyOf": [
@@ -2026,9 +2044,10 @@ include
         `Assoc
           [("type", (`String "array"));
           ("items",
-            ((match event_jsonschema with
+            ((match (event_jsonschema : Ppx_deriving_jsonschema_runtime.t)
+              with
               | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                  `Assoc (("$id", (`String "file://test.ml:957")) ::
+                  `Assoc (("$id", (`String "file://test.ml:966")) ::
                     (List.filter
                        (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                        pairs))
@@ -2136,9 +2155,10 @@ include
             (`Assoc
                [("type", (`String "array"));
                ("items",
-                 ((match event_jsonschema with
+                 ((match (event_jsonschema : Ppx_deriving_jsonschema_runtime.t)
+                   with
                    | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                       `Assoc (("$id", (`String "file://test.ml:1039")) ::
+                       `Assoc (("$id", (`String "file://test.ml:1048")) ::
                          (List.filter
                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                             pairs))
@@ -2247,9 +2267,10 @@ include
           [("type", (`String "array"));
           ("prefixItems",
             (`List
-               [(match event_jsonschema with
+               [(match (event_jsonschema : Ppx_deriving_jsonschema_runtime.t)
+                 with
                  | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                     `Assoc (("$id", (`String "file://test.ml:1124")) ::
+                     `Assoc (("$id", (`String "file://test.ml:1133")) ::
                        (List.filter
                           (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                           pairs))
@@ -2364,9 +2385,10 @@ include
         `Assoc
           [("type", (`String "array"));
           ("items",
-            ((match event_comment_jsonschema with
+            ((match (event_comment_jsonschema : Ppx_deriving_jsonschema_runtime.t)
+              with
               | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                  `Assoc (("$id", (`String "file://test.ml:1212")) ::
+                  `Assoc (("$id", (`String "file://test.ml:1221")) ::
                     (List.filter
                        (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                        pairs))
@@ -2484,9 +2506,10 @@ include
                [("type", (`String "array"));
                ("prefixItems",
                  (`List
-                    [(match event_jsonschema with
+                    [(match (event_jsonschema : Ppx_deriving_jsonschema_runtime.t)
+                      with
                       | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                          `Assoc (("$id", (`String "file://test.ml:1303")) ::
+                          `Assoc (("$id", (`String "file://test.ml:1312")) ::
                             (List.filter
                                (fun (k, _) ->
                                   not (Stdlib.String.equal k "$id")) pairs))
@@ -2604,9 +2627,10 @@ include
         `Assoc
           [("type", (`String "array"));
           ("items",
-            ((match events_jsonschema with
+            ((match (events_jsonschema : Ppx_deriving_jsonschema_runtime.t)
+              with
               | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                  `Assoc (("$id", (`String "file://test.ml:1394")) ::
+                  `Assoc (("$id", (`String "file://test.ml:1403")) ::
                     (List.filter
                        (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                        pairs))
@@ -2775,9 +2799,10 @@ include
           ("properties",
             (`Assoc
                [("m",
-                  ((match Mod1.m_1_jsonschema with
+                  ((match (Mod1.m_1_jsonschema : Ppx_deriving_jsonschema_runtime.t)
+                    with
                     | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                        `Assoc (("$id", (`String "file://test.ml:1503")) ::
+                        `Assoc (("$id", (`String "file://test.ml:1512")) ::
                           (List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -3029,9 +3054,10 @@ include
           ("properties",
             (`Assoc
                [("address",
-                  ((match address_jsonschema with
+                  ((match (address_jsonschema : Ppx_deriving_jsonschema_runtime.t)
+                    with
                     | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                        `Assoc (("$id", (`String "file://test.ml:1625")) ::
+                        `Assoc (("$id", (`String "file://test.ml:1634")) ::
                           (List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -4063,9 +4089,10 @@ include
           ("properties",
             (`Assoc
                [("obj2",
-                  ((match obj2_jsonschema with
+                  ((match (obj2_jsonschema : Ppx_deriving_jsonschema_runtime.t)
+                    with
                     | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                        `Assoc (("$id", (`String "file://test.ml:2099")) ::
+                        `Assoc (("$id", (`String "file://test.ml:2108")) ::
                           (List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -4095,9 +4122,10 @@ include
           ("properties",
             (`Assoc
                [("obj1",
-                  ((match obj1_jsonschema with
+                  ((match (obj1_jsonschema : Ppx_deriving_jsonschema_runtime.t)
+                    with
                     | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                        `Assoc (("$id", (`String "file://test.ml:2100")) ::
+                        `Assoc (("$id", (`String "file://test.ml:2109")) ::
                           (List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -4249,11 +4277,11 @@ include
     let string_link_traffic_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        match generic_link_traffic_jsonschema
-                (`Assoc [("type", (`String "string"))])
+        match (generic_link_traffic_jsonschema
+                 (`Assoc [("type", (`String "string"))]) : Ppx_deriving_jsonschema_runtime.t)
         with
         | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-            `Assoc (("$id", (`String "file://test.ml:2171")) ::
+            `Assoc (("$id", (`String "file://test.ml:2180")) ::
               (List.filter (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                  pairs))
         | other -> other in
@@ -4484,9 +4512,10 @@ include
     let either_alias_jsonschema a b =
       let ppx_eds = ref [] in
       let ppx_result =
-        match either_jsonschema a b with
+        match (either_jsonschema a b : Ppx_deriving_jsonschema_runtime.t)
+        with
         | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-            `Assoc (("$id", (`String "file://test.ml:2283")) ::
+            `Assoc (("$id", (`String "file://test.ml:2292")) ::
               (List.filter (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                  pairs))
         | other -> other in
@@ -4951,6 +4980,487 @@ include
       ]
     }
     |}]]
+type doc_comment_record =
+  {
+  name: string [@ocaml.doc " The user's full name "];
+  age: int [@ocaml.doc " The user's age "]}[@@ocaml.doc " A user object "]
+[@@deriving jsonschema ~ocaml_doc]
+include
+  struct
+    let doc_comment_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("description", (`String "A user object"));
+          ("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("age",
+                  (`Assoc
+                     [("description", (`String "The user's age"));
+                     ("type", (`String "integer"))]));
+               ("name",
+                 (`Assoc
+                    [("description", (`String "The user's full name"));
+                    ("type", (`String "string"))]))]));
+          ("required", (`List [`String "age"; `String "name"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "ocaml_doc_fallback_for_record" =
+    print_schema doc_comment_record_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "A user object",
+      "type": "object",
+      "properties": {
+        "age": { "description": "The user's age", "type": "integer" },
+        "name": { "description": "The user's full name", "type": "string" }
+      },
+      "required": [ "age", "name" ],
+      "additionalProperties": false
+    }
+    |}]]
+type doc_comment_disabled =
+  {
+  name: string [@ocaml.doc " The user's full name "]}[@@ocaml.doc
+                                                       " A user object "]
+[@@deriving jsonschema]
+include
+  struct
+    let doc_comment_disabled_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc [("name", (`Assoc [("type", (`String "string"))]))]));
+          ("required", (`List [`String "name"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "ocaml_doc_disabled_by_default" =
+    print_schema doc_comment_disabled_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": { "name": { "type": "string" } },
+      "required": [ "name" ],
+      "additionalProperties": false
+    }
+    |}]]
+type doc_comment_override =
+  {
+  field: string
+    [@jsonschema.description "explicit wins"][@ocaml.doc " ocaml.doc loses "]}
+[@@deriving jsonschema ~ocaml_doc]
+include
+  struct
+    let doc_comment_override_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("field",
+                  (`Assoc
+                     [("description", (`String "explicit wins"));
+                     ("type", (`String "string"))]))]));
+          ("required", (`List [`String "field"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "ocaml_doc_overridden_by_jsonschema_description" =
+    print_schema doc_comment_override_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "field": { "description": "explicit wins", "type": "string" }
+      },
+      "required": [ "field" ],
+      "additionalProperties": false
+    }
+    |}]]
+type doc_comment_variant =
+  | Plain [@ocaml.doc " No payload "]
+  | With_int of int [@ocaml.doc " Single integer tag "][@@deriving
+                                                         jsonschema
+                                                           ~ocaml_doc]
+include
+  struct
+    let doc_comment_variant_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("description", (`String "No payload"));
+                   ("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Plain"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("description", (`String "Single integer tag"));
+                  ("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "With_int"))];
+                       `Assoc [("type", (`String "integer"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "ocaml_doc_fallback_for_variant" =
+    print_schema doc_comment_variant_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "description": "No payload",
+          "type": "array",
+          "prefixItems": [ { "const": "Plain" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "description": "Single integer tag",
+          "type": "array",
+          "prefixItems": [ { "const": "With_int" }, { "type": "integer" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    }
+    |}]]
+type doc_comment_core_type = ((string)[@ocaml.doc " A string alias "])
+[@@deriving jsonschema ~ocaml_doc]
+include
+  struct
+    let doc_comment_core_type_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("description", (`String "A string alias"));
+          ("type", (`String "string"))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "ocaml_doc_fallback_for_core_type" =
+    print_schema doc_comment_core_type_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "A string alias",
+      "type": "string"
+    }
+    |}]]
+type doc_attribute_alias = ((string)[@doc " Alias fallback "])[@@deriving
+                                                                jsonschema
+                                                                  ~ocaml_doc]
+include
+  struct
+    let doc_attribute_alias_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("description", (`String "Alias fallback"));
+          ("type", (`String "string"))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "doc_attribute_alias_fallback" =
+    print_schema doc_attribute_alias_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Alias fallback",
+      "type": "string"
+    }
+    |}]]
+type doc_comment_multiline =
+  {
+  name: string
+    [@ocaml.doc
+      " The user's full name.\n          Must be non-empty and under 100 characters. "]}
+[@@deriving jsonschema ~ocaml_doc]
+include
+  struct
+    let doc_comment_multiline_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("name",
+                  (`Assoc
+                     [("description",
+                        (`String
+                           "The user's full name.\n          Must be non-empty and under 100 characters."));
+                     ("type", (`String "string"))]))]));
+          ("required", (`List [`String "name"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "ocaml_doc_multiline_preserves_internal_whitespace" =
+    print_schema doc_comment_multiline_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The user's full name.\n          Must be non-empty and under 100 characters.",
+          "type": "string"
+        }
+      },
+      "required": [ "name" ],
+      "additionalProperties": false
+    }
+    |}]]
+type doc_comment_poly_variant =
+  [ `Plain [@ocaml.doc " No payload "]
+  | `With_int of int [@ocaml.doc " Single integer tag "]][@@deriving
+                                                           jsonschema
+                                                             ~ocaml_doc]
+include
+  struct
+    let doc_comment_poly_variant_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("description", (`String "No payload"));
+                   ("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Plain"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("description", (`String "Single integer tag"));
+                  ("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "With_int"))];
+                       `Assoc [("type", (`String "integer"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "ocaml_doc_fallback_for_polymorphic_variant" =
+    print_schema doc_comment_poly_variant_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "description": "No payload",
+          "type": "array",
+          "prefixItems": [ { "const": "Plain" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "description": "Single integer tag",
+          "type": "array",
+          "prefixItems": [ { "const": "With_int" }, { "type": "integer" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    }
+    |}]]
+type doc_comment_multiple =
+  ((string)[@ocaml.doc " first block "][@ocaml.doc " second block "][@doc
+                                                                    " third block "])
+[@@deriving jsonschema ~ocaml_doc]
+include
+  struct
+    let doc_comment_multiple_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("description",
+             (`String "first block\n\nsecond block\n\nthird block"));
+          ("type", (`String "string"))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "ocaml_doc_multiple_attrs_joined" =
+    print_schema doc_comment_multiple_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "first block\n\nsecond block\n\nthird block",
+      "type": "string"
+    }
+    |}]]
+type doc_comment_poly_variant_override =
+  [
+    `Tagged
+      [@jsonschema.description "explicit wins"][@ocaml.doc
+                                                 " ocaml.doc loses "]]
+[@@deriving jsonschema ~ocaml_doc]
+include
+  struct
+    let doc_comment_poly_variant_override_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("description", (`String "explicit wins"));
+                   ("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Tagged"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "ocaml_doc_overridden_on_polymorphic_variant" =
+    print_schema doc_comment_poly_variant_override_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "description": "explicit wins",
+          "type": "array",
+          "prefixItems": [ { "const": "Tagged" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        }
+      ]
+    }
+    |}]]
 type computation_result =
   | Ok 
   | Err of string [@@deriving jsonschema][@@jsonschema.description
@@ -5103,11 +5613,12 @@ include
                   (`Assoc
                      [("anyOf",
                         (`List
-                           [(match composing_type_jsonschema with
+                           [(match (composing_type_jsonschema : Ppx_deriving_jsonschema_runtime.t)
+                             with
                              | `Assoc pairs when List.mem_assoc "$defs" pairs
                                  ->
                                  `Assoc
-                                   (("$id", (`String "file://test.ml:2574"))
+                                   (("$id", (`String "file://test.ml:2805"))
                                    ::
                                    (List.filter
                                       (fun (k, _) ->
@@ -5433,17 +5944,19 @@ include
           ("properties",
             (`Assoc
                [("b",
-                  ((match self_ref_jsonschema with
+                  ((match (self_ref_jsonschema : Ppx_deriving_jsonschema_runtime.t)
+                    with
                     | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                        `Assoc (("$id", (`String "file://test.ml:2727")) ::
+                        `Assoc (("$id", (`String "file://test.ml:2958")) ::
                           (List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
                     | other -> other)));
                ("a",
-                 ((match self_ref_jsonschema with
+                 ((match (self_ref_jsonschema : Ppx_deriving_jsonschema_runtime.t)
+                   with
                    | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                       `Assoc (("$id", (`String "file://test.ml:2726")) ::
+                       `Assoc (("$id", (`String "file://test.ml:2957")) ::
                          (List.filter
                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                             pairs))
@@ -5471,7 +5984,7 @@ include
       "type": "object",
       "properties": {
         "b": {
-          "$id": "file://test/test.ml:2727",
+          "$id": "file://test/test.ml:2958",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -5488,7 +6001,7 @@ include
           "$ref": "#/$defs/self_ref"
         },
         "a": {
-          "$id": "file://test/test.ml:2726",
+          "$id": "file://test/test.ml:2957",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -5562,9 +6075,10 @@ include
                    ("prefixItems",
                      (`List
                         [`Assoc [("const", (`String "BoolAtom"))];
-                        (match filter_jsonschema atom group_atom with
+                        (match (filter_jsonschema atom group_atom : Ppx_deriving_jsonschema_runtime.t)
+                         with
                          | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                             `Assoc (("$id", (`String "file://test.ml:2786"))
+                             `Assoc (("$id", (`String "file://test.ml:3017"))
                                ::
                                (List.filter
                                   (fun (k, _) ->
@@ -5682,9 +6196,10 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "ORNode"))];
-                       (match rec_wrapper_jsonschema
-                                (`Assoc
-                                   [("$ref", (`String "#/$defs/outer_rec"))])
+                       (match (rec_wrapper_jsonschema
+                                 (`Assoc
+                                    [("$ref", (`String "#/$defs/outer_rec"))]) : 
+                          Ppx_deriving_jsonschema_runtime.t)
                         with
                         | `Assoc ppx_pairs ->
                             (match List.assoc_opt "$defs" ppx_pairs with
@@ -5780,7 +6295,7 @@ include
               "prefixItems": [
                 { "const": "BoolAtom" },
                 {
-                  "$id": "file://test/test.ml:2786",
+                  "$id": "file://test/test.ml:3017",
                   "$defs": {
                     "filter": {
                       "anyOf": [
@@ -6407,9 +6922,10 @@ include
                      ("type", (`String "array"));
                      ("items", (`Assoc [("type", (`String "integer"))]))]));
                ("record",
-                 ((match match record_for_default_jsonschema with
+                 ((match match (record_for_default_jsonschema : Ppx_deriving_jsonschema_runtime.t)
+                         with
                          | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                             `Assoc (("$id", (`String "file://test.ml:3198"))
+                             `Assoc (("$id", (`String "file://test.ml:3429"))
                                ::
                                (List.filter
                                   (fun (k, _) ->
@@ -6419,13 +6935,37 @@ include
                    | `Assoc ppx_fields ->
                        `Assoc
                          (("default",
-                            (record_for_default_to_json { score = None }))
+                            (((fun x ->
+                                 let rec ppx_deriving_jsonschema_runtime_of_json_like
+                                   json =
+                                   match Melange_json.classify json with
+                                   | `Null -> `Null
+                                   | `String s -> `String s
+                                   | `Float f -> `Float f
+                                   | `Int i -> `Int i
+                                   | `Bool b -> `Bool b
+                                   | `List xs ->
+                                       `List
+                                         (List.map
+                                            ppx_deriving_jsonschema_runtime_of_json_like
+                                            xs)
+                                   | `Assoc fields ->
+                                       `Assoc
+                                         (List.map
+                                            (fun (k, v) ->
+                                               (k,
+                                                 (ppx_deriving_jsonschema_runtime_of_json_like
+                                                    v))) fields) in
+                                 ppx_deriving_jsonschema_runtime_of_json_like
+                                   (record_for_default_to_json x)))
+                               { score = None }))
                          :: ppx_fields)
                    | ppx_other -> ppx_other)));
                ("variant",
-                 ((match match variant_for_default_jsonschema with
+                 ((match match (variant_for_default_jsonschema : Ppx_deriving_jsonschema_runtime.t)
+                         with
                          | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                             `Assoc (("$id", (`String "file://test.ml:3197"))
+                             `Assoc (("$id", (`String "file://test.ml:3428"))
                                ::
                                (List.filter
                                   (fun (k, _) ->
@@ -6433,7 +6973,31 @@ include
                          | other -> other
                    with
                    | `Assoc ppx_fields ->
-                       `Assoc (("default", (variant_for_default_to_json A))
+                       `Assoc
+                         (("default",
+                            (((fun x ->
+                                 let rec ppx_deriving_jsonschema_runtime_of_json_like
+                                   json =
+                                   match Melange_json.classify json with
+                                   | `Null -> `Null
+                                   | `String s -> `String s
+                                   | `Float f -> `Float f
+                                   | `Int i -> `Int i
+                                   | `Bool b -> `Bool b
+                                   | `List xs ->
+                                       `List
+                                         (List.map
+                                            ppx_deriving_jsonschema_runtime_of_json_like
+                                            xs)
+                                   | `Assoc fields ->
+                                       `Assoc
+                                         (List.map
+                                            (fun (k, v) ->
+                                               (k,
+                                                 (ppx_deriving_jsonschema_runtime_of_json_like
+                                                    v))) fields) in
+                                 ppx_deriving_jsonschema_runtime_of_json_like
+                                   (variant_for_default_to_json x))) A))
                          :: ppx_fields)
                    | ppx_other -> ppx_other)));
                ("is_active",
@@ -6571,10 +7135,11 @@ include
           ("properties",
             (`Assoc
                [("status",
-                  ((match match Status.t_jsonschema with
+                  ((match match (Status.t_jsonschema : Ppx_deriving_jsonschema_runtime.t)
+                          with
                           | `Assoc pairs when List.mem_assoc "$defs" pairs ->
                               `Assoc
-                                (("$id", (`String "file://test.ml:3263")) ::
+                                (("$id", (`String "file://test.ml:3494")) ::
                                 (List.filter
                                    (fun (k, _) ->
                                       not (Stdlib.String.equal k "$id"))
@@ -6582,7 +7147,31 @@ include
                           | other -> other
                     with
                     | `Assoc ppx_fields ->
-                        `Assoc (("default", (Status.to_json Status.Active))
+                        `Assoc
+                          (("default",
+                             (((fun x ->
+                                  let rec ppx_deriving_jsonschema_runtime_of_json_like
+                                    json =
+                                    match Melange_json.classify json with
+                                    | `Null -> `Null
+                                    | `String s -> `String s
+                                    | `Float f -> `Float f
+                                    | `Int i -> `Int i
+                                    | `Bool b -> `Bool b
+                                    | `List xs ->
+                                        `List
+                                          (List.map
+                                             ppx_deriving_jsonschema_runtime_of_json_like
+                                             xs)
+                                    | `Assoc fields ->
+                                        `Assoc
+                                          (List.map
+                                             (fun (k, v) ->
+                                                (k,
+                                                  (ppx_deriving_jsonschema_runtime_of_json_like
+                                                     v))) fields) in
+                                  ppx_deriving_jsonschema_runtime_of_json_like
+                                    (Status.to_json x))) Status.Active))
                           :: ppx_fields)
                     | ppx_other -> ppx_other)))]));
           ("required", (`List []));

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,7 +1,9 @@
 [@@@ocaml.warning "-37-69"]
 
 let print_schema ?definitions ?id ?title ?description s =
-  let s : Yojson.Basic.t = (Ppx_deriving_jsonschema_runtime.json_schema ?definitions ?id ?title ?description s :> Yojson.Basic.t) in
+  let s : Yojson.Basic.t =
+    (Ppx_deriving_jsonschema_runtime.json_schema ?definitions ?id ?title ?description s :> Yojson.Basic.t)
+  in
   let () = print_endline (Yojson.Basic.pretty_to_string s) in
   ()
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,8 +1,17 @@
 [@@@ocaml.warning "-37-69"]
 
+let rec runtime_to_yojson : Ppx_deriving_jsonschema_runtime.t -> Yojson.Basic.t = function
+  | `Null -> `Null
+  | `String s -> `String s
+  | `Float f -> `Float f
+  | `Int i -> `Int i
+  | `Bool b -> `Bool b
+  | `List xs -> `List (List.map runtime_to_yojson xs)
+  | `Assoc fields -> `Assoc (List.map (fun (k, v) -> k, runtime_to_yojson v) fields)
+
 let print_schema ?definitions ?id ?title ?description s =
   let s = Ppx_deriving_jsonschema_runtime.json_schema ?definitions ?id ?title ?description s in
-  let () = print_endline (Yojson.Basic.pretty_to_string s) in
+  let () = print_endline (Yojson.Basic.pretty_to_string (runtime_to_yojson s)) in
   ()
 
 let string_jsonschema = `Assoc [ "type", `String "string" ]
@@ -917,7 +926,7 @@ let%expect_test "recursive_abstract_alias" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "file://test/test.ml:912",
+      "$id": "file://test/test.ml:921",
       "$defs": {
         "tree": {
           "anyOf": [
@@ -2507,6 +2516,228 @@ let%expect_test "variant_constructor_description_variant_as_string" =
     }
     |}]
 
+(* The [~ocaml_doc] flag opts into using [(** ... *)] doc comments as a
+   fallback for [@jsonschema.description]. Without the flag, doc comments are
+   ignored (see [ocaml_doc_disabled_by_default] below). *)
+
+(** A user object *)
+type doc_comment_record = {
+  name : string;  (** The user's full name *)
+  age : int;  (** The user's age *)
+}
+[@@deriving jsonschema ~ocaml_doc]
+
+let%expect_test "ocaml_doc_fallback_for_record" =
+  print_schema doc_comment_record_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "A user object",
+      "type": "object",
+      "properties": {
+        "age": { "description": "The user's age", "type": "integer" },
+        "name": { "description": "The user's full name", "type": "string" }
+      },
+      "required": [ "age", "name" ],
+      "additionalProperties": false
+    }
+    |}]
+
+(* Without the [~ocaml_doc] flag, doc comments are not turned into descriptions. *)
+
+(** A user object *)
+type doc_comment_disabled = { name : string  (** The user's full name *) } [@@deriving jsonschema]
+
+let%expect_test "ocaml_doc_disabled_by_default" =
+  print_schema doc_comment_disabled_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": { "name": { "type": "string" } },
+      "required": [ "name" ],
+      "additionalProperties": false
+    }
+    |}]
+
+(* Explicit [@jsonschema.description] wins over an ocaml.doc comment on the same node. *)
+type doc_comment_override = { field : string [@jsonschema.description "explicit wins"]  (** ocaml.doc loses *) }
+[@@deriving jsonschema ~ocaml_doc]
+
+let%expect_test "ocaml_doc_overridden_by_jsonschema_description" =
+  print_schema doc_comment_override_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "field": { "description": "explicit wins", "type": "string" }
+      },
+      "required": [ "field" ],
+      "additionalProperties": false
+    }
+    |}]
+
+type doc_comment_variant =
+  | Plain  (** No payload *)
+  | With_int of int  (** Single integer tag *)
+[@@deriving jsonschema ~ocaml_doc]
+
+let%expect_test "ocaml_doc_fallback_for_variant" =
+  print_schema doc_comment_variant_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "description": "No payload",
+          "type": "array",
+          "prefixItems": [ { "const": "Plain" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "description": "Single integer tag",
+          "type": "array",
+          "prefixItems": [ { "const": "With_int" }, { "type": "integer" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    }
+    |}]
+
+type doc_comment_core_type = (string[@ocaml.doc " A string alias "]) [@@deriving jsonschema ~ocaml_doc]
+
+let%expect_test "ocaml_doc_fallback_for_core_type" =
+  print_schema doc_comment_core_type_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "A string alias",
+      "type": "string"
+    }
+    |}]
+
+type doc_attribute_alias = (string[@doc " Alias fallback "]) [@@deriving jsonschema ~ocaml_doc]
+
+let%expect_test "doc_attribute_alias_fallback" =
+  print_schema doc_attribute_alias_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Alias fallback",
+      "type": "string"
+    }
+    |}]
+
+(* Multi-line doc comments are preserved as-is apart from a [String.trim] on the
+   outermost whitespace. Internal newlines and indentation remain in the
+   generated description. *)
+type doc_comment_multiline = {
+  name : string;  (** The user's full name.
+          Must be non-empty and under 100 characters. *)
+}
+[@@deriving jsonschema ~ocaml_doc]
+
+let%expect_test "ocaml_doc_multiline_preserves_internal_whitespace" =
+  print_schema doc_comment_multiline_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The user's full name.\n          Must be non-empty and under 100 characters.",
+          "type": "string"
+        }
+      },
+      "required": [ "name" ],
+      "additionalProperties": false
+    }
+    |}]
+
+type doc_comment_poly_variant =
+  [ `Plain  (** No payload *)
+  | `With_int of int  (** Single integer tag *)
+  ]
+[@@deriving jsonschema ~ocaml_doc]
+
+let%expect_test "ocaml_doc_fallback_for_polymorphic_variant" =
+  print_schema doc_comment_poly_variant_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "description": "No payload",
+          "type": "array",
+          "prefixItems": [ { "const": "Plain" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "description": "Single integer tag",
+          "type": "array",
+          "prefixItems": [ { "const": "With_int" }, { "type": "integer" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    }
+    |}]
+
+(* Multiple hand-written [@ocaml.doc] / [@doc] attributes on the same node are
+   joined into a single description with a blank-line separator. *)
+type doc_comment_multiple = (string[@ocaml.doc " first block "] [@ocaml.doc " second block "] [@doc " third block "])
+[@@deriving jsonschema ~ocaml_doc]
+
+let%expect_test "ocaml_doc_multiple_attrs_joined" =
+  print_schema doc_comment_multiple_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "first block\n\nsecond block\n\nthird block",
+      "type": "string"
+    }
+    |}]
+
+(* Explicit [@jsonschema.description] on a polymorphic variant tag takes precedence. *)
+type doc_comment_poly_variant_override = [ `Tagged [@jsonschema.description "explicit wins"]  (** ocaml.doc loses *) ]
+[@@deriving jsonschema ~ocaml_doc]
+
+let%expect_test "ocaml_doc_overridden_on_polymorphic_variant" =
+  print_schema doc_comment_poly_variant_override_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "description": "explicit wins",
+          "type": "array",
+          "prefixItems": [ { "const": "Tagged" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        }
+      ]
+    }
+    |}]
+
 (* Top-level @@jsonschema.description on a variant (whole anyOf schema). *)
 type computation_result =
   | Ok
@@ -2737,7 +2968,7 @@ let%expect_test "no_duplicate_id_when_recursive_type_used_twice" =
       "type": "object",
       "properties": {
         "b": {
-          "$id": "file://test/test.ml:2727",
+          "$id": "file://test/test.ml:2958",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -2754,7 +2985,7 @@ let%expect_test "no_duplicate_id_when_recursive_type_used_twice" =
           "$ref": "#/$defs/self_ref"
         },
         "a": {
-          "$id": "file://test/test.ml:2726",
+          "$id": "file://test/test.ml:2957",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -2901,7 +3132,7 @@ let%expect_test "polymorphic_recursive_ref_bool_filter" =
               "prefixItems": [
                 { "const": "BoolAtom" },
                 {
-                  "$id": "file://test/test.ml:2786",
+                  "$id": "file://test/test.ml:3017",
                   "$defs": {
                     "filter": {
                       "anyOf": [

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,17 +1,8 @@
 [@@@ocaml.warning "-37-69"]
 
-let rec runtime_to_yojson : Ppx_deriving_jsonschema_runtime.t -> Yojson.Basic.t = function
-  | `Null -> `Null
-  | `String s -> `String s
-  | `Float f -> `Float f
-  | `Int i -> `Int i
-  | `Bool b -> `Bool b
-  | `List xs -> `List (List.map runtime_to_yojson xs)
-  | `Assoc fields -> `Assoc (List.map (fun (k, v) -> k, runtime_to_yojson v) fields)
-
 let print_schema ?definitions ?id ?title ?description s =
-  let s = Ppx_deriving_jsonschema_runtime.json_schema ?definitions ?id ?title ?description s in
-  let () = print_endline (Yojson.Basic.pretty_to_string (runtime_to_yojson s)) in
+  let s : Yojson.Basic.t = (Ppx_deriving_jsonschema_runtime.json_schema ?definitions ?id ?title ?description s :> Yojson.Basic.t) in
+  let () = print_endline (Yojson.Basic.pretty_to_string s) in
   ()
 
 let string_jsonschema = `Assoc [ "type", `String "string" ]
@@ -926,7 +917,7 @@ let%expect_test "recursive_abstract_alias" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "file://test/test.ml:921",
+      "$id": "file://test/test.ml:912",
       "$defs": {
         "tree": {
           "anyOf": [
@@ -2968,7 +2959,7 @@ let%expect_test "no_duplicate_id_when_recursive_type_used_twice" =
       "type": "object",
       "properties": {
         "b": {
-          "$id": "file://test/test.ml:2958",
+          "$id": "file://test/test.ml:2949",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -2985,7 +2976,7 @@ let%expect_test "no_duplicate_id_when_recursive_type_used_twice" =
           "$ref": "#/$defs/self_ref"
         },
         "a": {
-          "$id": "file://test/test.ml:2957",
+          "$id": "file://test/test.ml:2948",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -3132,7 +3123,7 @@ let%expect_test "polymorphic_recursive_ref_bool_filter" =
               "prefixItems": [
                 { "const": "BoolAtom" },
                 {
-                  "$id": "file://test/test.ml:3017",
+                  "$id": "file://test/test.ml:3008",
                   "$defs": {
                     "filter": {
                       "anyOf": [


### PR DESCRIPTION
Summary:
- cherry-pick the top 4 commits from louis/jsonschema-typing-fix onto main
- exclude the louis/ocamldoc base commits
- keep the Yojson.Basic compatibility changes for runtime schemas

Why:
- this is the minimal ppx_deriving_jsonschema stack that makes the companion monorepo changes build cleanly

Companion monorepo PR:
- https://github.com/ahrefs-core/monorepo/pull/34147