### PR TITLE
Add missing odoc on dune-project

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -42,6 +42,7 @@
    (and
     (= "0.29.0")
     :with-dev-setup))
-  (ocaml-lsp-server :with-dev-setup))
+  (ocaml-lsp-server :with-dev-setup)
+  (odoc-driver :with-doc))
  (tags
   (jsonschema "org:ahrefs" syntax)))

--- a/ppx_deriving_jsonschema.opam
+++ b/ppx_deriving_jsonschema.opam
@@ -27,6 +27,7 @@ depends: [
   "ppx_expect" {with-test}
   "ocamlformat" {= "0.29.0" & with-dev-setup}
   "ocaml-lsp-server" {with-dev-setup}
+  "odoc-driver" {with-doc}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
## Summary

odoc-driver was missing on dune-project