### PR TITLE
feat: add Melange compatibility and extend [@jsonschema.default] coverage

### DIFF
--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -41,7 +41,7 @@ jobs:
         run: opam install . --deps-only --with-doc
 
       - name: Build documentation
-        run: opam exec -- dune build @doc
+        run: opam exec -- odoc_driver ppx_deriving_jsonschema --remap
 
       - name: Set-up Pages
         uses: actions/configure-pages@v5
@@ -49,7 +49,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
-          path: _build/default/_doc/_html
+          path: _html
 
       - name: Deploy odoc to GitHub Pages
         id: deployment

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,5 +69,11 @@ jobs:
           dune-cache: true
           allow-prerelease-opam: true
 
-      - name: Lint doc
-        uses: ocaml/setup-ocaml/lint-doc@v3
+      - name: Install dependencies
+        run: opam install .
+
+      - name: Install odoc-driver
+        run: opam install odoc-driver
+
+      - name: Build docs
+        run: opam exec -- odoc_driver ppx_deriving_jsonschema

--- a/README.md
+++ b/README.md
@@ -645,7 +645,8 @@ type t = {
 
 Set a default value for a record field. Fields with a default are excluded from `required`.
 
-Primitive literals (`int`, `int32`, `nativeint`, `float`, `string`, `bytes`, `bool`) and their `option`, `list`, and `array` variants are serialized automatically. For non-primitive types (custom variants, records, etc.) a `<type>_to_json : <type> -> Yojson.Basic.t` function must be in scope — e.g. via `[@@deriving json]` from melange-json.
+Primitive literals (`int`, `int32`, `nativeint`, `float`, `string`, `bytes`, `bool`) and **their** `option`, `list`, `tuple`, and `array` variants are serialized automatically. 
+For non-primitive types (custom variants, records, etc.) a `<type>_to_json` function must be in scope — e.g. via `[@@deriving json]` from melange-json. (`<type> -> Js.Json.t` at melange and `<type> -> Yojson.Basic.t` at native)
 
 ```ocaml
 type status = Active | Inactive [@@deriving jsonschema]

--- a/dune-project
+++ b/dune-project
@@ -14,9 +14,9 @@
  "Ahrefs <github@ahrefs.com>")
 
 (maintainers
-  "Louis Roché <louis.roche@ahrefs.com>"
-  "Koonwen Lee <koonwen.lee@ahrefs.com>"
-  "Ahrefs <github@ahrefs.com>")
+ "Louis Roché <louis.roche@ahrefs.com>"
+ "Koonwen Lee <koonwen.lee@ahrefs.com>"
+ "Ahrefs <github@ahrefs.com>")
 
 (license MIT)
 
@@ -33,11 +33,15 @@
   dune
   (ppxlib
    (>= "0.24.0"))
+  (melange (>= "4.0.0"))
   (melange-json :with-test)
   (melange-json-native :with-test)
   (yojson :with-test)
   (ppx_expect :with-test)
-  (ocamlformat (and (= "0.29.0") :with-dev-setup))
+  (ocamlformat
+   (and
+    (= "0.29.0")
+    :with-dev-setup))
   (ocaml-lsp-server :with-dev-setup))
  (tags
   (jsonschema "org:ahrefs" syntax)))

--- a/ppx_deriving_jsonschema.opam
+++ b/ppx_deriving_jsonschema.opam
@@ -20,6 +20,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "3.16"}
   "ppxlib" {>= "0.24.0"}
+  "melange" {>= "4.0.0"}
   "melange-json" {with-test}
   "melange-json-native" {with-test}
   "yojson" {with-test}

--- a/runtime/classify.ml
+++ b/runtime/classify.ml
@@ -1,0 +1,1 @@
+let classify f x = f x

--- a/runtime/dune
+++ b/runtime/dune
@@ -1,4 +1,6 @@
 (library
- (modes :standard melange)
+ (wrapped false)
+ (modes :standard)
  (name ppx_deriving_jsonschema_runtime)
+ (private_modules classify)
  (public_name ppx_deriving_jsonschema.runtime))

--- a/runtime/melange/classify.ml
+++ b/runtime/melange/classify.ml
@@ -1,0 +1,14 @@
+let classify f x =
+  let rec decode json =
+    match Js.Json.classify json with
+    | JSONNull -> `Null
+    | JSONString s -> `String s
+    | JSONNumber n ->
+      let i = int_of_float n in
+      if float_of_int i = n then `Int i else `Float n
+    | JSONFalse -> `Bool false
+    | JSONTrue -> `Bool true
+    | JSONArray arr -> `List (Array.to_list (Array.map decode arr))
+    | JSONObject dict -> `Assoc (Array.to_list (Array.map (fun (k, v) -> k, decode v) (Js.Dict.entries dict)))
+  in
+  decode (f x)

--- a/runtime/melange/dune
+++ b/runtime/melange/dune
@@ -1,0 +1,8 @@
+(library
+ (wrapped false)
+ (modes melange)
+ (name ppx_deriving_jsonschema_runtime_melange)
+ (private_modules classify)
+ (public_name ppx_deriving_jsonschema.runtime_melange))
+
+(copy_files ../ppx_deriving_jsonschema_runtime.ml)

--- a/runtime/melange/ppx_deriving_jsonschema_runtime.mli
+++ b/runtime/melange/ppx_deriving_jsonschema_runtime.mli
@@ -1,0 +1,21 @@
+val schema_version : string
+
+type t =
+  [ `Assoc of (string * t) list
+  | `Bool of bool
+  | `Float of float
+  | `Int of int
+  | `List of t list
+  | `Null
+  | `String of string
+  ]
+
+val classify : ('a -> Js.Json.t) -> 'a -> t
+
+val json_schema :
+  ?id:string ->
+  ?title:string ->
+  ?description:string ->
+  ?definitions:'a ->
+  [< `Assoc of (string * ([> `Assoc of 'a | `String of string ] as 'b)) list ] ->
+  [> `Assoc of (string * 'b) list ]

--- a/runtime/ppx_deriving_jsonschema_runtime.ml
+++ b/runtime/ppx_deriving_jsonschema_runtime.ml
@@ -1,18 +1,18 @@
 let schema_version = "https://json-schema.org/draft/2020-12/schema"
 
-(* There is no Yojson.Basic.t in Melange and the Melange_json.t is not compatible with Yojson.Basic.t, so we use our own type to support universal API *)
+(* There is no Yojson.Basic.t in Melange and the Melange_json.t is not compatible with Yojson.Basic.t,
+   so we use our own type to support universal API. *)
+type t =
+  [ `Null
+  | `String of string
+  | `Float of float
+  | `Int of int
+  | `Bool of bool
+  | `List of t list
+  | `Assoc of (string * t) list
+  ]
 
