### PR TITLE
feat: add [@@compact_variants] to library

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Next release
+- add `[@@jsonschema.compact_variants]` attribute on variant type declarations to render unit constructors as plain string constants (`{ "const": "Name" }`) instead of single-element tuple arrays; constructors with arguments keep the tuple array encoding
 - add `[@@jsonschema.format]` attribute to add a format to a type or a field; now also supported on core types (e.g. variant payloads: `A of (string[@jsonschema.format "date-time"])`); validated to only apply to `string` and `bytes` types
 - add `[@@jsonschema.description]` attribute to add a description to a type or a field; now also supported on core types (e.g. variant payloads and inline type annotations)
 - add `[@jsonschema.attrs]` composite attribute to bundle multiple schema annotations in a single record expression (e.g. `[@jsonschema.attrs { maximum = 100; minimum = 0; description = "Score out of 100" }]`); supported on core types, label declarations, and type declarations

--- a/README.md
+++ b/README.md
@@ -233,6 +233,32 @@ type t =
 { "anyOf": [ { "const": "Typ" }, { "const": "Class" } ] }
 ```
 
+The `[@@jsonschema.compact_variants]` attribute provides a middle ground: unit constructors (no arguments) are rendered as plain string constants, while constructors with arguments keep the tuple array encoding.
+
+```ocaml
+type t =
+| A
+| B
+| C of int
+[@@deriving jsonschema] [@@jsonschema.compact_variants]
+```
+
+```json
+{
+  "anyOf": [
+    { "const": "A" },
+    { "const": "B" },
+    {
+      "type": "array",
+      "prefixItems": [ { "const": "C" }, { "type": "integer" } ],
+      "unevaluatedItems": false,
+      "minItems": 2,
+      "maxItems": 2
+    }
+  ]
+}
+```
+
 If the JSON variant names differ from OCaml conventions, it is possible to specify the corresponding JSON string explicitly using `[@name "constr"]`, for example:
 
 ```ocaml

--- a/src/attrs.ml
+++ b/src/attrs.ml
@@ -52,6 +52,9 @@ let jsonschema_ld_attrs = expr_attr "jsonschema.attrs" Attribute.Context.label_d
 
 let jsonschema_ld_default = expr_attr "jsonschema.default" Attribute.Context.label_declaration
 
+let jsonschema_td_compact_variants =
+  Attribute.declare_flag "jsonschema.compact_variants" Attribute.Context.type_declaration
+
 let attributes =
   [
     Attribute.T jsonschema_key;
@@ -78,6 +81,7 @@ let attributes =
     Attribute.T jsonschema_td_attrs;
     Attribute.T jsonschema_ld_attrs;
     Attribute.T jsonschema_ld_default;
+    Attribute.T jsonschema_td_compact_variants;
   ]
 
 let args () = Deriving.Args.(empty +> flag "variant_as_string" +> flag "polymorphic_variant_tuple")

--- a/src/attrs.mli
+++ b/src/attrs.mli
@@ -30,5 +30,6 @@ val jsonschema_ct_attrs : (Ppxlib.core_type, Ppxlib.expression) Ppxlib.Attribute
 val jsonschema_td_attrs : (Ppxlib.type_declaration, Ppxlib.expression) Ppxlib.Attribute.t
 val jsonschema_ld_attrs : (Ppxlib.label_declaration, Ppxlib.expression) Ppxlib.Attribute.t
 val jsonschema_ld_default : (Ppxlib.label_declaration, Ppxlib.expression) Ppxlib.Attribute.t
+val jsonschema_td_compact_variants : Ppxlib.type_declaration Ppxlib.Attribute.flag
 val attributes : Ppxlib.Attribute.packed list
 val args : unit -> (bool -> bool -> 'a, 'a) Ppxlib.Deriving.Args.t

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -191,7 +191,7 @@ let schema_of_record ~loc ~(config : Attrs.config) ?(recursive_types = []) field
     is_rec )
 
 (* Returns (schema_expression, is_recursive, params_prefix) *)