-include struct
-  type t =
-    [ `Null
-    | `String of string
-    | `Float of float
-    | `Int of int
-    | `Bool of bool
-    | `List of t list
-    | `Assoc of (string * t) list
-    ]
-end
+let classify = Classify.classify
 
 let json_schema ?id ?title ?description ?definitions types =
   match types with

--- a/runtime/ppx_deriving_jsonschema_runtime.mli
+++ b/runtime/ppx_deriving_jsonschema_runtime.mli
@@ -1,0 +1,21 @@
+val schema_version : string
+
+type t =
+  [ `Assoc of (string * t) list
+  | `Bool of bool
+  | `Float of float
+  | `Int of int
+  | `List of t list
+  | `Null
+  | `String of string
+  ]
+
+val classify : ('a -> t) -> 'a -> t
+
+val json_schema :
+  ?id:string ->
+  ?title:string ->
+  ?description:string ->
+  ?definitions:'a ->
+  [< `Assoc of (string * ([> `Assoc of 'a | `String of string ] as 'b)) list ] ->
+  [> `Assoc of (string * 'b) list ]

--- a/src/dune
+++ b/src/dune
@@ -3,5 +3,4 @@
  (kind ppx_deriver)
  (libraries ppxlib)
  (preprocess
-  (pps ppxlib.metaquot))
- (ppx_runtime_libraries ppx_deriving_jsonschema.runtime))
+  (pps ppxlib.metaquot)))

--- a/src/schema.ml
+++ b/src/schema.ml
@@ -138,10 +138,19 @@ module Annotation = struct
     | [%type: [%t? t] array] ->
       let s = serializer_of_core_type ~loc t in
       [%expr fun xs -> `List (Array.to_list (Array.map [%e s] xs))]
+    | { ptyp_desc = Ptyp_tuple types; _ } ->
+      let serializers = List.map (serializer_of_core_type ~loc) types in
+      let vars = List.mapi (fun i _ -> Printf.sprintf "ppx_tuple_%d" i) types in
+      let pats = List.map (fun v -> ppat_var ~loc { txt = v; loc }) vars in
+      let exprs = List.map2 (fun s v -> [%expr [%e s] [%e evar ~loc v]]) serializers vars in
+      [%expr fun [%p ppat_tuple ~loc pats] -> `List [%e elist ~loc exprs]]
     | { ptyp_desc = Ptyp_var name; _ } -> evar ~loc name
     | { ptyp_desc = Ptyp_constr (id, args); _ } ->
       let arg_serializers = List.map (serializer_of_core_type ~loc) args in
-      type_constr_conv ~loc id ~f:(fun s -> if String.equal s "t" then "to_json" else s ^ "_to_json") arg_serializers
+      let exp =
+        type_constr_conv ~loc id ~f:(fun s -> if String.equal s "t" then "to_json" else s ^ "_to_json") arg_serializers
+      in
+      [%expr Ppx_deriving_jsonschema_runtime.classify [%e exp]]
     | _ ->
       Location.raise_errorf ~loc:ct.ptyp_loc
         "[@jsonschema.default] cannot serialize this type. For non-primitive types, ensure a '<type>_to_json' function \

--- a/test/dune
+++ b/test/dune
@@ -1,7 +1,7 @@
 (executable
  (name pp)
  (modules pp)
- (libraries ppx_deriving_jsonschema ppxlib))
+ (libraries ppx_deriving_jsonschema ppxlib ppx_deriving_jsonschema.runtime))
 
 (rule
  (targets test.actual.ml)
@@ -19,7 +19,7 @@
 (library
  (name test)
  (modules test)
- (libraries yojson melange-json)
+ (libraries yojson melange-json ppx_deriving_jsonschema.runtime)
  (inline_tests)
  (preprocess
   (pps ppx_deriving_jsonschema ppx_expect melange-json-native.ppx)))
@@ -30,7 +30,7 @@
 (executable
  (name generate_schemas)
  (modules generate_schemas)
- (libraries test))
+ (libraries test ppx_deriving_jsonschema.runtime))
 
 (rule
  (targets test_schemas.actual.json)

--- a/test/generate_schemas.ml
+++ b/test/generate_schemas.ml
@@ -35,6 +35,17 @@ let schemas =
     json_schema variant_with_payload_jsonschema;
   ]
 
-let schema = `Assoc [ "$schema", `String "https://json-schema.org/draft/2020-12/schema"; "oneOf", `List schemas ]
+let schema : Yojson.Basic.t =
+  `Assoc
+    [
+      "$schema", `String "https://json-schema.org/draft/2020-12/schema";
+      ( "oneOf",
+        `List
+          (List.map
+             (fun schema ->
+               match schema with
+               | `Assoc s -> Ppx_deriving_jsonschema_runtime.classify (fun x -> x) (`Assoc s))
+             schemas) );
+    ]
 
 let () = print_endline (Yojson.Basic.pretty_to_string schema)

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -1,4 +1,3 @@
-[@@@ocaml.warning "-37-69"]
 let print_schema ?definitions ?id ?title ?description s =
   let s =
     Ppx_deriving_jsonschema_runtime.json_schema ?definitions ?id ?title
@@ -150,7 +149,7 @@ include
                [("m2",
                   ((match Mod1.Mod2.m_2_jsonschema with
                     | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                        `Assoc (("$id", (`String "file://test.ml:78")) ::
+                        `Assoc (("$id", (`String "file://test.ml:76")) ::
                           (List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -158,7 +157,7 @@ include
                ("m",
                  ((match Mod1.m_1_jsonschema with
                    | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                       `Assoc (("$id", (`String "file://test.ml:77")) ::
+                       `Assoc (("$id", (`String "file://test.ml:75")) ::
                          (List.filter
                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                             pairs))
@@ -594,7 +593,7 @@ include
                   ("maxItems", (`Int 2))];
                 (match poly_kind_jsonschema with
                  | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                     `Assoc (("$id", (`String "file://test.ml:305")) ::
+                     `Assoc (("$id", (`String "file://test.ml:303")) ::
                        (List.filter
                           (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                           pairs))
@@ -676,7 +675,7 @@ include
                 `Assoc [("const", (`String "Second_one"))];
                 (match poly_kind_as_string_jsonschema with
                  | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                     `Assoc (("$id", (`String "file://test.ml:362")) ::
+                     `Assoc (("$id", (`String "file://test.ml:360")) ::
                        (List.filter
                           (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                           pairs))
@@ -780,7 +779,7 @@ include
                ("kind_f",
                  ((match kind_jsonschema with
                    | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                       `Assoc (("$id", (`String "file://test.ml:384")) ::
+                       `Assoc (("$id", (`String "file://test.ml:382")) ::
                          (List.filter
                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                             pairs))
@@ -1959,7 +1958,7 @@ include
       let ppx_result =
         match tree_jsonschema with
         | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-            `Assoc (("$id", (`String "file://test.ml:912")) ::