-let schema_of_variants ~loc ~(config : Attrs.config) ?(recursive_types = []) variants =
+let schema_of_variants ~loc ~(config : Attrs.config) ?(recursive_types = []) ?(compact_variants = false) variants =
   let variants, is_rec =
     List.fold_left
       (fun (variants, is_rec) ({ pcd_args; pcd_name = { txt = name; _ }; _ } as var) ->
@@ -223,7 +223,7 @@ let schema_of_variants ~loc ~(config : Attrs.config) ?(recursive_types = []) var
   let schema, params_prefix =
     match config.Attrs.variant_as_string with
     | true -> Schema.variants ~loc ~as_string:true variants, "_"
-    | false -> Schema.variants ~loc variants, ""
+    | false -> Schema.variants ~loc ~compact_variants variants, ""
   in
   schema, is_rec, params_prefix
 
@@ -234,7 +234,8 @@ let schema_of_type_decl ~loc ~(config : Attrs.config) ~recursive_types type_decl
   let params = List.map (fun tp -> (get_type_param_name tp).txt) type_decl.ptype_params in
   match type_decl.ptype_kind with
   | Ptype_variant variants ->
-    let schema, is_rec, params_prefix = schema_of_variants ~loc ~config ~recursive_types variants in
+    let compact_variants = Attribute.has_flag Attrs.jsonschema_td_compact_variants type_decl in
+    let schema, is_rec, params_prefix = schema_of_variants ~loc ~config ~recursive_types ~compact_variants variants in
     type_name, schema, is_rec, params, params_prefix
   | Ptype_record label_declarations ->
     let schema, is_rec = schema_of_record ~loc ~config ~recursive_types label_declarations allow_extra_fields in

--- a/src/schema.ml
+++ b/src/schema.ml
@@ -71,7 +71,7 @@ let default ~loc value = annotation ~loc ("default", value)
 let description ~loc description schema_expr =
   annotation ~loc ("description", [%expr `String [%e estring ~loc description]]) schema_expr
 
-let variants ~loc ?(as_string = false) constrs =
+let variants ~loc ?(as_string = false) ?(compact_variants = false) constrs =
   let opt_description ~loc desc schema =
     match desc with
     | Some d -> description ~loc d schema
@@ -81,7 +81,12 @@ let variants ~loc ?(as_string = false) constrs =
     (List.map
        (function
          | `Tag (name, typs, desc) ->
-           opt_description ~loc desc (if as_string then const ~loc name else tuple ~loc (const ~loc name :: typs))
+           let schema =
+             if as_string then const ~loc name
+             else if compact_variants && typs = [] then const ~loc name
+             else tuple ~loc (const ~loc name :: typs)
+           in
+           opt_description ~loc desc schema
          | `Inherit typ -> typ)
        constrs)
 

--- a/src/schema.mli
+++ b/src/schema.mli
@@ -19,6 +19,7 @@ val description : loc:Warnings.loc -> string -> Ppxlib.expression -> Ppxlib.expr
 val variants :
   loc:Warnings.loc ->
   ?as_string:bool ->
+  ?compact_variants:bool ->
   [< `Inherit of Ppxlib.expression | `Tag of string * Ppxlib.expression list * string option ] list ->
   Ppxlib.expression
 

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -6631,3 +6631,57 @@ include
       "additionalProperties": false
     }
     |}]]
+type compact_variants =
+  | A 
+  | B 
+  | C of int [@@deriving jsonschema][@@jsonschema.compact_variants ]
+include
+  struct
+    let compact_variants_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "A"))];
+                `Assoc [("const", (`String "B"))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "C"))];
+                       `Assoc [("type", (`String "integer"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[%%expect_test
+  let "compact_variants" =
+    print_schema compact_variants_jsonschema;
+    [%expect
+      {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        { "const": "A" },
+        { "const": "B" },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "C" }, { "type": "integer" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    }
+    |}]]

--- a/test/test.ml
+++ b/test/test.ml
@@ -3294,3 +3294,29 @@ let%expect_test "default_with_module_type" =
       "additionalProperties": false
     }
     |}]
+
+type compact_variants =
+  | A
+  | B
+  | C of int
+[@@deriving jsonschema] [@@jsonschema.compact_variants]
+
+let%expect_test "compact_variants" =
+  print_schema compact_variants_jsonschema;
+  [%expect
+    {|
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        { "const": "A" },
+        { "const": "B" },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "C" }, { "type": "integer" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    }
+    |}]


### PR DESCRIPTION
## Summary

Adds a new type-level attribute that makes unit constructors in variant types render as plain string constants instead of single-element tuple arrays.

### Before

```ocaml
type t = A | B | C of int [@@deriving jsonschema] [@@jsonschema.compact_variants]

{
  "anyOf": [
    { "const": "A" },
    { "const": "B" },
    { "type": "array", "prefixItems": [{ "const": "C" }, { "type": "integer" }], "unevaluatedItems": false, "minItems": 2, "maxItems": 2 }
  ]
}
```