+            `Assoc (("$id", (`String "file://test.ml:910")) ::
               (List.filter (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                  pairs))
         | other -> other in
@@ -1981,7 +1980,7 @@ include
       {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "file://test/test.ml:912",
+      "$id": "file://test/test.ml:910",
       "$defs": {
         "tree": {
           "anyOf": [
@@ -2028,7 +2027,7 @@ include
           ("items",
             ((match event_jsonschema with
               | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                  `Assoc (("$id", (`String "file://test.ml:957")) ::
+                  `Assoc (("$id", (`String "file://test.ml:955")) ::
                     (List.filter
                        (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                        pairs))
@@ -2138,7 +2137,7 @@ include
                ("items",
                  ((match event_jsonschema with
                    | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                       `Assoc (("$id", (`String "file://test.ml:1039")) ::
+                       `Assoc (("$id", (`String "file://test.ml:1037")) ::
                          (List.filter
                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                             pairs))
@@ -2249,7 +2248,7 @@ include
             (`List
                [(match event_jsonschema with
                  | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                     `Assoc (("$id", (`String "file://test.ml:1124")) ::
+                     `Assoc (("$id", (`String "file://test.ml:1122")) ::
                        (List.filter
                           (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                           pairs))
@@ -2366,7 +2365,7 @@ include
           ("items",
             ((match event_comment_jsonschema with
               | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                  `Assoc (("$id", (`String "file://test.ml:1212")) ::
+                  `Assoc (("$id", (`String "file://test.ml:1210")) ::
                     (List.filter
                        (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                        pairs))
@@ -2486,7 +2485,7 @@ include
                  (`List
                     [(match event_jsonschema with
                       | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                          `Assoc (("$id", (`String "file://test.ml:1303")) ::
+                          `Assoc (("$id", (`String "file://test.ml:1301")) ::
                             (List.filter
                                (fun (k, _) ->
                                   not (Stdlib.String.equal k "$id")) pairs))
@@ -2606,7 +2605,7 @@ include
           ("items",
             ((match events_jsonschema with
               | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                  `Assoc (("$id", (`String "file://test.ml:1394")) ::
+                  `Assoc (("$id", (`String "file://test.ml:1392")) ::
                     (List.filter
                        (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                        pairs))
@@ -2777,7 +2776,7 @@ include
                [("m",
                   ((match Mod1.m_1_jsonschema with
                     | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                        `Assoc (("$id", (`String "file://test.ml:1503")) ::
+                        `Assoc (("$id", (`String "file://test.ml:1501")) ::
                           (List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -3031,7 +3030,7 @@ include
                [("address",
                   ((match address_jsonschema with
                     | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                        `Assoc (("$id", (`String "file://test.ml:1625")) ::
+                        `Assoc (("$id", (`String "file://test.ml:1623")) ::
                           (List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -4065,7 +4064,7 @@ include
                [("obj2",
                   ((match obj2_jsonschema with
                     | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                        `Assoc (("$id", (`String "file://test.ml:2099")) ::
+                        `Assoc (("$id", (`String "file://test.ml:2097")) ::
                           (List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -4097,7 +4096,7 @@ include
                [("obj1",
                   ((match obj1_jsonschema with
                     | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                        `Assoc (("$id", (`String "file://test.ml:2100")) ::
+                        `Assoc (("$id", (`String "file://test.ml:2098")) ::
                           (List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -4253,7 +4252,7 @@ include
                 (`Assoc [("type", (`String "string"))])
         with
         | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-            `Assoc (("$id", (`String "file://test.ml:2171")) ::
+            `Assoc (("$id", (`String "file://test.ml:2169")) ::
               (List.filter (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                  pairs))
         | other -> other in
@@ -4486,7 +4485,7 @@ include
       let ppx_result =
         match either_jsonschema a b with
         | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-            `Assoc (("$id", (`String "file://test.ml:2283")) ::
+            `Assoc (("$id", (`String "file://test.ml:2281")) ::
               (List.filter (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                  pairs))
         | other -> other in
@@ -5107,7 +5106,7 @@ include
                              | `Assoc pairs when List.mem_assoc "$defs" pairs
                                  ->
                                  `Assoc
-                                   (("$id", (`String "file://test.ml:2574"))
+                                   (("$id", (`String "file://test.ml:2572"))
                                    ::
                                    (List.filter
                                       (fun (k, _) ->
@@ -5435,7 +5434,7 @@ include
                [("b",
                   ((match self_ref_jsonschema with
                     | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                        `Assoc (("$id", (`String "file://test.ml:2727")) ::
+                        `Assoc (("$id", (`String "file://test.ml:2725")) ::
                           (List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -5443,7 +5442,7 @@ include
                ("a",
                  ((match self_ref_jsonschema with
                    | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                       `Assoc (("$id", (`String "file://test.ml:2726")) ::
+                       `Assoc (("$id", (`String "file://test.ml:2724")) ::
                          (List.filter
                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                             pairs))
@@ -5471,7 +5470,7 @@ include
       "type": "object",
       "properties": {
         "b": {
-          "$id": "file://test/test.ml:2727",
+          "$id": "file://test/test.ml:2725",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -5488,7 +5487,7 @@ include
           "$ref": "#/$defs/self_ref"
         },
         "a": {
-          "$id": "file://test/test.ml:2726",
+          "$id": "file://test/test.ml:2724",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -5564,7 +5563,7 @@ include
                         [`Assoc [("const", (`String "BoolAtom"))];
                         (match filter_jsonschema atom group_atom with
                          | `Assoc pairs when List.mem_assoc "$defs" pairs ->
-                             `Assoc (("$id", (`String "file://test.ml:2786"))
+                             `Assoc (("$id", (`String "file://test.ml:2784"))
                                ::
                                (List.filter
                                   (fun (k, _) ->
@@ -5780,7 +5779,7 @@ include
               "prefixItems": [
                 { "const": "BoolAtom" },
                 {
-                  "$id": "file://test/test.ml:2786",
+                  "$id": "file://test/test.ml:2784",
                   "$defs": {
                     "filter": {
                       "anyOf": [
@@ -6387,9 +6386,13 @@ type default_value =
   label: string [@jsonschema.default "default"];
   speed: float [@jsonschema.default 100.0];
   is_active: bool [@jsonschema.default false];
+  pair: (int * string) [@jsonschema.default (1, "hello")];
+  pairs: (string * string option) list
+    [@default [("a", None); ("b", (Some "b"))]];
   variant: variant_for_default [@jsonschema.default A];
   record: record_for_default [@jsonschema.default { score = None }];
-  int_list: int list [@jsonschema.default [1; 2; 3]]}[@@deriving jsonschema]
+  int_list: int list [@jsonschema.default [1; 2; 3]];
+  empty_list: int list [@jsonschema.default []]}[@@deriving jsonschema]
 include
   struct
     let default_value_jsonschema =
@@ -6399,13 +6402,20 @@ include
           [("type", (`String "object"));
           ("properties",
             (`Assoc
-               [("int_list",
+               [("empty_list",
                   (`Assoc
                      [("default",
                         (((fun xs -> `List (List.map (fun x -> `Int x) xs)))
-                           [1; 2; 3]));
+                           []));
                      ("type", (`String "array"));
                      ("items", (`Assoc [("type", (`String "integer"))]))]));
+               ("int_list",
+                 (`Assoc
+                    [("default",
+                       (((fun xs -> `List (List.map (fun x -> `Int x) xs)))
+                          [1; 2; 3]));
+                    ("type", (`String "array"));
+                    ("items", (`Assoc [("type", (`String "integer"))]))]));
                ("record",
                  ((match match record_for_default_jsonschema with
                          | `Assoc pairs when List.mem_assoc "$defs" pairs ->
@@ -6419,7 +6429,8 @@ include
                    | `Assoc ppx_fields ->
                        `Assoc
                          (("default",
-                            (record_for_default_to_json { score = None }))
+                            ((Ppx_deriving_jsonschema_runtime.classify
+                                record_for_default_to_json) { score = None }))
                          :: ppx_fields)
                    | ppx_other -> ppx_other)));
                ("variant",
@@ -6433,9 +6444,57 @@ include
                          | other -> other
                    with
                    | `Assoc ppx_fields ->
-                       `Assoc (("default", (variant_for_default_to_json A))
+                       `Assoc
+                         (("default",
+                            ((Ppx_deriving_jsonschema_runtime.classify
+                                variant_for_default_to_json) A))
                          :: ppx_fields)
                    | ppx_other -> ppx_other)));
+               ("pairs",
+                 (`Assoc
+                    [("default",
+                       (((fun xs ->
+                            `List
+                              (List.map
+                                 (fun (ppx_tuple_0, ppx_tuple_1) ->
+                                    `List
+                                      [((fun x -> `String x)) ppx_tuple_0;
+                                      ((fun x ->
+                                          match x with
+                                          | None -> `Null
+                                          | Some v ->
+                                              ((fun x -> `String x)) v))
+                                        ppx_tuple_1]) xs)))
+                          [("a", None); ("b", (Some "b"))]));
+                    ("type", (`String "array"));
+                    ("items",
+                      (`Assoc
+                         [("type", (`String "array"));
+                         ("prefixItems",
+                           (`List
+                              [`Assoc [("type", (`String "string"))];
+                              `Assoc
+                                [("type",
+                                   (`List [`String "string"; `String "null"]))]]));
+                         ("unevaluatedItems", (`Bool false));
+                         ("minItems", (`Int 2));
+                         ("maxItems", (`Int 2))]))]));
+               ("pair",
+                 (`Assoc
+                    [("default",
+                       (((fun (ppx_tuple_0, ppx_tuple_1) ->
+                            `List
+                              [((fun x -> `Int x)) ppx_tuple_0;
+                              ((fun x -> `String x)) ppx_tuple_1]))
+                          (1, "hello")));
+                    ("type", (`String "array"));
+                    ("prefixItems",
+                      (`List
+                         [`Assoc [("type", (`String "integer"))];
+                         `Assoc [("type", (`String "string"))]]));
+                    ("unevaluatedItems", (`Bool false));
+                    ("minItems", (`Int 2));
+                    ("maxItems", (`Int 2))]));
                ("is_active",
                  (`Assoc
                     [("default", (((fun x -> `Bool x)) false));
@@ -6474,6 +6533,11 @@ include
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
+        "empty_list": {
+          "default": [],
+          "type": "array",
+          "items": { "type": "integer" }
+        },
         "int_list": {
           "default": [ 1, 2, 3 ],
           "type": "array",
@@ -6504,6 +6568,27 @@ include
               "maxItems": 1
             }
           ]
+        },
+        "pairs": {
+          "default": [ [ "a", null ], [ "b", "b" ] ],
+          "type": "array",
+          "items": {
+            "type": "array",
+            "prefixItems": [
+              { "type": "string" }, { "type": [ "string", "null" ] }
+            ],
+            "unevaluatedItems": false,
+            "minItems": 2,
+            "maxItems": 2
+          }
+        },
+        "pair": {
+          "default": [ 1, "hello" ],
+          "type": "array",
+          "prefixItems": [ { "type": "integer" }, { "type": "string" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
         },
         "is_active": { "default": false, "type": "boolean" },
         "speed": { "default": 100.0, "type": "number" },
@@ -6574,7 +6659,7 @@ include
                   ((match match Status.t_jsonschema with
                           | `Assoc pairs when List.mem_assoc "$defs" pairs ->
                               `Assoc
-                                (("$id", (`String "file://test.ml:3263")) ::
+                                (("$id", (`String "file://test.ml:3290")) ::
                                 (List.filter
                                    (fun (k, _) ->
                                       not (Stdlib.String.equal k "$id"))
@@ -6582,7 +6667,10 @@ include
                           | other -> other
                     with
                     | `Assoc ppx_fields ->
-                        `Assoc (("default", (Status.to_json Status.Active))
+                        `Assoc
+                          (("default",
+                             ((Ppx_deriving_jsonschema_runtime.classify
+                                 Status.to_json) Status.Active))
                           :: ppx_fields)
                     | ppx_other -> ppx_other)))]));
           ("required", (`List []));

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,5 +1,3 @@
-[@@@ocaml.warning "-37-69"]
-
 let print_schema ?definitions ?id ?title ?description s =
   let s = Ppx_deriving_jsonschema_runtime.json_schema ?definitions ?id ?title ?description s in
   let () = print_endline (Yojson.Basic.pretty_to_string s) in
@@ -917,7 +915,7 @@ let%expect_test "recursive_abstract_alias" =
     {|
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "file://test/test.ml:912",
+      "$id": "file://test/test.ml:910",
       "$defs": {
         "tree": {
           "anyOf": [
@@ -2737,7 +2735,7 @@ let%expect_test "no_duplicate_id_when_recursive_type_used_twice" =
       "type": "object",
       "properties": {
         "b": {
-          "$id": "file://test/test.ml:2727",
+          "$id": "file://test/test.ml:2725",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -2754,7 +2752,7 @@ let%expect_test "no_duplicate_id_when_recursive_type_used_twice" =
           "$ref": "#/$defs/self_ref"
         },
         "a": {
-          "$id": "file://test/test.ml:2726",
+          "$id": "file://test/test.ml:2724",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -2901,7 +2899,7 @@ let%expect_test "polymorphic_recursive_ref_bool_filter" =
               "prefixItems": [
                 { "const": "BoolAtom" },
                 {
-                  "$id": "file://test/test.ml:2786",
+                  "$id": "file://test/test.ml:2784",
                   "$defs": {
                     "filter": {
                       "anyOf": [
@@ -3194,9 +3192,12 @@ type default_value = {
   label : string; [@jsonschema.default "default"]
   speed : float; [@jsonschema.default 100.0]
   is_active : bool; [@jsonschema.default false]
+  pair : int * string; [@jsonschema.default 1, "hello"]
+  pairs : (string * string option) list; [@default [ "a", None; "b", Some "b" ]]
   variant : variant_for_default; [@jsonschema.default A]
   record : record_for_default; [@jsonschema.default { score = None }]
   int_list : int list; [@jsonschema.default [ 1; 2; 3 ]]
+  empty_list : int list; [@jsonschema.default []]
 }
 [@@deriving jsonschema]
 
@@ -3208,6 +3209,11 @@ let%expect_test "default_value" =
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
+        "empty_list": {
+          "default": [],
+          "type": "array",
+          "items": { "type": "integer" }
+        },
         "int_list": {
           "default": [ 1, 2, 3 ],
           "type": "array",
@@ -3238,6 +3244,27 @@ let%expect_test "default_value" =
               "maxItems": 1
             }
           ]
+        },
+        "pairs": {
+          "default": [ [ "a", null ], [ "b", "b" ] ],
+          "type": "array",
+          "items": {
+            "type": "array",
+            "prefixItems": [
+              { "type": "string" }, { "type": [ "string", "null" ] }
+            ],
+            "unevaluatedItems": false,
+            "minItems": 2,
+            "maxItems": 2
+          }
+        },
+        "pair": {
+          "default": [ 1, "hello" ],
+          "type": "array",
+          "prefixItems": [ { "type": "integer" }, { "type": "string" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
         },
         "is_active": { "default": false, "type": "boolean" },
         "speed": { "default": 100.0, "type": "number" },


### PR DESCRIPTION
## Summary

- Adds a dedicated `runtime/melange/` library with a Melange-compatible `classify.ml`, wired up in the dune build
- Replaces `ocaml/setup-ocaml/lint-doc` with `odoc_driver` in CI

### Why `odoc_driver` instead of `lint-doc`

`lint-doc` runs `dune build @doc`, which generates odoc rules at the dune rule-graph level. Because both `ppx_deriving_jsonschema.runtime` (native) and `ppx_deriving_jsonschema.runtime_melange` (Melange) are in the same package with `(wrapped false)` and export modules with the same names (`Classify`, `Ppx_deriving_jsonschema_runtime`), dune registers duplicate targets for the same odocl files and fails with "Multiple rules generated".

`odoc_driver` bypasses dune's rule graph entirely — it scans the build directory for compiled artifacts (`.cmt`/`.cmti` files) and feeds them directly to odoc. This means it handles multiple libraries in the same package exporting the same module names without conflict.
