### PR TITLE
Add Primitives to the ppx

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,17 +55,255 @@ Such a type will be turned into a JSON schema like this:
 }
 ```
 
+## Usage
+
+To generate jsonschema for a type, add the `[@@deriving jsonschema]` attribute to
+the type declaration.
+
+```ocaml
+open Ppx_deriving_jsonschema_runtime.Primitives.Melange_json
+
+type t = {
+  a: int;
+  b: string;
+} [@@deriving jsonschema]
+```
+
 ### Conversion rules
 
-#### Basic types
+#### Primitives
 
-Types `int`, `int32`, `int64`, `nativeint`, `string`, `bytes`, `float`, `bool` are converted to their JSON equivalents.
+As we support the ppx to be used with both melange-json and yojson, we provide two primitives modules: `Melange_json` and `Yojson`.
 
-Type `char` is converted to `{ "type": "string",  "minLength": 1,  "maxLength": 1}`.
+##### Melange_json
+
+<table>
+<thead>
+<tr><th>OCaml type</th><th>JSON schema</th></tr>
+</thead>
+<tbody>
+<tr>
+<td><code>char</code></td>
+<td>
+
+```json
+{ "type": "string", "minLength": 1, "maxLength": 1 }
+```
+
+</tr>
+<tr>
+<td><code>int</code></td>
+<td>
+
+```json
+{ "type": "integer" }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>int64</code></td>
+<td>
+
+```json
+{ "type": "string", "description": "int64 is represented as a string" }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>float</code></td>
+<td>
+
+```json
+{ "type": "number" }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>bool</code></td>
+<td>
+
+```json
+{ "type": "boolean" }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>string</code></td>
+<td>
+
+```json
+{ "type": "string" }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>list</code>, <code>array</code></td>
+<td>
+
+```json
+{ "type": "array", "items": { "type": "..." } }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>'a option</code></td>
+<td>
+
+```json
+{ "type": ["...", "null"] }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>unit</code></td>
+<td>
+
+```json
+{ "type": "null" }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>result('a, 'b)</code></td>
+<td>
+
+```json
+{
+  "anyOf": [
+    {
+      "type": "array",
+      "prefixItems": [ { "const": "Error" }, { "type": "..." } ],
+      "unevaluatedItems": false,
+      "minItems": 1
+    },
+    {
+      "type": "array",
+      "prefixItems": [ { "const": "Ok" }, { "type": "..." } ],
+      "unevaluatedItems": false,
+      "minItems": 2,
+      "maxItems": 2
+    }
+  ]
+}
+```
+
+</td>
+</tr>
+</tbody>
+</table>
+
+
+##### Yojson
+
+<table>
+<thead>
+<tr><th>OCaml type</th><th>JSON schema</th></tr>
+</thead>
+<tbody>
+<tr>
+<td><code>char</code></td>
+<td>
+
+```json
+{ "type": "string", "minLength": 1, "maxLength": 1 }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>int</code>, <code>int64</code></td>
+<td>
+
+```json
+{ "type": "number" }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>float</code></td>
+<td>
+
+```json
+{ "type": "number" }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>bool</code></td>
+<td>
+
+```json
+{ "type": "boolean" }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>string</code></td>
+<td>
+
+```json
+{ "type": "string" }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>list</code>, <code>array</code></td>
+<td>
+
+```json
+{ "type": "array", "items": { "type": "..." } }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>'a option</code></td>
+<td>
+
+```json
+{ "type": ["...", "null"] }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>unit</code></td>
+<td>
+
+```json
+{ "type": "null" }
+```
+
+</td>
+</tr>
+</tbody>
+</table>
+
+#### Ref
 
 Type `'a ref` is treated as `'a`.
 
-Type `unit` is converted to `{ "type": "null" }`.
+```ocaml
+type t = {
+  name : string ref;
+} [@@deriving jsonschema]
+```
+
+```json
+{ "type": "string" }
+```
 
 #### Option
 
@@ -110,6 +348,34 @@ type t = {
   "additionalProperties": false 
 }
 ```
+#### Result
+
+`('ok, 'err) result` is converted to an `anyOf` with two array variants, matching the standard variant encoding:
+
+```ocaml
+type result_value = (int, string) result [@@deriving jsonschema]
+```
+
+```json
+{
+  "anyOf": [
+    {
+      "type": "array",
+      "prefixItems": [ { "const": "Error" }, { "type": "integer" } ],
+      "unevaluatedItems": false,
+      "minItems": 1
+    },
+    {
+      "type": "array",
+      "prefixItems": [ { "const": "Ok" }, { "type": "string" } ],
+      "unevaluatedItems": false,
+      "minItems": 2,
+      "maxItems": 2
+    }
+  ]
+}
+```
+
 #### List and arrays
 
 OCaml lists and arrays are converted to `{ "type": "array", "items": { "type": "..." } }`.

--- a/runtime/Ppx_deriving_jsonschema_runtime_classify.ml
+++ b/runtime/Ppx_deriving_jsonschema_runtime_classify.ml
@@ -1,3 +1,13 @@
+type t =
+  [ `Null
+  | `String of string
+  | `Float of float
+  | `Int of int
+  | `Bool of bool
+  | `List of t list
+  | `Assoc of (string * t) list
+  ]
+
 let classify f x =
   match%platform () with
   | Server -> f x

--- a/runtime/ppx_deriving_jsonschema_runtime.ml
+++ b/runtime/ppx_deriving_jsonschema_runtime.ml
@@ -1,41 +1,34 @@
 let schema_version = "https://json-schema.org/draft/2020-12/schema"
 
-(* There is no Yojson.Basic.t in Melange and the Melange_json.t is not compatible with Yojson.Basic.t,
-   so we use our own type to support universal API. Platform-specific conversion is in classify.ml
-   (native: Obj.magic coercion; Melange: Js.Json decode). *)
+type t = Ppx_deriving_jsonschema_runtime_classify.t
 
-type t =
-  [ `Null
-  | `String of string
-  | `Float of float
-  | `Int of int
-  | `Bool of bool
-  | `List of t list
-  | `Assoc of (string * t) list
-  ]
-
-let classify = Ppx_deriving_jsonschema_classify.classify
+let classify = Ppx_deriving_jsonschema_runtime_classify.classify
 
 let json_schema ?id ?title ?description ?definitions types =
-  match types with
-  | `Assoc types ->
-    let metadata =
-      List.filter_map
-        (fun x -> x)
-        [
-          Some ("$schema", `String schema_version);
-          (match id with
-          | None -> None
-          | Some id -> Some ("$id", `String id));
-          (match title with
-          | None -> None
-          | Some title -> Some ("title", `String title));
-          (match description with
-          | None -> None
-          | Some description -> Some ("description", `String description));
-          (match definitions with
-          | None -> None
-          | Some defs -> Some ("$defs", `Assoc defs));
-        ]
-    in
-    `Assoc (metadata @ types)
+  let fields =
+    match types with
+    | `Assoc fields -> fields
+    | _ -> []
+  in
+  let metadata =
+    List.filter_map
+      (fun x -> x)
+      [
+        Some ("$schema", `String schema_version);
+        (match id with
+        | None -> None
+        | Some id -> Some ("$id", `String id));
+        (match title with
+        | None -> None
+        | Some title -> Some ("title", `String title));
+        (match description with
+        | None -> None
+        | Some description -> Some ("description", `String description));
+        (match definitions with
+        | None -> None
+        | Some defs -> Some ("$defs", `Assoc defs));
+      ]
+  in
+  `Assoc (metadata @ fields)
+
+module Primitives = Ppx_deriving_jsonschema_runtime_primitives

--- a/runtime/ppx_deriving_jsonschema_runtime.mli
+++ b/runtime/ppx_deriving_jsonschema_runtime.mli
@@ -1,22 +1,10 @@
 val schema_version : string
 
-type t =
-  [ `Assoc of (string * t) list
-  | `Bool of bool
-  | `Float of float
-  | `Int of int
-  | `List of t list
-  | `Null
-  | `String of string
-  ]
+type t = Ppx_deriving_jsonschema_runtime_classify.t
 
 val classify : ('a -> t) -> 'a -> t [@@platform native]
 val classify : ('a -> Js.Json.t) -> 'a -> t [@@platform js]
 
-val json_schema :
-  ?id:string ->
-  ?title:string ->
-  ?description:string ->
-  ?definitions:'a ->
-  [< `Assoc of (string * ([> `Assoc of 'a | `String of string ] as 'b)) list ] ->
-  [> `Assoc of (string * 'b) list ]
+val json_schema : ?id:string -> ?title:string -> ?description:string -> ?definitions:(string * t) list -> t -> t
+
+module Primitives : module type of Ppx_deriving_jsonschema_runtime_primitives

--- a/runtime/ppx_deriving_jsonschema_runtime_primitives.ml
+++ b/runtime/ppx_deriving_jsonschema_runtime_primitives.ml
@@ -1,0 +1,52 @@
+module Common = struct
+  type t = Ppx_deriving_jsonschema_runtime_classify.t
+  let char_jsonschema : t = `Assoc [ "type", `String "string"; "minLength", `Int 1; "maxLength", `Int 1 ]
+  let string_jsonschema : t = `Assoc [ "type", `String "string" ]
+  let bool_jsonschema : t = `Assoc [ "type", `String "boolean" ]
+  let float_jsonschema : t = `Assoc [ "type", `String "number" ]
+  let int_jsonschema : t = `Assoc [ "type", `String "integer" ]
+  let option_jsonschema (schema : t) : t =
+    let is_basic_type ty = ty = "string" || ty = "number" || ty = "boolean" || ty = "integer" in
+    match schema with
+    | `Assoc (("type", `String ty) :: rest) when is_basic_type ty ->
+      `Assoc (("type", `List [ `String ty; `String "null" ]) :: rest)
+    | s -> `Assoc [ "anyOf", `List [ s; `Assoc [ "type", `String "null" ] ] ]
+  let unit_jsonschema : t = `Assoc [ "type", `String "null" ]
+  let list_jsonschema element_type : t = `Assoc [ "type", `String "array"; "items", element_type ]
+  let array_jsonschema element_type : t = `Assoc [ "type", `String "array"; "items", element_type ]
+end
+
+module Yojson = struct
+  include Common
+  let int64_jsonschema : t = `Assoc [ "type", `String "integer" ]
+end
+[@@platform native]
+
+module Melange_json = struct
+  include Common
+  let int64_jsonschema : t =
+    `Assoc [ "type", `String "string"; "description", `String "int64 is represented as a string" ]
+  let result_jsonschema (error_schema : t) (ok_schema : t) : t =
+    `Assoc
+      [
+        ( "anyOf",
+          `List
+            [
+              `Assoc
+                [
+                  "type", `String "array";
+                  "prefixItems", `List [ `Assoc [ "const", `String "Error" ]; error_schema ];
+                  "unevaluatedItems", `Bool false;
+                  "minItems", `Int 1;
+                ];
+              `Assoc
+                [
+                  "type", `String "array";
+                  "prefixItems", `List [ `Assoc [ "const", `String "Ok" ]; ok_schema ];
+                  "unevaluatedItems", `Bool false;
+                  "minItems", `Int 2;
+                  "maxItems", `Int 2;
+                ];
+            ] );
+      ]
+end

--- a/runtime/ppx_deriving_jsonschema_runtime_primitives.mli
+++ b/runtime/ppx_deriving_jsonschema_runtime_primitives.mli
@@ -1,0 +1,29 @@
+module Yojson : sig
+  type t = Ppx_deriving_jsonschema_runtime_classify.t
+  val char_jsonschema : t
+  val string_jsonschema : t
+  val bool_jsonschema : t
+  val float_jsonschema : t
+  val int_jsonschema : t
+  val option_jsonschema : t -> t
+  val unit_jsonschema : t
+  val list_jsonschema : t -> t
+  val array_jsonschema : t -> t
+  val int64_jsonschema : t
+end
+[@@platform native]
+
+module Melange_json : sig
+  type t = Ppx_deriving_jsonschema_runtime_classify.t
+  val char_jsonschema : t
+  val string_jsonschema : t
+  val bool_jsonschema : t
+  val float_jsonschema : t
+  val int_jsonschema : t
+  val option_jsonschema : t -> t
+  val unit_jsonschema : t
+  val list_jsonschema : t -> t
+  val array_jsonschema : t -> t
+  val int64_jsonschema : t
+  val result_jsonschema : t -> t -> t
+end

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -22,23 +22,26 @@ let rec schema_of_core_type ~(config : Attrs.config) ?(recursive_types = []) cor
   let loc = core_type.ptyp_loc in
   let schema, is_rec =
     match core_type with
-    | [%type: int] | [%type: int32] | [%type: nativeint] -> Schema.type_def ~loc "integer", false
-    | [%type: int64] ->
-      ( Schema.type_def ~loc "string"
-        |> Schema.annotation ~loc ("description", [%expr `String [%e estring ~loc "int64 is represented as a string"]]),
-        false )
-    | [%type: float] -> Schema.type_def ~loc "number", false
-    | [%type: string] | [%type: bytes] -> Schema.type_def ~loc "string", false
-    | [%type: bool] -> Schema.type_def ~loc "boolean", false
-    | [%type: char] -> Schema.char ~loc, false
-    | [%type: unit] -> Schema.null ~loc, false
+    | [%type: int] | [%type: int32] | [%type: nativeint] -> [%expr int_jsonschema], false
+    | [%type: int64] -> [%expr int64_jsonschema], false
+    | [%type: float] -> [%expr float_jsonschema], false
+    | [%type: string] | [%type: bytes] -> [%expr string_jsonschema], false
+    | [%type: bool] -> [%expr bool_jsonschema], false
+    | [%type: char] -> [%expr char_jsonschema], false
+    | [%type: unit] -> [%expr unit_jsonschema], false
+    | [%type: [%t? t] result] ->
+      let expr, is_rec = schema_of_core_type ~config ~recursive_types t in
+      [%expr result_jsonschema [%e expr]], is_rec
     | [%type: [%t? t] option] ->
       let s, is_rec = schema_of_core_type ~config ~recursive_types t in
-      Schema.nullable ~loc s, is_rec
+      [%expr option_jsonschema [%e s]], is_rec
     | [%type: [%t? t] ref] -> schema_of_core_type ~config ~recursive_types t
-    | [%type: [%t? t] list] | [%type: [%t? t] array] ->
+    | [%type: [%t? t] list] ->
       let t, is_rec = schema_of_core_type ~config ~recursive_types t in
-      Schema.array_ ~loc t, is_rec
+      [%expr list_jsonschema [%e t]], is_rec
+    | [%type: [%t? t] array] ->
+      let t, is_rec = schema_of_core_type ~config ~recursive_types t in
+      [%expr array_jsonschema [%e t]], is_rec
     | _ ->
     match core_type.ptyp_desc with
     | Ptyp_var name -> evar ~loc name, false
@@ -166,7 +169,7 @@ let schema_of_record ~loc ~(config : Attrs.config) ?(recursive_types = []) field
           match pld_type with
           | [%type: [%t? inner] option] ->
             let s, r = schema_of_core_type ~config ~recursive_types inner in
-            Schema.nullable ~loc s, r
+            [%expr option_jsonschema [%e s]], r
           | _ -> schema_of_core_type ~config ~recursive_types pld_type
         in
         let type_def =
@@ -326,11 +329,6 @@ let str_type_decl ~ctxt ast flag_variant_as_string flag_polymorphic_variant_tupl
           [%e apply_defs ~loc (`NonRec raw_schema)]]
     in
     let schema = wrap_type_params ~loc ~prefix:params_prefix params schema in
-    let schema =
-      match Attrs.td_description ~ocaml_doc:config.Attrs.ocaml_doc type_decl with
-      | Some desc -> Schema.description ~loc desc.txt schema
-      | None -> schema
-    in
     [ create_value ~loc type_name schema ]
   (* Multiple type declarations (mutually recursive types) *)
   | _, type_decls when List.length type_decls > 1 ->

--- a/src/schema.ml
+++ b/src/schema.ml
@@ -9,30 +9,9 @@ let type_ref ~loc type_name =
 
 let type_def ~loc type_name = [%expr `Assoc [ "type", `String [%e estring ~loc type_name] ]]
 
-let null ~loc = [%expr `Assoc [ "type", `String "null" ]]
-
-let char ~loc = [%expr `Assoc [ "type", `String "string"; "minLength", `Int 1; "maxLength", `Int 1 ]]
-
 let oneOf ~loc values = [%expr `Assoc [ "oneOf", `List [%e elist ~loc values] ]]
 
 let anyOf ~loc values = [%expr `Assoc [ "anyOf", `List [%e elist ~loc values] ]]
-
-let array_ ~loc ?min_items ?max_items element_type =
-  let fields =
-    List.filter_map
-      (fun x -> x)
-      [
-        Some [%expr "type", `String "array"];
-        Some [%expr "items", [%e element_type]];
-        (match min_items with
-        | Some min -> Some [%expr "minItems", `Int [%e eint ~loc min]]
-        | None -> None);
-        (match max_items with
-        | Some max -> Some [%expr "maxItems", `Int [%e eint ~loc max]]
-        | None -> None);
-      ]
-  in
-  [%expr `Assoc [%e elist ~loc fields]]
 
 let tuple ~loc elements =
   [%expr
@@ -54,16 +33,14 @@ let enum_string ~loc values =
   let values = List.map (fun name -> [%expr `String [%e estring ~loc name]]) values in
   enum ~loc (Some "string") values
 
-let nullable ~loc schema =
-  match schema with
-  | [%expr `Assoc [ "type", `String [%e? t] ]] -> [%expr `Assoc [ "type", `List [ `String [%e t]; `String "null" ] ]]
-  | s -> [%expr `Assoc [ "anyOf", `List [ [%e s]; `Assoc [ "type", `String "null" ] ] ]]
-
 let annotation ~loc (name, value) schema =
   match schema with
   | [%expr `Assoc [%e? fields]] -> [%expr `Assoc (([%e estring ~loc name], [%e value]) :: [%e fields])]
-  | s -> s
-
+  | s ->
+    [%expr
+      match [%e s] with
+      | `Assoc ppx_fields -> `Assoc (([%e estring ~loc name], [%e value]) :: ppx_fields)
+      | ppx_other -> ppx_other]
 let format ~loc format = annotation ~loc ("format", [%expr `String [%e estring ~loc format]])
 let maximum ~loc maximum = annotation ~loc ("maximum", maximum)
 let minimum ~loc minimum = annotation ~loc ("minimum", minimum)

--- a/src/schema.mli
+++ b/src/schema.mli
@@ -1,15 +1,11 @@
 val const : loc:Warnings.loc -> string -> Ppxlib.expression
 val type_ref : loc:Warnings.loc -> string -> Ppxlib.expression
 val type_def : loc:Warnings.loc -> string -> Ppxlib.expression
-val null : loc:Warnings.loc -> Ppxlib.expression
-val char : loc:Warnings.loc -> Ppxlib.expression
 val oneOf : loc:Warnings.loc -> Ppxlib.expression list -> Ppxlib.expression
 val anyOf : loc:Warnings.loc -> Ppxlib.expression list -> Ppxlib.expression
-val array_ : loc:Warnings.loc -> ?min_items:int -> ?max_items:int -> Ppxlib.expression -> Ppxlib.expression
 val tuple : loc:Warnings.loc -> Ppxlib.expression list -> Ppxlib.expression
 val enum : loc:Warnings.loc -> string option -> Ppxlib.expression list -> Ppxlib.expression
 val enum_string : loc:Warnings.loc -> string list -> Ppxlib.expression
-val nullable : loc:Warnings.loc -> Ppxlib.expression -> Ppxlib.expression
 val annotation : loc:Warnings.loc -> string * Ppxlib.expression -> Ppxlib.expression -> Ppxlib.expression
 val format : loc:Warnings.loc -> string -> Ppxlib.expression -> Ppxlib.expression
 val maximum : loc:Warnings.loc -> Ppxlib.expression -> Ppxlib.expression -> Ppxlib.expression

--- a/test/shared/cases.ml
+++ b/test/shared/cases.ml
@@ -1,4 +1,4 @@
-[@@@ocaml.warning "-37-69"]
+open Ppx_deriving_jsonschema_runtime.Primitives.Melange_json
 open Melange_json.Primitives
 
 let string_jsonschema = `Assoc [ "type", `String "string" ]

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -1,4 +1,4 @@
-[@@@ocaml.warning "-37-69"]
+open Ppx_deriving_jsonschema_runtime.Primitives.Melange_json
 open Melange_json.Primitives
 let string_jsonschema = `Assoc [("type", (`String "string"))]
 let int_jsonschema = `Assoc [("type", (`String "integer"))]
@@ -276,8 +276,7 @@ include
                    [("type", (`String "array"));
                    ("prefixItems",
                      (`List
-                        [`Assoc [("const", (`String "Aaa"))];
-                        `Assoc [("type", (`String "integer"))]]));
+                        [`Assoc [("const", (`String "Aaa"))]; int_jsonschema]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 2));
                    ("maxItems", (`Int 2))];
@@ -293,8 +292,8 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "ccc"))];
-                       `Assoc [("type", (`String "string"))];
-                       `Assoc [("type", (`String "boolean"))]]));
+                       string_jsonschema;
+                       bool_jsonschema]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 3));
                   ("maxItems", (`Int 3))]]))] in
@@ -357,7 +356,7 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "Second_one"))];
-                       `Assoc [("type", (`String "integer"))]]));
+                       int_jsonschema]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))];
@@ -436,15 +435,11 @@ include
           [("type", (`String "object"));
           ("properties",
             (`Assoc
-               [("native_int", (`Assoc [("type", (`String "integer"))]));
-               ("unit", (`Assoc [("type", (`String "null"))]));
-               ("string_ref", (`Assoc [("type", (`String "string"))]));
-               ("bunch_of_bytes", (`Assoc [("type", (`String "string"))]));
-               ("c",
-                 (`Assoc
-                    [("type", (`String "string"));
-                    ("minLength", (`Int 1));
-                    ("maxLength", (`Int 1))]));
+               [("native_int", int_jsonschema);
+               ("unit", unit_jsonschema);
+               ("string_ref", string_jsonschema);
+               ("bunch_of_bytes", string_jsonschema);
+               ("c", char_jsonschema);
                ("t",
                  (`Assoc
                     [("anyOf",
@@ -470,18 +465,10 @@ include
                             ("unevaluatedItems", (`Bool false));
                             ("minItems", (`Int 1));
                             ("maxItems", (`Int 1))]]))]));
-               ("l",
-                 (`Assoc
-                    [("type", (`String "array"));
-                    ("items", (`Assoc [("type", (`String "string"))]))]));
-               ("a",
-                 (`Assoc
-                    [("type", (`String "array"));
-                    ("items", (`Assoc [("type", (`String "number"))]))]));
-               ("opt_int",
-                 (`Assoc
-                    [("type", (`List [`String "integer"; `String "null"]))]));
-               ("comment", (`Assoc [("type", (`String "string"))]));
+               ("l", (list_jsonschema string_jsonschema));
+               ("a", (array_jsonschema float_jsonschema));
+               ("opt_int", (option_jsonschema int_jsonschema));
+               ("comment", string_jsonschema);
                ("kind_f",
                  ((match kind_jsonschema with
                    | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
@@ -491,7 +478,7 @@ include
                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                             pairs))
                    | other -> other)));
-               ("date", (`Assoc [("type", (`String "number"))]))]));
+               ("date", float_jsonschema)]));
           ("required",
             (`List
                [`String "native_int";
@@ -531,12 +518,9 @@ include
           ("properties",
             (`Assoc
                [("b",
-                  (`Assoc
-                     [("type", (`String "array"));
-                     ("items",
-                       (`Assoc
-                          [("$ref", (`String "#/$defs/recursive_record"))]))]));
-               ("a", (`Assoc [("type", (`String "integer"))]))]));
+                  (list_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/recursive_record"))])));
+               ("a", int_jsonschema)]));
           ("required", (`List [`String "b"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
       `Assoc
@@ -614,8 +598,7 @@ include
                                  (`Assoc [("$ref", (`String "#/$defs/tree"))]));
                               ("left",
                                 (`Assoc [("$ref", (`String "#/$defs/tree"))]));
-                              ("value",
-                                (`Assoc [("type", (`String "integer"))]))]));
+                              ("value", int_jsonschema)]));
                          ("required",
                            (`List
                               [`String "right";
@@ -640,9 +623,7 @@ include
         `Assoc
           [("type", (`String "object"));
           ("properties",
-            (`Assoc
-               [("y", (`Assoc [("type", (`String "string"))]));
-               ("x", (`Assoc [("type", (`String "integer"))]))]));
+            (`Assoc [("y", string_jsonschema); ("x", int_jsonschema)]));
           ("required", (`List [`String "y"; `String "x"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -670,11 +651,8 @@ include
           ("properties",
             (`Assoc
                [("bar",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/bar"))];
-                           `Assoc [("type", (`String "null"))]]))]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/bar"))])))]));
           ("required", (`List [`String "bar"]));
           ("additionalProperties", (`Bool false))] in
       let ppx_body_bar =
@@ -683,11 +661,8 @@ include
           ("properties",
             (`Assoc
                [("foo",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/foo"))];
-                           `Assoc [("type", (`String "null"))]]))]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/foo"))])))]));
           ("required", (`List [`String "foo"]));
           ("additionalProperties", (`Bool false))] in
       `Assoc
@@ -703,11 +678,8 @@ include
           ("properties",
             (`Assoc
                [("bar",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/bar"))];
-                           `Assoc [("type", (`String "null"))]]))]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/bar"))])))]));
           ("required", (`List [`String "bar"]));
           ("additionalProperties", (`Bool false))] in
       let ppx_body_bar =
@@ -716,11 +688,8 @@ include
           ("properties",
             (`Assoc
                [("foo",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/foo"))];
-                           `Assoc [("type", (`String "null"))]]))]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/foo"))])))]));
           ("required", (`List [`String "foo"]));
           ("additionalProperties", (`Bool false))] in
       `Assoc
@@ -752,7 +721,7 @@ include
                    ("prefixItems",
                      (`List
                         [`Assoc [("const", (`String "Literal"))];
-                        `Assoc [("type", (`String "integer"))]]));
+                        int_jsonschema]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 2));
                    ("maxItems", (`Int 2))];
@@ -771,10 +740,8 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "Block"))];
-                       `Assoc
-                         [("type", (`String "array"));
-                         ("items",
-                           (`Assoc [("$ref", (`String "#/$defs/stmt"))]))]]));
+                       list_jsonschema
+                         (`Assoc [("$ref", (`String "#/$defs/stmt"))])]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
@@ -801,13 +768,9 @@ include
                          ("properties",
                            (`Assoc
                               [("else_",
-                                 (`Assoc
-                                    [("anyOf",
-                                       (`List
-                                          [`Assoc
-                                             [("$ref",
-                                                (`String "#/$defs/stmt"))];
-                                          `Assoc [("type", (`String "null"))]]))]));
+                                 (option_jsonschema
+                                    (`Assoc
+                                       [("$ref", (`String "#/$defs/stmt"))])));
                               ("then_",
                                 (`Assoc [("$ref", (`String "#/$defs/stmt"))]));
                               ("cond",
@@ -838,7 +801,7 @@ include
                    ("prefixItems",
                      (`List
                         [`Assoc [("const", (`String "Literal"))];
-                        `Assoc [("type", (`String "integer"))]]));
+                        int_jsonschema]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 2));
                    ("maxItems", (`Int 2))];
@@ -857,10 +820,8 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "Block"))];
-                       `Assoc
-                         [("type", (`String "array"));
-                         ("items",
-                           (`Assoc [("$ref", (`String "#/$defs/stmt"))]))]]));
+                       list_jsonschema
+                         (`Assoc [("$ref", (`String "#/$defs/stmt"))])]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
@@ -887,13 +848,9 @@ include
                          ("properties",
                            (`Assoc
                               [("else_",
-                                 (`Assoc
-                                    [("anyOf",
-                                       (`List
-                                          [`Assoc
-                                             [("$ref",
-                                                (`String "#/$defs/stmt"))];
-                                          `Assoc [("type", (`String "null"))]]))]));
+                                 (option_jsonschema
+                                    (`Assoc
+                                       [("$ref", (`String "#/$defs/stmt"))])));
                               ("then_",
                                 (`Assoc [("$ref", (`String "#/$defs/stmt"))]));
                               ("cond",
@@ -925,8 +882,7 @@ include
       let ppx_result =
         `Assoc
           [("type", (`String "object"));
-          ("properties",
-            (`Assoc [("x", (`Assoc [("type", (`String "integer"))]))]));
+          ("properties", (`Assoc [("x", int_jsonschema)]));
           ("required", (`List [`String "x"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -944,8 +900,7 @@ include
       let ppx_result =
         `Assoc
           [("type", (`String "object"));
-          ("properties",
-            (`Assoc [("y", (`Assoc [("type", (`String "string"))]))]));
+          ("properties", (`Assoc [("y", string_jsonschema)]));
           ("required", (`List [`String "y"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -978,17 +933,11 @@ include
           ("properties",
             (`Assoc
                [("c",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/node_c"))];
-                           `Assoc [("type", (`String "null"))]]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
                ("b",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc [("$ref", (`String "#/$defs/node_b"))];
-                          `Assoc [("type", (`String "null"))]]))]))]));
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_b"))])))]));
           ("required", (`List [`String "c"; `String "b"]));
           ("additionalProperties", (`Bool false))] in
       let ppx_body_node_b =
@@ -997,17 +946,11 @@ include
           ("properties",
             (`Assoc
                [("c",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/node_c"))];
-                           `Assoc [("type", (`String "null"))]]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
                ("a",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc [("$ref", (`String "#/$defs/node_a"))];
-                          `Assoc [("type", (`String "null"))]]))]))]));
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
           ("required", (`List [`String "c"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
       let ppx_body_node_c =
@@ -1016,17 +959,11 @@ include
           ("properties",
             (`Assoc
                [("b",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/node_b"))];
-                           `Assoc [("type", (`String "null"))]]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_b"))])));
                ("a",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc [("$ref", (`String "#/$defs/node_a"))];
-                          `Assoc [("type", (`String "null"))]]))]))]));
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
           ("required", (`List [`String "b"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
       `Assoc
@@ -1044,17 +981,11 @@ include
           ("properties",
             (`Assoc
                [("c",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/node_c"))];
-                           `Assoc [("type", (`String "null"))]]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
                ("b",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc [("$ref", (`String "#/$defs/node_b"))];
-                          `Assoc [("type", (`String "null"))]]))]))]));
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_b"))])))]));
           ("required", (`List [`String "c"; `String "b"]));
           ("additionalProperties", (`Bool false))] in
       let ppx_body_node_b =
@@ -1063,17 +994,11 @@ include
           ("properties",
             (`Assoc
                [("c",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/node_c"))];
-                           `Assoc [("type", (`String "null"))]]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
                ("a",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc [("$ref", (`String "#/$defs/node_a"))];
-                          `Assoc [("type", (`String "null"))]]))]))]));
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
           ("required", (`List [`String "c"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
       let ppx_body_node_c =
@@ -1082,17 +1007,11 @@ include
           ("properties",
             (`Assoc
                [("b",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/node_b"))];
-                           `Assoc [("type", (`String "null"))]]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_b"))])));
                ("a",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc [("$ref", (`String "#/$defs/node_a"))];
-                          `Assoc [("type", (`String "null"))]]))]))]));
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
           ("required", (`List [`String "b"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
       `Assoc
@@ -1110,17 +1029,11 @@ include
           ("properties",
             (`Assoc
                [("c",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/node_c"))];
-                           `Assoc [("type", (`String "null"))]]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
                ("b",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc [("$ref", (`String "#/$defs/node_b"))];
-                          `Assoc [("type", (`String "null"))]]))]))]));
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_b"))])))]));
           ("required", (`List [`String "c"; `String "b"]));
           ("additionalProperties", (`Bool false))] in
       let ppx_body_node_b =
@@ -1129,17 +1042,11 @@ include
           ("properties",
             (`Assoc
                [("c",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/node_c"))];
-                           `Assoc [("type", (`String "null"))]]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
                ("a",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc [("$ref", (`String "#/$defs/node_a"))];
-                          `Assoc [("type", (`String "null"))]]))]))]));
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
           ("required", (`List [`String "c"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
       let ppx_body_node_c =
@@ -1148,17 +1055,11 @@ include
           ("properties",
             (`Assoc
                [("b",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/node_b"))];
-                           `Assoc [("type", (`String "null"))]]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_b"))])));
                ("a",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc [("$ref", (`String "#/$defs/node_a"))];
-                          `Assoc [("type", (`String "null"))]]))]))]));
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
           ("required", (`List [`String "b"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
       `Assoc
@@ -1185,7 +1086,7 @@ include
                    ("prefixItems",
                      (`List
                         [`Assoc [("const", (`String "Leaf"))];
-                        `Assoc [("type", (`String "integer"))]]));
+                        int_jsonschema]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 2));
                    ("maxItems", (`Int 2))];
@@ -1245,16 +1146,13 @@ include
     let events_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("type", (`String "array"));
-          ("items",
-            ((match event_jsonschema with
-              | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                  `Assoc (("$id", (`String "file://shared/cases.ml:141")) ::
-                    (Stdlib.List.filter
-                       (fun (k, _) -> not (Stdlib.String.equal k "$id"))
-                       pairs))
-              | other -> other)))] in
+        list_jsonschema
+          (match event_jsonschema with
+           | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+               `Assoc (("$id", (`String "file://shared/cases.ml:141")) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
+           | other -> other) in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -1272,20 +1170,15 @@ include
     let eventss_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("type", (`String "array"));
-          ("items",
-            (`Assoc
-               [("type", (`String "array"));
-               ("items",
-                 ((match event_jsonschema with
-                   | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                       `Assoc
-                         (("$id", (`String "file://shared/cases.ml:142")) ::
-                         (Stdlib.List.filter
-                            (fun (k, _) -> not (Stdlib.String.equal k "$id"))
-                            pairs))
-                   | other -> other)))]))] in
+        list_jsonschema
+          (list_jsonschema
+             (match event_jsonschema with
+              | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                  `Assoc (("$id", (`String "file://shared/cases.ml:142")) ::
+                    (Stdlib.List.filter
+                       (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                       pairs))
+              | other -> other)) in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -1315,7 +1208,7 @@ include
                           (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                           pairs))
                  | other -> other);
-               `Assoc [("type", (`String "string"))]]));
+               string_jsonschema]));
           ("unevaluatedItems", (`Bool false));
           ("minItems", (`Int 2));
           ("maxItems", (`Int 2))] in
@@ -1336,16 +1229,13 @@ include
     let event_comments'_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("type", (`String "array"));
-          ("items",
-            ((match event_comment_jsonschema with
-              | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                  `Assoc (("$id", (`String "file://shared/cases.ml:144")) ::
-                    (Stdlib.List.filter
-                       (fun (k, _) -> not (Stdlib.String.equal k "$id"))
-                       pairs))
-              | other -> other)))] in
+        list_jsonschema
+          (match event_comment_jsonschema with
+           | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+               `Assoc (("$id", (`String "file://shared/cases.ml:144")) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
+           | other -> other) in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -1363,27 +1253,24 @@ include
     let event_n_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("type", (`String "array"));
-          ("items",
-            (`Assoc
-               [("type", (`String "array"));
-               ("prefixItems",
-                 (`List
-                    [(match event_jsonschema with
-                      | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
-                          ->
-                          `Assoc
-                            (("$id", (`String "file://shared/cases.ml:145"))
-                            ::
-                            (Stdlib.List.filter
-                               (fun (k, _) ->
-                                  not (Stdlib.String.equal k "$id")) pairs))
-                      | other -> other);
-                    `Assoc [("type", (`String "integer"))]]));
-               ("unevaluatedItems", (`Bool false));
-               ("minItems", (`Int 2));
-               ("maxItems", (`Int 2))]))] in
+        list_jsonschema
+          (`Assoc
+             [("type", (`String "array"));
+             ("prefixItems",
+               (`List
+                  [(match event_jsonschema with
+                    | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
+                        ->
+                        `Assoc
+                          (("$id", (`String "file://shared/cases.ml:145")) ::
+                          (Stdlib.List.filter
+                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                             pairs))
+                    | other -> other);
+                  int_jsonschema]));
+             ("unevaluatedItems", (`Bool false));
+             ("minItems", (`Int 2));
+             ("maxItems", (`Int 2))]) in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -1401,16 +1288,13 @@ include
     let events_array_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("type", (`String "array"));
-          ("items",
-            ((match events_jsonschema with
-              | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                  `Assoc (("$id", (`String "file://shared/cases.ml:146")) ::
-                    (Stdlib.List.filter
-                       (fun (k, _) -> not (Stdlib.String.equal k "$id"))
-                       pairs))
-              | other -> other)))] in
+        array_jsonschema
+          (match events_jsonschema with
+           | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+               `Assoc (("$id", (`String "file://shared/cases.ml:146")) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
+           | other -> other) in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -1427,10 +1311,7 @@ include
   struct
     let numbers_jsonschema =
       let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc
-          [("type", (`String "array"));
-          ("items", (`Assoc [("type", (`String "integer"))]))] in
+      let ppx_result = list_jsonschema int_jsonschema in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -1447,8 +1328,7 @@ include
   struct
     let opt_jsonschema =
       let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc [("type", (`List [`String "integer"; `String "null"]))] in
+      let ppx_result = option_jsonschema int_jsonschema in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -1524,7 +1404,7 @@ include
           [("type", (`String "array"));
           ("prefixItems",
             (`List
-               [`Assoc [("type", (`String "integer"))];
+               [int_jsonschema;
                `Assoc
                  [("anyOf",
                     (`List
@@ -1572,7 +1452,7 @@ include
             (`Assoc
                [("scores_ref",
                   (`Assoc [("$ref", (`String "#/$defs/numbers"))]));
-               ("player", (`Assoc [("type", (`String "string"))]))]));
+               ("player", string_jsonschema)]));
           ("required", (`List [`String "scores_ref"; `String "player"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -1599,9 +1479,9 @@ include
           [("type", (`String "object"));
           ("properties",
             (`Assoc
-               [("zip", (`Assoc [("type", (`String "string"))]));
-               ("city", (`Assoc [("type", (`String "string"))]));
-               ("street", (`Assoc [("type", (`String "string"))]))]));
+               [("zip", string_jsonschema);
+               ("city", string_jsonschema);
+               ("street", string_jsonschema)]));
           ("required",
             (`List [`String "zip"; `String "city"; `String "street"]));
           ("additionalProperties", (`Bool false))] in
@@ -1640,11 +1520,9 @@ include
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
                     | other -> other)));
-               ("email",
-                 (`Assoc
-                    [("type", (`List [`String "string"; `String "null"]))]));
-               ("age", (`Assoc [("type", (`String "integer"))]));
-               ("name", (`Assoc [("type", (`String "string"))]))]));
+               ("email", (option_jsonschema string_jsonschema));
+               ("age", int_jsonschema);
+               ("name", string_jsonschema)]));
           ("required",
             (`List
                [`String "address";
@@ -1686,11 +1564,9 @@ include
                  (`Assoc [("$ref", (`String "#/$defs/shared_address"))]));
                ("home_address",
                  (`Assoc [("$ref", (`String "#/$defs/shared_address"))]));
-               ("email",
-                 (`Assoc
-                    [("type", (`List [`String "string"; `String "null"]))]));
-               ("age", (`Assoc [("type", (`String "integer"))]));
-               ("name", (`Assoc [("type", (`String "string"))]))]));
+               ("email", (option_jsonschema string_jsonschema));
+               ("age", int_jsonschema);
+               ("name", string_jsonschema)]));
           ("required",
             (`List
                [`String "retreat_address";
@@ -1716,11 +1592,7 @@ include
   struct
     let c_jsonschema =
       let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc
-          [("type", (`String "string"));
-          ("minLength", (`Int 1));
-          ("maxLength", (`Int 1))] in
+      let ppx_result = char_jsonschema in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -1781,10 +1653,8 @@ include
                           [("type", (`String "object"));
                           ("properties",
                             (`Assoc
-                               [("email",
-                                  (`Assoc [("type", (`String "string"))]));
-                               ("name",
-                                 (`Assoc [("type", (`String "string"))]))]));
+                               [("email", string_jsonschema);
+                               ("name", string_jsonschema)]));
                           ("required",
                             (`List [`String "email"; `String "name"]));
                           ("additionalProperties", (`Bool true))]]));
@@ -1798,10 +1668,7 @@ include
                        [`Assoc [("const", (`String "Guest"))];
                        `Assoc
                          [("type", (`String "object"));
-                         ("properties",
-                           (`Assoc
-                              [("ip",
-                                 (`Assoc [("type", (`String "string"))]))]));
+                         ("properties", (`Assoc [("ip", string_jsonschema)]));
                          ("required", (`List [`String "ip"]));
                          ("additionalProperties", (`Bool false))]]));
                   ("unevaluatedItems", (`Bool false));
@@ -1869,7 +1736,7 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "Class"))];
-                       `Assoc [("type", (`String "string"))]]));
+                       string_jsonschema]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
@@ -1931,7 +1798,7 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "class"))];
-                       `Assoc [("type", (`String "string"))]]));
+                       string_jsonschema]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
@@ -1954,10 +1821,7 @@ include
       let ppx_result =
         `Assoc
           [("type", (`String "array"));
-          ("prefixItems",
-            (`List
-               [`Assoc [("type", (`String "integer"))];
-               `Assoc [("type", (`String "string"))]]));
+          ("prefixItems", (`List [int_jsonschema; string_jsonschema]));
           ("unevaluatedItems", (`Bool false));
           ("minItems", (`Int 2));
           ("maxItems", (`Int 2))] in
@@ -1986,9 +1850,9 @@ include
                    ("prefixItems",
                      (`List
                         [`Assoc [("const", (`String "A"))];
-                        `Assoc [("type", (`String "integer"))];
-                        `Assoc [("type", (`String "string"))];
-                        `Assoc [("type", (`String "boolean"))]]));
+                        int_jsonschema;
+                        string_jsonschema;
+                        bool_jsonschema]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 4));
                    ("maxItems", (`Int 4))]]))] in
@@ -2021,13 +1885,13 @@ include
                           [("type", (`String "array"));
                           ("prefixItems",
                             (`List
-                               [`Assoc [("type", (`String "integer"))];
-                               `Assoc [("type", (`String "string"))];
-                               `Assoc [("type", (`String "boolean"))]]));
+                               [int_jsonschema;
+                               string_jsonschema;
+                               bool_jsonschema]));
                           ("unevaluatedItems", (`Bool false));
                           ("minItems", (`Int 3));
                           ("maxItems", (`Int 3))];
-                        `Assoc [("type", (`String "number"))]]));
+                        float_jsonschema]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 3));
                    ("maxItems", (`Int 3))]]))] in
@@ -2057,9 +1921,9 @@ include
                    ("prefixItems",
                      (`List
                         [`Assoc [("const", (`String "A"))];
-                        `Assoc [("type", (`String "integer"))];
-                        `Assoc [("type", (`String "string"))];
-                        `Assoc [("type", (`String "boolean"))]]));
+                        int_jsonschema;
+                        string_jsonschema;
+                        bool_jsonschema]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 4));
                    ("maxItems", (`Int 4))]]))] in
@@ -2093,9 +1957,9 @@ include
                           [("type", (`String "array"));
                           ("prefixItems",
                             (`List
-                               [`Assoc [("type", (`String "integer"))];
-                               `Assoc [("type", (`String "string"))];
-                               `Assoc [("type", (`String "boolean"))]]));
+                               [int_jsonschema;
+                               string_jsonschema;
+                               bool_jsonschema]));
                           ("unevaluatedItems", (`Bool false));
                           ("minItems", (`Int 3));
                           ("maxItems", (`Int 3))]]));
@@ -2132,13 +1996,13 @@ include
                           [("type", (`String "array"));
                           ("prefixItems",
                             (`List
-                               [`Assoc [("type", (`String "integer"))];
-                               `Assoc [("type", (`String "string"))];
-                               `Assoc [("type", (`String "boolean"))]]));
+                               [int_jsonschema;
+                               string_jsonschema;
+                               bool_jsonschema]));
                           ("unevaluatedItems", (`Bool false));
                           ("minItems", (`Int 3));
                           ("maxItems", (`Int 3))];
-                        `Assoc [("type", (`String "number"))]]));
+                        float_jsonschema]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 3));
                    ("maxItems", (`Int 3))]]))] in
@@ -2167,9 +2031,9 @@ include
                    ("prefixItems",
                      (`List
                         [`Assoc [("const", (`String "A"))];
-                        `Assoc [("type", (`String "integer"))];
-                        `Assoc [("type", (`String "string"))];
-                        `Assoc [("type", (`String "boolean"))]]));
+                        int_jsonschema;
+                        string_jsonschema;
+                        bool_jsonschema]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 4));
                    ("maxItems", (`Int 4))]]))] in
@@ -2204,9 +2068,9 @@ include
                           [("type", (`String "array"));
                           ("prefixItems",
                             (`List
-                               [`Assoc [("type", (`String "integer"))];
-                               `Assoc [("type", (`String "string"))];
-                               `Assoc [("type", (`String "boolean"))]]));
+                               [int_jsonschema;
+                               string_jsonschema;
+                               bool_jsonschema]));
                           ("unevaluatedItems", (`Bool false));
                           ("minItems", (`Int 3));
                           ("maxItems", (`Int 3))]]));
@@ -2233,8 +2097,7 @@ include
       let ppx_result =
         `Assoc
           [("type", (`String "object"));
-          ("properties",
-            (`Assoc [("x", (`Assoc [("type", (`String "integer"))]))]));
+          ("properties", (`Assoc [("x", int_jsonschema)]));
           ("required", (`List [`String "x"]));
           ("additionalProperties", (`Bool true))] in
       match !ppx_eds with
@@ -2325,8 +2188,7 @@ include
       let ppx_result =
         `Assoc
           [("type", (`String "object"));
-          ("properties",
-            (`Assoc [("x", (`Assoc [("type", (`String "integer"))]))]));
+          ("properties", (`Assoc [("x", int_jsonschema)]));
           ("required", (`List [`String "x"]));
           ("additionalProperties", (`Bool true))] in
       match !ppx_eds with
@@ -2351,9 +2213,7 @@ include
         `Assoc
           [("type", (`String "object"));
           ("properties",
-            (`Assoc
-               [("y", (`Assoc [("type", (`String "integer"))]));
-               ("x", (`Assoc [("type", (`String "integer"))]))]));
+            (`Assoc [("y", int_jsonschema); ("x", int_jsonschema)]));
           ("required", (`List [`String "y"; `String "x"]));
           ("additionalProperties", (`Bool true))] in
       match !ppx_eds with
@@ -2380,9 +2240,7 @@ include
           ("properties",
             (`Assoc
                [("url", url);
-               ("title",
-                 (`Assoc
-                    [("type", (`List [`String "string"; `String "null"]))]))]));
+               ("title", (option_jsonschema string_jsonschema))]));
           ("required", (`List [`String "url"; `String "title"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -2402,9 +2260,7 @@ include
     let string_link_traffic_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        match generic_link_traffic_jsonschema
-                (`Assoc [("type", (`String "string"))])
-        with
+        match generic_link_traffic_jsonschema string_jsonschema with
         | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
             `Assoc (("$id", (`String "file://shared/cases.ml:231")) ::
               (Stdlib.List.filter
@@ -2470,9 +2326,7 @@ include
           [("type", (`String "object"));
           ("properties",
             (`Assoc
-               [("label", (`Assoc [("type", (`String "string"))]));
-               ("second", b);
-               ("first", a)]));
+               [("label", string_jsonschema); ("second", b); ("first", a)]));
           ("required",
             (`List [`String "label"; `String "second"; `String "first"]));
           ("additionalProperties", (`Bool false))] in
@@ -2492,7 +2346,7 @@ include
   struct
     let param_list_jsonschema a =
       let ppx_eds = ref [] in
-      let ppx_result = `Assoc [("type", (`String "array")); ("items", a)] in
+      let ppx_result = list_jsonschema a in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -2603,14 +2457,21 @@ include
           ("properties",
             (`Assoc
                [("max_results",
-                  (`Assoc
-                     [("description",
-                        (`String "Maximum number of results to return"));
-                     ("type", (`String "integer"))]));
+                  ((match int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc
+                          (("description",
+                             (`String "Maximum number of results to return"))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)));
                ("query",
-                 (`Assoc
-                    [("description", (`String "The search query to execute"));
-                    ("type", (`String "string"))]))]));
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("description",
+                            (`String "The search query to execute"))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)))]));
           ("required", (`List [`String "max_results"; `String "query"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -2642,13 +2503,18 @@ include
           ("properties",
             (`Assoc
                [("age",
-                  (`Assoc
-                     [("description", (`String "The user's age"));
-                     ("type", (`List [`String "integer"; `String "null"]))]));
+                  ((match option_jsonschema int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("description", (`String "The user's age"))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)));
                ("name",
-                 (`Assoc
-                    [("description", (`String "The user's full name"));
-                    ("type", (`String "string"))]))]));
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("description", (`String "The user's full name"))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)))]));
           ("required", (`List [`String "name"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -2678,9 +2544,12 @@ include
           ("properties",
             (`Assoc
                [("opt_int",
-                  (`Assoc
-                     [("description", (`String "An optional integer"));
-                     ("type", (`List [`String "integer"; `String "null"]))]))]));
+                  ((match option_jsonschema int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc
+                          (("description", (`String "An optional integer"))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)))]));
           ("required", (`List []));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -2722,7 +2591,7 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "With_int"))];
-                       `Assoc [("type", (`String "integer"))]]));
+                       int_jsonschema]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))];
@@ -2732,8 +2601,8 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "Pair"))];
-                       `Assoc [("type", (`String "string"))];
-                       `Assoc [("type", (`String "integer"))]]));
+                       string_jsonschema;
+                       int_jsonschema]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 3));
                   ("maxItems", (`Int 3))];
@@ -2742,9 +2611,12 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "Description_value"))];
-                       `Assoc
-                         [("description", (`String "A string value"));
-                         ("type", (`String "string"))]]));
+                       (match string_jsonschema with
+                        | `Assoc ppx_fields ->
+                            `Assoc
+                              (("description", (`String "A string value")) ::
+                              ppx_fields)
+                        | ppx_other -> ppx_other)]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
@@ -2781,10 +2653,7 @@ include
                           [("type", (`String "object"));
                           ("properties",
                             (`Assoc
-                               [("y",
-                                  (`Assoc [("type", (`String "integer"))]));
-                               ("x",
-                                 (`Assoc [("type", (`String "integer"))]))]));
+                               [("y", int_jsonschema); ("x", int_jsonschema)]));
                           ("required", (`List [`String "y"; `String "x"]));
                           ("additionalProperties", (`Bool false))]]));
                    ("unevaluatedItems", (`Bool false));
@@ -2847,13 +2716,18 @@ include
           ("properties",
             (`Assoc
                [("age",
-                  (`Assoc
-                     [("description", (`String "The user's age"));
-                     ("type", (`String "integer"))]));
+                  ((match int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("description", (`String "The user's age"))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)));
                ("name",
-                 (`Assoc
-                    [("description", (`String "The user's full name"));
-                    ("type", (`String "string"))]))]));
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("description", (`String "The user's full name"))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)))]));
           ("required", (`List [`String "age"; `String "name"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -2879,8 +2753,7 @@ include
       let ppx_result =
         `Assoc
           [("type", (`String "object"));
-          ("properties",
-            (`Assoc [("name", (`Assoc [("type", (`String "string"))]))]));
+          ("properties", (`Assoc [("name", string_jsonschema)]));
           ("required", (`List [`String "name"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -2909,9 +2782,11 @@ include
           ("properties",
             (`Assoc
                [("field",
-                  (`Assoc
-                     [("description", (`String "explicit wins"));
-                     ("type", (`String "string"))]))]));
+                  ((match string_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("description", (`String "explicit wins")) ::
+                          ppx_fields)
+                    | ppx_other -> ppx_other)))]));
           ("required", (`List [`String "field"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -2952,7 +2827,7 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "With_int"))];
-                       `Assoc [("type", (`String "integer"))]]));
+                       int_jsonschema]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
@@ -2974,9 +2849,11 @@ include
     let doc_comment_core_type_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("description", (`String "A string alias"));
-          ("type", (`String "string"))] in
+        match string_jsonschema with
+        | `Assoc ppx_fields ->
+            `Assoc (("description", (`String "A string alias")) ::
+              ppx_fields)
+        | ppx_other -> ppx_other in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -2996,9 +2873,11 @@ include
     let doc_attribute_alias_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("description", (`String "Alias fallback"));
-          ("type", (`String "string"))] in
+        match string_jsonschema with
+        | `Assoc ppx_fields ->
+            `Assoc (("description", (`String "Alias fallback")) ::
+              ppx_fields)
+        | ppx_other -> ppx_other in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -3027,11 +2906,14 @@ include
           ("properties",
             (`Assoc
                [("name",
-                  (`Assoc
-                     [("description",
-                        (`String
-                           "The user's full name.\n          Must be non-empty and under 100 characters."));
-                     ("type", (`String "string"))]))]));
+                  ((match string_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc
+                          (("description",
+                             (`String
+                                "The user's full name.\n          Must be non-empty and under 100 characters."))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)))]));
           ("required", (`List [`String "name"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -3073,7 +2955,7 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "With_int"))];
-                       `Assoc [("type", (`String "integer"))]]));
+                       int_jsonschema]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
@@ -3097,10 +2979,13 @@ include
     let doc_comment_multiple_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("description",
-             (`String "first block\n\nsecond block\n\nthird block"));
-          ("type", (`String "string"))] in
+        match string_jsonschema with
+        | `Assoc ppx_fields ->
+            `Assoc
+              (("description",
+                 (`String "first block\n\nsecond block\n\nthird block"))
+              :: ppx_fields)
+        | ppx_other -> ppx_other in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -3171,7 +3056,7 @@ include
                  ("prefixItems",
                    (`List
                       [`Assoc [("const", (`String "Err"))];
-                      `Assoc [("type", (`String "string"))]]));
+                      string_jsonschema]));
                  ("unevaluatedItems", (`Bool false));
                  ("minItems", (`Int 2));
                  ("maxItems", (`Int 2))]]))] in
@@ -3201,20 +3086,9 @@ include
           ("properties",
             (`Assoc
                [("drop_complex",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc
-                              [("type", (`String "array"));
-                              ("items",
-                                (`Assoc [("type", (`String "integer"))]))];
-                           `Assoc [("type", (`String "null"))]]))]));
-               ("drop_simple",
-                 (`Assoc
-                    [("type", (`List [`String "string"; `String "null"]))]));
-               ("plain",
-                 (`Assoc
-                    [("type", (`List [`String "string"; `String "null"]))]))]));
+                  (option_jsonschema (list_jsonschema int_jsonschema)));
+               ("drop_simple", (option_jsonschema string_jsonschema));
+               ("plain", (option_jsonschema string_jsonschema))]));
           ("required", (`List [`String "plain"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -3249,29 +3123,35 @@ include
           ("properties",
             (`Assoc
                [("custom_drop_default",
-                  (`Assoc
-                     [("default", (((fun x -> `Float x)) 0.0));
-                     ("type", (`String "number"))]));
+                  ((match float_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("default", (((fun x -> `Float x)) 0.0)) ::
+                          ppx_fields)
+                    | ppx_other -> ppx_other)));
                ("dropped_default",
-                 (`Assoc
-                    [("default", (`List []));
-                    ("type", (`String "array"));
-                    ("items", (`Assoc [("type", (`String "integer"))]))]));
-               ("dropped_option",
-                 (`Assoc
-                    [("type", (`List [`String "integer"; `String "null"]))]));
+                 ((match list_jsonschema int_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (`List [])) :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("dropped_option", (option_jsonschema int_jsonschema));
                ("default_value",
-                 (`Assoc
-                    [("default", (((fun x -> `String x)) "-"));
-                    ("type", (`String "string"))]));
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (((fun x -> `String x)) "-")) ::
+                         ppx_fields)
+                   | ppx_other -> ppx_other)));
                ("default_none",
-                 (`Assoc [("default", `Null); ("type", (`String "string"))]));
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", `Null) :: ppx_fields)
+                   | ppx_other -> ppx_other)));
                ("option_default_none",
-                 (`Assoc [("default", `Null); ("type", (`String "string"))]));
-               ("option_value",
-                 (`Assoc
-                    [("type", (`List [`String "string"; `String "null"]))]));
-               ("required_value", (`Assoc [("type", (`String "integer"))]))]));
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", `Null) :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("option_value", (option_jsonschema string_jsonschema));
+               ("required_value", int_jsonschema)]));
           ("required", (`List [`String "required_value"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -3303,22 +3183,17 @@ include
           ("properties",
             (`Assoc
                [("composing_type",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [(match composing_type_jsonschema with
-                             | `Assoc pairs when
-                                 Stdlib.List.mem_assoc "$defs" pairs ->
-                                 `Assoc
-                                   (("$id",
-                                      (`String "file://shared/cases.ml:361"))
-                                   ::
-                                   (Stdlib.List.filter
-                                      (fun (k, _) ->
-                                         not (Stdlib.String.equal k "$id"))
-                                      pairs))
-                             | other -> other);
-                           `Assoc [("type", (`String "null"))]]))]))]));
+                  (option_jsonschema
+                     (match composing_type_jsonschema with
+                      | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
+                          ->
+                          `Assoc
+                            (("$id", (`String "file://shared/cases.ml:361"))
+                            ::
+                            (Stdlib.List.filter
+                               (fun (k, _) ->
+                                  not (Stdlib.String.equal k "$id")) pairs))
+                      | other -> other)))]));
           ("required", (`List []));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -3339,8 +3214,10 @@ include
     let with_format_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("format", (`String "date-time")); ("type", (`String "string"))] in
+        match string_jsonschema with
+        | `Assoc ppx_fields ->
+            `Assoc (("format", (`String "date-time")) :: ppx_fields)
+        | ppx_other -> ppx_other in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -3366,9 +3243,11 @@ include
           ("properties",
             (`Assoc
                [("with_format",
-                  (`Assoc
-                     [("format", (`String "date-time"));
-                     ("type", (`String "string"))]))]));
+                  ((match string_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("format", (`String "date-time")) ::
+                          ppx_fields)
+                    | ppx_other -> ppx_other)))]));
           ("required", (`List [`String "with_format"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -3401,10 +3280,18 @@ include
                    ("prefixItems",
                      (`List
                         [`Assoc [("const", (`String "A"))];
-                        `Assoc
-                          [("format", (`String "date-time"));
-                          ("description", (`String "A date-time string"));
-                          ("type", (`String "string"))]]));
+                        (match match string_jsonschema with
+                               | `Assoc ppx_fields ->
+                                   `Assoc
+                                     (("description",
+                                        (`String "A date-time string"))
+                                     :: ppx_fields)
+                               | ppx_other -> ppx_other
+                         with
+                         | `Assoc ppx_fields ->
+                             `Assoc (("format", (`String "date-time")) ::
+                               ppx_fields)
+                         | ppx_other -> ppx_other)]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 2));
                    ("maxItems", (`Int 2))];
@@ -3489,10 +3376,8 @@ include
           ("properties",
             (`Assoc
                [("children",
-                  (`Assoc
-                     [("type", (`String "array"));
-                     ("items",
-                       (`Assoc [("$ref", (`String "#/$defs/self_ref"))]))]))]));
+                  (list_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/self_ref"))])))]));
           ("required", (`List [`String "children"]));
           ("additionalProperties", (`Bool false))] in
       `Assoc
@@ -3567,10 +3452,8 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "Group"))];
-                       `Assoc
-                         [("type", (`String "array"));
-                         ("items",
-                           (`Assoc [("$ref", (`String "#/$defs/filter"))]))];
+                       list_jsonschema
+                         (`Assoc [("$ref", (`String "#/$defs/filter"))]);
                        group_atom]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 3));
@@ -3615,11 +3498,8 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "BoolFilterGroup"))];
-                       `Assoc
-                         [("type", (`String "array"));
-                         ("items",
-                           (`Assoc
-                              [("$ref", (`String "#/$defs/bool_filter"))]))]]));
+                       list_jsonschema
+                         (`Assoc [("$ref", (`String "#/$defs/bool_filter"))])]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
@@ -3676,7 +3556,7 @@ include
                    ("prefixItems",
                      (`List
                         [`Assoc [("const", (`String "ORLeaf"))];
-                        `Assoc [("type", (`String "integer"))]]));
+                        int_jsonschema]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 2));
                    ("maxItems", (`Int 2))];
@@ -3721,7 +3601,9 @@ include
     let with_maximum_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc [("maximum", (`Int 100)); ("type", (`String "integer"))] in
+        match int_jsonschema with
+        | `Assoc ppx_fields -> `Assoc (("maximum", (`Int 100)) :: ppx_fields)
+        | ppx_other -> ppx_other in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -3745,8 +3627,10 @@ include
           ("properties",
             (`Assoc
                [("field",
-                  (`Assoc
-                     [("maximum", (`Int 100)); ("type", (`String "integer"))]))]));
+                  ((match int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("maximum", (`Int 100)) :: ppx_fields)
+                    | ppx_other -> ppx_other)))]));
           ("required", (`List [`String "field"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -3772,12 +3656,21 @@ include
     let attrs_core_type_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("description",
-             (`String "Integer percentage value (0-100 inclusive)"));
-          ("minimum", (`Int 0));
-          ("maximum", (`Int 100));
-          ("type", (`String "integer"))] in
+        match match match int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("maximum", (`Int 100)) :: ppx_fields)
+                    | ppx_other -> ppx_other
+              with
+              | `Assoc ppx_fields ->
+                  `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+              | ppx_other -> ppx_other
+        with
+        | `Assoc ppx_fields ->
+            `Assoc
+              (("description",
+                 (`String "Integer percentage value (0-100 inclusive)"))
+              :: ppx_fields)
+        | ppx_other -> ppx_other in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -3808,16 +3701,31 @@ include
           ("properties",
             (`Assoc
                [("label",
-                  (`Assoc
-                     [("description", (`String "An ISO date-time"));
-                     ("format", (`String "date-time"));
-                     ("type", (`String "string"))]));
+                  ((match match string_jsonschema with
+                          | `Assoc ppx_fields ->
+                              `Assoc (("format", (`String "date-time")) ::
+                                ppx_fields)
+                          | ppx_other -> ppx_other
+                    with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("description", (`String "An ISO date-time"))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)));
                ("score",
-                 (`Assoc
-                    [("description", (`String "Score out of 100"));
-                    ("minimum", (`Int 0));
-                    ("maximum", (`Int 100));
-                    ("type", (`String "integer"))]))]));
+                 ((match match match int_jsonschema with
+                               | `Assoc ppx_fields ->
+                                   `Assoc (("maximum", (`Int 100)) ::
+                                     ppx_fields)
+                               | ppx_other -> ppx_other
+                         with
+                         | `Assoc ppx_fields ->
+                             `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+                         | ppx_other -> ppx_other
+                   with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("description", (`String "Score out of 100"))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)))]));
           ("required", (`List [`String "label"; `String "score"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -3839,9 +3747,11 @@ include
     let attrs_type_decl_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("description", (`String "A plain integer"));
-          ("type", (`String "integer"))] in
+        match int_jsonschema with
+        | `Assoc ppx_fields ->
+            `Assoc (("description", (`String "A plain integer")) ::
+              ppx_fields)
+        | ppx_other -> ppx_other in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -3861,10 +3771,13 @@ include
     let minimum_core_type_int_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("minimum", (`Int 0));
-          ("maximum", (`Int 100));
-          ("type", (`String "integer"))] in
+        match match int_jsonschema with
+              | `Assoc ppx_fields ->
+                  `Assoc (("maximum", (`Int 100)) :: ppx_fields)
+              | ppx_other -> ppx_other
+        with
+        | `Assoc ppx_fields -> `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+        | ppx_other -> ppx_other in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -3884,10 +3797,14 @@ include
     let minimum_core_type_float_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("minimum", (`Float 0.0));
-          ("maximum", (`Float 1.0));
-          ("type", (`String "number"))] in
+        match match float_jsonschema with
+              | `Assoc ppx_fields ->
+                  `Assoc (("maximum", (`Float 1.0)) :: ppx_fields)
+              | ppx_other -> ppx_other
+        with
+        | `Assoc ppx_fields ->
+            `Assoc (("minimum", (`Float 0.0)) :: ppx_fields)
+        | ppx_other -> ppx_other in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -3914,15 +3831,24 @@ include
           ("properties",
             (`Assoc
                [("ratio",
-                  (`Assoc
-                     [("minimum", (`Float 0.0));
-                     ("maximum", (`Float 1.0));
-                     ("type", (`String "number"))]));
+                  ((match match float_jsonschema with
+                          | `Assoc ppx_fields ->
+                              `Assoc (("maximum", (`Float 1.0)) ::
+                                ppx_fields)
+                          | ppx_other -> ppx_other
+                    with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("minimum", (`Float 0.0)) :: ppx_fields)
+                    | ppx_other -> ppx_other)));
                ("score",
-                 (`Assoc
-                    [("minimum", (`Int 0));
-                    ("maximum", (`Int 100));
-                    ("type", (`String "integer"))]))]));
+                 ((match match int_jsonschema with
+                         | `Assoc ppx_fields ->
+                             `Assoc (("maximum", (`Int 100)) :: ppx_fields)
+                         | ppx_other -> ppx_other
+                   with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+                   | ppx_other -> ppx_other)))]));
           ("required", (`List [`String "ratio"; `String "score"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -3944,10 +3870,13 @@ include
     let minimum_maximum_type_decl_int_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("minimum", (`Int 0));
-          ("maximum", (`Int 255));
-          ("type", (`String "integer"))] in
+        match match int_jsonschema with
+              | `Assoc ppx_fields ->
+                  `Assoc (("maximum", (`Int 255)) :: ppx_fields)
+              | ppx_other -> ppx_other
+        with
+        | `Assoc ppx_fields -> `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+        | ppx_other -> ppx_other in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -3966,10 +3895,14 @@ include
     let minimum_maximum_type_decl_float_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("minimum", (`Float 0.0));
-          ("maximum", (`Float 1.0));
-          ("type", (`String "number"))] in
+        match match float_jsonschema with
+              | `Assoc ppx_fields ->
+                  `Assoc (("maximum", (`Float 1.0)) :: ppx_fields)
+              | ppx_other -> ppx_other
+        with
+        | `Assoc ppx_fields ->
+            `Assoc (("minimum", (`Float 0.0)) :: ppx_fields)
+        | ppx_other -> ppx_other in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -3998,10 +3931,15 @@ include
                    ("prefixItems",
                      (`List
                         [`Assoc [("const", (`String "Percentage"))];
-                        `Assoc
-                          [("minimum", (`Int 0));
-                          ("maximum", (`Int 100));
-                          ("type", (`String "integer"))]]));
+                        (match match int_jsonschema with
+                               | `Assoc ppx_fields ->
+                                   `Assoc (("maximum", (`Int 100)) ::
+                                     ppx_fields)
+                               | ppx_other -> ppx_other
+                         with
+                         | `Assoc ppx_fields ->
+                             `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+                         | ppx_other -> ppx_other)]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 2));
                    ("maxItems", (`Int 2))];
@@ -4010,10 +3948,15 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "Factor"))];
-                       `Assoc
-                         [("minimum", (`Float 0.0));
-                         ("maximum", (`Float 1.0));
-                         ("type", (`String "number"))]]));
+                       (match match float_jsonschema with
+                              | `Assoc ppx_fields ->
+                                  `Assoc (("maximum", (`Float 1.0)) ::
+                                    ppx_fields)
+                              | ppx_other -> ppx_other
+                        with
+                        | `Assoc ppx_fields ->
+                            `Assoc (("minimum", (`Float 0.0)) :: ppx_fields)
+                        | ppx_other -> ppx_other)]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
@@ -4090,10 +4033,7 @@ include
         `Assoc
           [("type", (`String "object"));
           ("properties",
-            (`Assoc
-               [("score",
-                  (`Assoc
-                     [("type", (`List [`String "integer"; `String "null"]))]))]));
+            (`Assoc [("score", (option_jsonschema int_jsonschema))]));
           ("required", (`List [`String "score"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -4130,18 +4070,20 @@ include
           ("properties",
             (`Assoc
                [("empty_list",
-                  (`Assoc
-                     [("default", (`List []));
-                     ("type", (`String "array"));
-                     ("items", (`Assoc [("type", (`String "integer"))]))]));
+                  ((match list_jsonschema int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("default", (`List [])) :: ppx_fields)
+                    | ppx_other -> ppx_other)));
                ("int_list",
-                 (`Assoc
-                    [("default",
-                       (((fun xs ->
-                            `List (Stdlib.List.map (fun x -> `Int x) xs)))
-                          [1; 2; 3]));
-                    ("type", (`String "array"));
-                    ("items", (`Assoc [("type", (`String "integer"))]))]));
+                 ((match list_jsonschema int_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("default",
+                            (((fun xs ->
+                                 `List (Stdlib.List.map (fun x -> `Int x) xs)))
+                               [1; 2; 3]))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)));
                ("record",
                  ((match match record_for_default_jsonschema with
                          | `Assoc pairs when
@@ -4183,34 +4125,36 @@ include
                          :: ppx_fields)
                    | ppx_other -> ppx_other)));
                ("pairs",
-                 (`Assoc
-                    [("default",
-                       (((fun xs ->
-                            `List
-                              (Stdlib.List.map
-                                 (fun (ppx_tuple_0, ppx_tuple_1) ->
-                                    `List
-                                      [((fun x -> `String x)) ppx_tuple_0;
-                                      ((fun x ->
-                                          match x with
-                                          | None -> `Null
-                                          | Some v ->
-                                              ((fun x -> `String x)) v))
-                                        ppx_tuple_1]) xs)))
-                          [("a", None); ("b", (Some "b"))]));
-                    ("type", (`String "array"));
-                    ("items",
-                      (`Assoc
-                         [("type", (`String "array"));
-                         ("prefixItems",
-                           (`List
-                              [`Assoc [("type", (`String "string"))];
-                              `Assoc
-                                [("type",
-                                   (`List [`String "string"; `String "null"]))]]));
-                         ("unevaluatedItems", (`Bool false));
-                         ("minItems", (`Int 2));
-                         ("maxItems", (`Int 2))]))]));
+                 ((match list_jsonschema
+                           (`Assoc
+                              [("type", (`String "array"));
+                              ("prefixItems",
+                                (`List
+                                   [string_jsonschema;
+                                   option_jsonschema string_jsonschema]));
+                              ("unevaluatedItems", (`Bool false));
+                              ("minItems", (`Int 2));
+                              ("maxItems", (`Int 2))])
+                   with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("default",
+                            (((fun xs ->
+                                 `List
+                                   (Stdlib.List.map
+                                      (fun (ppx_tuple_0, ppx_tuple_1) ->
+                                         `List
+                                           [((fun x -> `String x))
+                                              ppx_tuple_0;
+                                           ((fun x ->
+                                               match x with
+                                               | None -> `Null
+                                               | Some v ->
+                                                   ((fun x -> `String x)) v))
+                                             ppx_tuple_1]) xs)))
+                               [("a", None); ("b", (Some "b"))]))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)));
                ("pair",
                  (`Assoc
                     [("default",
@@ -4221,28 +4165,35 @@ include
                           (1, "hello")));
                     ("type", (`String "array"));
                     ("prefixItems",
-                      (`List
-                         [`Assoc [("type", (`String "integer"))];
-                         `Assoc [("type", (`String "string"))]]));
+                      (`List [int_jsonschema; string_jsonschema]));
                     ("unevaluatedItems", (`Bool false));
                     ("minItems", (`Int 2));
                     ("maxItems", (`Int 2))]));
                ("is_active",
-                 (`Assoc
-                    [("default", (((fun x -> `Bool x)) false));
-                    ("type", (`String "boolean"))]));
+                 ((match bool_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (((fun x -> `Bool x)) false)) ::
+                         ppx_fields)
+                   | ppx_other -> ppx_other)));
                ("speed",
-                 (`Assoc
-                    [("default", (((fun x -> `Float x)) 100.0));
-                    ("type", (`String "number"))]));
+                 ((match float_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (((fun x -> `Float x)) 100.0)) ::
+                         ppx_fields)
+                   | ppx_other -> ppx_other)));
                ("label",
-                 (`Assoc
-                    [("default", (((fun x -> `String x)) "default"));
-                    ("type", (`String "string"))]));
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("default", (((fun x -> `String x)) "default")) ::
+                         ppx_fields)
+                   | ppx_other -> ppx_other)));
                ("score",
-                 (`Assoc
-                    [("default", (((fun x -> `Int x)) 0));
-                    ("type", (`List [`String "integer"; `String "null"]))]))]));
+                 ((match option_jsonschema int_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (((fun x -> `Int x)) 0)) ::
+                         ppx_fields)
+                   | ppx_other -> ppx_other)))]));
           ("required", (`List []));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -4373,10 +4324,7 @@ include
         `Assoc
           [("type", (`String "object"));
           ("properties",
-            (`Assoc
-               [("foo",
-                  (`Assoc
-                     [("type", (`List [`String "integer"; `String "null"]))]))]));
+            (`Assoc [("foo", (option_jsonschema int_jsonschema))]));
           ("required", (`List []));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -4457,8 +4405,7 @@ include
                   [("type", (`String "array"));
                   ("prefixItems",
                     (`List
-                       [`Assoc [("const", (`String "C"))];
-                       `Assoc [("type", (`String "integer"))]]));
+                       [`Assoc [("const", (`String "C"))]; int_jsonschema]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
@@ -4570,7 +4517,7 @@ module Generated_code_must_qualify_stdlib =
                        ("prefixItems",
                          (`List
                             [`Assoc [("const", (`String "Leaf"))];
-                            `Assoc [("type", (`String "integer"))]]));
+                            int_jsonschema]));
                        ("unevaluatedItems", (`Bool false));
                        ("minItems", (`Int 2));
                        ("maxItems", (`Int 2))];
@@ -4633,27 +4580,34 @@ module Generated_code_must_qualify_stdlib =
               ("properties",
                 (`Assoc
                    [("name",
-                      (`Assoc
-                         [("default", (((fun x -> `String x)) "x"));
-                         ("type", (`String "string"))]));
+                      ((match string_jsonschema with
+                        | `Assoc ppx_fields ->
+                            `Assoc (("default", (((fun x -> `String x)) "x"))
+                              :: ppx_fields)
+                        | ppx_other -> ppx_other)));
                    ("items_a",
-                     (`Assoc
-                        [("default",
-                           (((fun xs ->
-                                `List
-                                  (Stdlib.Array.to_list
-                                     (Stdlib.Array.map (fun x -> `Int x) xs))))
-                              [|1;2|]));
-                        ("type", (`String "array"));
-                        ("items", (`Assoc [("type", (`String "integer"))]))]));
+                     ((match array_jsonschema int_jsonschema with
+                       | `Assoc ppx_fields ->
+                           `Assoc
+                             (("default",
+                                (((fun xs ->
+                                     `List
+                                       (Stdlib.Array.to_list
+                                          (Stdlib.Array.map (fun x -> `Int x)
+                                             xs)))) [|1;2|]))
+                             :: ppx_fields)
+                       | ppx_other -> ppx_other)));
                    ("items",
-                     (`Assoc
-                        [("default",
-                           (((fun xs ->
-                                `List (Stdlib.List.map (fun x -> `Int x) xs)))
-                              [1; 2]));
-                        ("type", (`String "array"));
-                        ("items", (`Assoc [("type", (`String "integer"))]))]))]));
+                     ((match list_jsonschema int_jsonschema with
+                       | `Assoc ppx_fields ->
+                           `Assoc
+                             (("default",
+                                (((fun xs ->
+                                     `List
+                                       (Stdlib.List.map (fun x -> `Int x) xs)))
+                                   [1; 2]))
+                             :: ppx_fields)
+                       | ppx_other -> ppx_other)))]));
               ("required", (`List []));
               ("additionalProperties", (`Bool false))] in
           match !ppx_eds with
@@ -4674,9 +4628,7 @@ module Generated_code_must_qualify_stdlib =
         let non_rec_using_wrapper_with_shadowed_stdlib_jsonschema =
           let ppx_eds = ref [] in
           let ppx_result =
-            match wrapper_with_shadowed_stdlib_jsonschema
-                    (`Assoc [("type", (`String "integer"))])
-            with
+            match wrapper_with_shadowed_stdlib_jsonschema int_jsonschema with
             | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
                 `Assoc (("$id", (`String "file://shared/cases.ml:499")) ::
                   (Stdlib.List.filter

--- a/test/test.melange.expected.ml
+++ b/test/test.melange.expected.ml
@@ -1,4 +1,4 @@
-[@@@ocaml.warning "-37-69"]
+open Ppx_deriving_jsonschema_runtime.Primitives.Melange_json
 open Melange_json.Primitives
 let string_jsonschema = `Assoc [("type", (`String "string"))]
 let int_jsonschema = `Assoc [("type", (`String "integer"))]
@@ -276,8 +276,7 @@ include
                    [("type", (`String "array"));
                    ("prefixItems",
                      (`List
-                        [`Assoc [("const", (`String "Aaa"))];
-                        `Assoc [("type", (`String "integer"))]]));
+                        [`Assoc [("const", (`String "Aaa"))]; int_jsonschema]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 2));
                    ("maxItems", (`Int 2))];
@@ -293,8 +292,8 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "ccc"))];
-                       `Assoc [("type", (`String "string"))];
-                       `Assoc [("type", (`String "boolean"))]]));
+                       string_jsonschema;
+                       bool_jsonschema]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 3));
                   ("maxItems", (`Int 3))]]))] in
@@ -357,7 +356,7 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "Second_one"))];
-                       `Assoc [("type", (`String "integer"))]]));
+                       int_jsonschema]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))];
@@ -436,15 +435,11 @@ include
           [("type", (`String "object"));
           ("properties",
             (`Assoc
-               [("native_int", (`Assoc [("type", (`String "integer"))]));
-               ("unit", (`Assoc [("type", (`String "null"))]));
-               ("string_ref", (`Assoc [("type", (`String "string"))]));
-               ("bunch_of_bytes", (`Assoc [("type", (`String "string"))]));
-               ("c",
-                 (`Assoc
-                    [("type", (`String "string"));
-                    ("minLength", (`Int 1));
-                    ("maxLength", (`Int 1))]));
+               [("native_int", int_jsonschema);
+               ("unit", unit_jsonschema);
+               ("string_ref", string_jsonschema);
+               ("bunch_of_bytes", string_jsonschema);
+               ("c", char_jsonschema);
                ("t",
                  (`Assoc
                     [("anyOf",
@@ -470,18 +465,10 @@ include
                             ("unevaluatedItems", (`Bool false));
                             ("minItems", (`Int 1));
                             ("maxItems", (`Int 1))]]))]));
-               ("l",
-                 (`Assoc
-                    [("type", (`String "array"));
-                    ("items", (`Assoc [("type", (`String "string"))]))]));
-               ("a",
-                 (`Assoc
-                    [("type", (`String "array"));
-                    ("items", (`Assoc [("type", (`String "number"))]))]));
-               ("opt_int",
-                 (`Assoc
-                    [("type", (`List [`String "integer"; `String "null"]))]));
-               ("comment", (`Assoc [("type", (`String "string"))]));
+               ("l", (list_jsonschema string_jsonschema));
+               ("a", (array_jsonschema float_jsonschema));
+               ("opt_int", (option_jsonschema int_jsonschema));
+               ("comment", string_jsonschema);
                ("kind_f",
                  ((match kind_jsonschema with
                    | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
@@ -491,7 +478,7 @@ include
                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                             pairs))
                    | other -> other)));
-               ("date", (`Assoc [("type", (`String "number"))]))]));
+               ("date", float_jsonschema)]));
           ("required",
             (`List
                [`String "native_int";
@@ -531,12 +518,9 @@ include
           ("properties",
             (`Assoc
                [("b",
-                  (`Assoc
-                     [("type", (`String "array"));
-                     ("items",
-                       (`Assoc
-                          [("$ref", (`String "#/$defs/recursive_record"))]))]));
-               ("a", (`Assoc [("type", (`String "integer"))]))]));
+                  (list_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/recursive_record"))])));
+               ("a", int_jsonschema)]));
           ("required", (`List [`String "b"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
       `Assoc
@@ -614,8 +598,7 @@ include
                                  (`Assoc [("$ref", (`String "#/$defs/tree"))]));
                               ("left",
                                 (`Assoc [("$ref", (`String "#/$defs/tree"))]));
-                              ("value",
-                                (`Assoc [("type", (`String "integer"))]))]));
+                              ("value", int_jsonschema)]));
                          ("required",
                            (`List
                               [`String "right";
@@ -640,9 +623,7 @@ include
         `Assoc
           [("type", (`String "object"));
           ("properties",
-            (`Assoc
-               [("y", (`Assoc [("type", (`String "string"))]));
-               ("x", (`Assoc [("type", (`String "integer"))]))]));
+            (`Assoc [("y", string_jsonschema); ("x", int_jsonschema)]));
           ("required", (`List [`String "y"; `String "x"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -670,11 +651,8 @@ include
           ("properties",
             (`Assoc
                [("bar",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/bar"))];
-                           `Assoc [("type", (`String "null"))]]))]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/bar"))])))]));
           ("required", (`List [`String "bar"]));
           ("additionalProperties", (`Bool false))] in
       let ppx_body_bar =
@@ -683,11 +661,8 @@ include
           ("properties",
             (`Assoc
                [("foo",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/foo"))];
-                           `Assoc [("type", (`String "null"))]]))]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/foo"))])))]));
           ("required", (`List [`String "foo"]));
           ("additionalProperties", (`Bool false))] in
       `Assoc
@@ -703,11 +678,8 @@ include
           ("properties",
             (`Assoc
                [("bar",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/bar"))];
-                           `Assoc [("type", (`String "null"))]]))]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/bar"))])))]));
           ("required", (`List [`String "bar"]));
           ("additionalProperties", (`Bool false))] in
       let ppx_body_bar =
@@ -716,11 +688,8 @@ include
           ("properties",
             (`Assoc
                [("foo",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/foo"))];
-                           `Assoc [("type", (`String "null"))]]))]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/foo"))])))]));
           ("required", (`List [`String "foo"]));
           ("additionalProperties", (`Bool false))] in
       `Assoc
@@ -752,7 +721,7 @@ include
                    ("prefixItems",
                      (`List
                         [`Assoc [("const", (`String "Literal"))];
-                        `Assoc [("type", (`String "integer"))]]));
+                        int_jsonschema]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 2));
                    ("maxItems", (`Int 2))];
@@ -771,10 +740,8 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "Block"))];
-                       `Assoc
-                         [("type", (`String "array"));
-                         ("items",
-                           (`Assoc [("$ref", (`String "#/$defs/stmt"))]))]]));
+                       list_jsonschema
+                         (`Assoc [("$ref", (`String "#/$defs/stmt"))])]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
@@ -801,13 +768,9 @@ include
                          ("properties",
                            (`Assoc
                               [("else_",
-                                 (`Assoc
-                                    [("anyOf",
-                                       (`List
-                                          [`Assoc
-                                             [("$ref",
-                                                (`String "#/$defs/stmt"))];
-                                          `Assoc [("type", (`String "null"))]]))]));
+                                 (option_jsonschema
+                                    (`Assoc
+                                       [("$ref", (`String "#/$defs/stmt"))])));
                               ("then_",
                                 (`Assoc [("$ref", (`String "#/$defs/stmt"))]));
                               ("cond",
@@ -838,7 +801,7 @@ include
                    ("prefixItems",
                      (`List
                         [`Assoc [("const", (`String "Literal"))];
-                        `Assoc [("type", (`String "integer"))]]));
+                        int_jsonschema]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 2));
                    ("maxItems", (`Int 2))];
@@ -857,10 +820,8 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "Block"))];
-                       `Assoc
-                         [("type", (`String "array"));
-                         ("items",
-                           (`Assoc [("$ref", (`String "#/$defs/stmt"))]))]]));
+                       list_jsonschema
+                         (`Assoc [("$ref", (`String "#/$defs/stmt"))])]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
@@ -887,13 +848,9 @@ include
                          ("properties",
                            (`Assoc
                               [("else_",
-                                 (`Assoc
-                                    [("anyOf",
-                                       (`List
-                                          [`Assoc
-                                             [("$ref",
-                                                (`String "#/$defs/stmt"))];
-                                          `Assoc [("type", (`String "null"))]]))]));
+                                 (option_jsonschema
+                                    (`Assoc
+                                       [("$ref", (`String "#/$defs/stmt"))])));
                               ("then_",
                                 (`Assoc [("$ref", (`String "#/$defs/stmt"))]));
                               ("cond",
@@ -925,8 +882,7 @@ include
       let ppx_result =
         `Assoc
           [("type", (`String "object"));
-          ("properties",
-            (`Assoc [("x", (`Assoc [("type", (`String "integer"))]))]));
+          ("properties", (`Assoc [("x", int_jsonschema)]));
           ("required", (`List [`String "x"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -944,8 +900,7 @@ include
       let ppx_result =
         `Assoc
           [("type", (`String "object"));
-          ("properties",
-            (`Assoc [("y", (`Assoc [("type", (`String "string"))]))]));
+          ("properties", (`Assoc [("y", string_jsonschema)]));
           ("required", (`List [`String "y"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -978,17 +933,11 @@ include
           ("properties",
             (`Assoc
                [("c",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/node_c"))];
-                           `Assoc [("type", (`String "null"))]]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
                ("b",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc [("$ref", (`String "#/$defs/node_b"))];
-                          `Assoc [("type", (`String "null"))]]))]))]));
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_b"))])))]));
           ("required", (`List [`String "c"; `String "b"]));
           ("additionalProperties", (`Bool false))] in
       let ppx_body_node_b =
@@ -997,17 +946,11 @@ include
           ("properties",
             (`Assoc
                [("c",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/node_c"))];
-                           `Assoc [("type", (`String "null"))]]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
                ("a",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc [("$ref", (`String "#/$defs/node_a"))];
-                          `Assoc [("type", (`String "null"))]]))]))]));
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
           ("required", (`List [`String "c"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
       let ppx_body_node_c =
@@ -1016,17 +959,11 @@ include
           ("properties",
             (`Assoc
                [("b",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/node_b"))];
-                           `Assoc [("type", (`String "null"))]]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_b"))])));
                ("a",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc [("$ref", (`String "#/$defs/node_a"))];
-                          `Assoc [("type", (`String "null"))]]))]))]));
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
           ("required", (`List [`String "b"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
       `Assoc
@@ -1044,17 +981,11 @@ include
           ("properties",
             (`Assoc
                [("c",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/node_c"))];
-                           `Assoc [("type", (`String "null"))]]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
                ("b",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc [("$ref", (`String "#/$defs/node_b"))];
-                          `Assoc [("type", (`String "null"))]]))]))]));
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_b"))])))]));
           ("required", (`List [`String "c"; `String "b"]));
           ("additionalProperties", (`Bool false))] in
       let ppx_body_node_b =
@@ -1063,17 +994,11 @@ include
           ("properties",
             (`Assoc
                [("c",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/node_c"))];
-                           `Assoc [("type", (`String "null"))]]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
                ("a",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc [("$ref", (`String "#/$defs/node_a"))];
-                          `Assoc [("type", (`String "null"))]]))]))]));
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
           ("required", (`List [`String "c"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
       let ppx_body_node_c =
@@ -1082,17 +1007,11 @@ include
           ("properties",
             (`Assoc
                [("b",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/node_b"))];
-                           `Assoc [("type", (`String "null"))]]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_b"))])));
                ("a",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc [("$ref", (`String "#/$defs/node_a"))];
-                          `Assoc [("type", (`String "null"))]]))]))]));
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
           ("required", (`List [`String "b"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
       `Assoc
@@ -1110,17 +1029,11 @@ include
           ("properties",
             (`Assoc
                [("c",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/node_c"))];
-                           `Assoc [("type", (`String "null"))]]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
                ("b",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc [("$ref", (`String "#/$defs/node_b"))];
-                          `Assoc [("type", (`String "null"))]]))]))]));
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_b"))])))]));
           ("required", (`List [`String "c"; `String "b"]));
           ("additionalProperties", (`Bool false))] in
       let ppx_body_node_b =
@@ -1129,17 +1042,11 @@ include
           ("properties",
             (`Assoc
                [("c",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/node_c"))];
-                           `Assoc [("type", (`String "null"))]]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
                ("a",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc [("$ref", (`String "#/$defs/node_a"))];
-                          `Assoc [("type", (`String "null"))]]))]))]));
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
           ("required", (`List [`String "c"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
       let ppx_body_node_c =
@@ -1148,17 +1055,11 @@ include
           ("properties",
             (`Assoc
                [("b",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc [("$ref", (`String "#/$defs/node_b"))];
-                           `Assoc [("type", (`String "null"))]]))]));
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_b"))])));
                ("a",
-                 (`Assoc
-                    [("anyOf",
-                       (`List
-                          [`Assoc [("$ref", (`String "#/$defs/node_a"))];
-                          `Assoc [("type", (`String "null"))]]))]))]));
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
           ("required", (`List [`String "b"; `String "a"]));
           ("additionalProperties", (`Bool false))] in
       `Assoc
@@ -1185,7 +1086,7 @@ include
                    ("prefixItems",
                      (`List
                         [`Assoc [("const", (`String "Leaf"))];
-                        `Assoc [("type", (`String "integer"))]]));
+                        int_jsonschema]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 2));
                    ("maxItems", (`Int 2))];
@@ -1245,16 +1146,13 @@ include
     let events_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("type", (`String "array"));
-          ("items",
-            ((match event_jsonschema with
-              | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                  `Assoc (("$id", (`String "file://shared/cases.ml:141")) ::
-                    (Stdlib.List.filter
-                       (fun (k, _) -> not (Stdlib.String.equal k "$id"))
-                       pairs))
-              | other -> other)))] in
+        list_jsonschema
+          (match event_jsonschema with
+           | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+               `Assoc (("$id", (`String "file://shared/cases.ml:141")) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
+           | other -> other) in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -1272,20 +1170,15 @@ include
     let eventss_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("type", (`String "array"));
-          ("items",
-            (`Assoc
-               [("type", (`String "array"));
-               ("items",
-                 ((match event_jsonschema with
-                   | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                       `Assoc
-                         (("$id", (`String "file://shared/cases.ml:142")) ::
-                         (Stdlib.List.filter
-                            (fun (k, _) -> not (Stdlib.String.equal k "$id"))
-                            pairs))
-                   | other -> other)))]))] in
+        list_jsonschema
+          (list_jsonschema
+             (match event_jsonschema with
+              | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                  `Assoc (("$id", (`String "file://shared/cases.ml:142")) ::
+                    (Stdlib.List.filter
+                       (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                       pairs))
+              | other -> other)) in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -1315,7 +1208,7 @@ include
                           (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                           pairs))
                  | other -> other);
-               `Assoc [("type", (`String "string"))]]));
+               string_jsonschema]));
           ("unevaluatedItems", (`Bool false));
           ("minItems", (`Int 2));
           ("maxItems", (`Int 2))] in
@@ -1336,16 +1229,13 @@ include
     let event_comments'_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("type", (`String "array"));
-          ("items",
-            ((match event_comment_jsonschema with
-              | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                  `Assoc (("$id", (`String "file://shared/cases.ml:144")) ::
-                    (Stdlib.List.filter
-                       (fun (k, _) -> not (Stdlib.String.equal k "$id"))
-                       pairs))
-              | other -> other)))] in
+        list_jsonschema
+          (match event_comment_jsonschema with
+           | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+               `Assoc (("$id", (`String "file://shared/cases.ml:144")) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
+           | other -> other) in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -1363,27 +1253,24 @@ include
     let event_n_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("type", (`String "array"));
-          ("items",
-            (`Assoc
-               [("type", (`String "array"));
-               ("prefixItems",
-                 (`List
-                    [(match event_jsonschema with
-                      | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
-                          ->
-                          `Assoc
-                            (("$id", (`String "file://shared/cases.ml:145"))
-                            ::
-                            (Stdlib.List.filter
-                               (fun (k, _) ->
-                                  not (Stdlib.String.equal k "$id")) pairs))
-                      | other -> other);
-                    `Assoc [("type", (`String "integer"))]]));
-               ("unevaluatedItems", (`Bool false));
-               ("minItems", (`Int 2));
-               ("maxItems", (`Int 2))]))] in
+        list_jsonschema
+          (`Assoc
+             [("type", (`String "array"));
+             ("prefixItems",
+               (`List
+                  [(match event_jsonschema with
+                    | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
+                        ->
+                        `Assoc
+                          (("$id", (`String "file://shared/cases.ml:145")) ::
+                          (Stdlib.List.filter
+                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                             pairs))
+                    | other -> other);
+                  int_jsonschema]));
+             ("unevaluatedItems", (`Bool false));
+             ("minItems", (`Int 2));
+             ("maxItems", (`Int 2))]) in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -1401,16 +1288,13 @@ include
     let events_array_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("type", (`String "array"));
-          ("items",
-            ((match events_jsonschema with
-              | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                  `Assoc (("$id", (`String "file://shared/cases.ml:146")) ::
-                    (Stdlib.List.filter
-                       (fun (k, _) -> not (Stdlib.String.equal k "$id"))
-                       pairs))
-              | other -> other)))] in
+        array_jsonschema
+          (match events_jsonschema with
+           | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+               `Assoc (("$id", (`String "file://shared/cases.ml:146")) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
+           | other -> other) in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -1427,10 +1311,7 @@ include
   struct
     let numbers_jsonschema =
       let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc
-          [("type", (`String "array"));
-          ("items", (`Assoc [("type", (`String "integer"))]))] in
+      let ppx_result = list_jsonschema int_jsonschema in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -1447,8 +1328,7 @@ include
   struct
     let opt_jsonschema =
       let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc [("type", (`List [`String "integer"; `String "null"]))] in
+      let ppx_result = option_jsonschema int_jsonschema in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -1524,7 +1404,7 @@ include
           [("type", (`String "array"));
           ("prefixItems",
             (`List
-               [`Assoc [("type", (`String "integer"))];
+               [int_jsonschema;
                `Assoc
                  [("anyOf",
                     (`List
@@ -1572,7 +1452,7 @@ include
             (`Assoc
                [("scores_ref",
                   (`Assoc [("$ref", (`String "#/$defs/numbers"))]));
-               ("player", (`Assoc [("type", (`String "string"))]))]));
+               ("player", string_jsonschema)]));
           ("required", (`List [`String "scores_ref"; `String "player"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -1599,9 +1479,9 @@ include
           [("type", (`String "object"));
           ("properties",
             (`Assoc
-               [("zip", (`Assoc [("type", (`String "string"))]));
-               ("city", (`Assoc [("type", (`String "string"))]));
-               ("street", (`Assoc [("type", (`String "string"))]))]));
+               [("zip", string_jsonschema);
+               ("city", string_jsonschema);
+               ("street", string_jsonschema)]));
           ("required",
             (`List [`String "zip"; `String "city"; `String "street"]));
           ("additionalProperties", (`Bool false))] in
@@ -1640,11 +1520,9 @@ include
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
                     | other -> other)));
-               ("email",
-                 (`Assoc
-                    [("type", (`List [`String "string"; `String "null"]))]));
-               ("age", (`Assoc [("type", (`String "integer"))]));
-               ("name", (`Assoc [("type", (`String "string"))]))]));
+               ("email", (option_jsonschema string_jsonschema));
+               ("age", int_jsonschema);
+               ("name", string_jsonschema)]));
           ("required",
             (`List
                [`String "address";
@@ -1686,11 +1564,9 @@ include
                  (`Assoc [("$ref", (`String "#/$defs/shared_address"))]));
                ("home_address",
                  (`Assoc [("$ref", (`String "#/$defs/shared_address"))]));
-               ("email",
-                 (`Assoc
-                    [("type", (`List [`String "string"; `String "null"]))]));
-               ("age", (`Assoc [("type", (`String "integer"))]));
-               ("name", (`Assoc [("type", (`String "string"))]))]));
+               ("email", (option_jsonschema string_jsonschema));
+               ("age", int_jsonschema);
+               ("name", string_jsonschema)]));
           ("required",
             (`List
                [`String "retreat_address";
@@ -1716,11 +1592,7 @@ include
   struct
     let c_jsonschema =
       let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc
-          [("type", (`String "string"));
-          ("minLength", (`Int 1));
-          ("maxLength", (`Int 1))] in
+      let ppx_result = char_jsonschema in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -1781,10 +1653,8 @@ include
                           [("type", (`String "object"));
                           ("properties",
                             (`Assoc
-                               [("email",
-                                  (`Assoc [("type", (`String "string"))]));
-                               ("name",
-                                 (`Assoc [("type", (`String "string"))]))]));
+                               [("email", string_jsonschema);
+                               ("name", string_jsonschema)]));
                           ("required",
                             (`List [`String "email"; `String "name"]));
                           ("additionalProperties", (`Bool true))]]));
@@ -1798,10 +1668,7 @@ include
                        [`Assoc [("const", (`String "Guest"))];
                        `Assoc
                          [("type", (`String "object"));
-                         ("properties",
-                           (`Assoc
-                              [("ip",
-                                 (`Assoc [("type", (`String "string"))]))]));
+                         ("properties", (`Assoc [("ip", string_jsonschema)]));
                          ("required", (`List [`String "ip"]));
                          ("additionalProperties", (`Bool false))]]));
                   ("unevaluatedItems", (`Bool false));
@@ -1869,7 +1736,7 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "Class"))];
-                       `Assoc [("type", (`String "string"))]]));
+                       string_jsonschema]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
@@ -1931,7 +1798,7 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "class"))];
-                       `Assoc [("type", (`String "string"))]]));
+                       string_jsonschema]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
@@ -1954,10 +1821,7 @@ include
       let ppx_result =
         `Assoc
           [("type", (`String "array"));
-          ("prefixItems",
-            (`List
-               [`Assoc [("type", (`String "integer"))];
-               `Assoc [("type", (`String "string"))]]));
+          ("prefixItems", (`List [int_jsonschema; string_jsonschema]));
           ("unevaluatedItems", (`Bool false));
           ("minItems", (`Int 2));
           ("maxItems", (`Int 2))] in
@@ -1986,9 +1850,9 @@ include
                    ("prefixItems",
                      (`List
                         [`Assoc [("const", (`String "A"))];
-                        `Assoc [("type", (`String "integer"))];
-                        `Assoc [("type", (`String "string"))];
-                        `Assoc [("type", (`String "boolean"))]]));
+                        int_jsonschema;
+                        string_jsonschema;
+                        bool_jsonschema]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 4));
                    ("maxItems", (`Int 4))]]))] in
@@ -2021,13 +1885,13 @@ include
                           [("type", (`String "array"));
                           ("prefixItems",
                             (`List
-                               [`Assoc [("type", (`String "integer"))];
-                               `Assoc [("type", (`String "string"))];
-                               `Assoc [("type", (`String "boolean"))]]));
+                               [int_jsonschema;
+                               string_jsonschema;
+                               bool_jsonschema]));
                           ("unevaluatedItems", (`Bool false));
                           ("minItems", (`Int 3));
                           ("maxItems", (`Int 3))];
-                        `Assoc [("type", (`String "number"))]]));
+                        float_jsonschema]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 3));
                    ("maxItems", (`Int 3))]]))] in
@@ -2057,9 +1921,9 @@ include
                    ("prefixItems",
                      (`List
                         [`Assoc [("const", (`String "A"))];
-                        `Assoc [("type", (`String "integer"))];
-                        `Assoc [("type", (`String "string"))];
-                        `Assoc [("type", (`String "boolean"))]]));
+                        int_jsonschema;
+                        string_jsonschema;
+                        bool_jsonschema]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 4));
                    ("maxItems", (`Int 4))]]))] in
@@ -2093,9 +1957,9 @@ include
                           [("type", (`String "array"));
                           ("prefixItems",
                             (`List
-                               [`Assoc [("type", (`String "integer"))];
-                               `Assoc [("type", (`String "string"))];
-                               `Assoc [("type", (`String "boolean"))]]));
+                               [int_jsonschema;
+                               string_jsonschema;
+                               bool_jsonschema]));
                           ("unevaluatedItems", (`Bool false));
                           ("minItems", (`Int 3));
                           ("maxItems", (`Int 3))]]));
@@ -2132,13 +1996,13 @@ include
                           [("type", (`String "array"));
                           ("prefixItems",
                             (`List
-                               [`Assoc [("type", (`String "integer"))];
-                               `Assoc [("type", (`String "string"))];
-                               `Assoc [("type", (`String "boolean"))]]));
+                               [int_jsonschema;
+                               string_jsonschema;
+                               bool_jsonschema]));
                           ("unevaluatedItems", (`Bool false));
                           ("minItems", (`Int 3));
                           ("maxItems", (`Int 3))];
-                        `Assoc [("type", (`String "number"))]]));
+                        float_jsonschema]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 3));
                    ("maxItems", (`Int 3))]]))] in
@@ -2167,9 +2031,9 @@ include
                    ("prefixItems",
                      (`List
                         [`Assoc [("const", (`String "A"))];
-                        `Assoc [("type", (`String "integer"))];
-                        `Assoc [("type", (`String "string"))];
-                        `Assoc [("type", (`String "boolean"))]]));
+                        int_jsonschema;
+                        string_jsonschema;
+                        bool_jsonschema]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 4));
                    ("maxItems", (`Int 4))]]))] in
@@ -2204,9 +2068,9 @@ include
                           [("type", (`String "array"));
                           ("prefixItems",
                             (`List
-                               [`Assoc [("type", (`String "integer"))];
-                               `Assoc [("type", (`String "string"))];
-                               `Assoc [("type", (`String "boolean"))]]));
+                               [int_jsonschema;
+                               string_jsonschema;
+                               bool_jsonschema]));
                           ("unevaluatedItems", (`Bool false));
                           ("minItems", (`Int 3));
                           ("maxItems", (`Int 3))]]));
@@ -2233,8 +2097,7 @@ include
       let ppx_result =
         `Assoc
           [("type", (`String "object"));
-          ("properties",
-            (`Assoc [("x", (`Assoc [("type", (`String "integer"))]))]));
+          ("properties", (`Assoc [("x", int_jsonschema)]));
           ("required", (`List [`String "x"]));
           ("additionalProperties", (`Bool true))] in
       match !ppx_eds with
@@ -2325,8 +2188,7 @@ include
       let ppx_result =
         `Assoc
           [("type", (`String "object"));
-          ("properties",
-            (`Assoc [("x", (`Assoc [("type", (`String "integer"))]))]));
+          ("properties", (`Assoc [("x", int_jsonschema)]));
           ("required", (`List [`String "x"]));
           ("additionalProperties", (`Bool true))] in
       match !ppx_eds with
@@ -2351,9 +2213,7 @@ include
         `Assoc
           [("type", (`String "object"));
           ("properties",
-            (`Assoc
-               [("y", (`Assoc [("type", (`String "integer"))]));
-               ("x", (`Assoc [("type", (`String "integer"))]))]));
+            (`Assoc [("y", int_jsonschema); ("x", int_jsonschema)]));
           ("required", (`List [`String "y"; `String "x"]));
           ("additionalProperties", (`Bool true))] in
       match !ppx_eds with
@@ -2380,9 +2240,7 @@ include
           ("properties",
             (`Assoc
                [("url", url);
-               ("title",
-                 (`Assoc
-                    [("type", (`List [`String "string"; `String "null"]))]))]));
+               ("title", (option_jsonschema string_jsonschema))]));
           ("required", (`List [`String "url"; `String "title"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -2402,9 +2260,7 @@ include
     let string_link_traffic_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        match generic_link_traffic_jsonschema
-                (`Assoc [("type", (`String "string"))])
-        with
+        match generic_link_traffic_jsonschema string_jsonschema with
         | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
             `Assoc (("$id", (`String "file://shared/cases.ml:231")) ::
               (Stdlib.List.filter
@@ -2470,9 +2326,7 @@ include
           [("type", (`String "object"));
           ("properties",
             (`Assoc
-               [("label", (`Assoc [("type", (`String "string"))]));
-               ("second", b);
-               ("first", a)]));
+               [("label", string_jsonschema); ("second", b); ("first", a)]));
           ("required",
             (`List [`String "label"; `String "second"; `String "first"]));
           ("additionalProperties", (`Bool false))] in
@@ -2492,7 +2346,7 @@ include
   struct
     let param_list_jsonschema a =
       let ppx_eds = ref [] in
-      let ppx_result = `Assoc [("type", (`String "array")); ("items", a)] in
+      let ppx_result = list_jsonschema a in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -2603,14 +2457,21 @@ include
           ("properties",
             (`Assoc
                [("max_results",
-                  (`Assoc
-                     [("description",
-                        (`String "Maximum number of results to return"));
-                     ("type", (`String "integer"))]));
+                  ((match int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc
+                          (("description",
+                             (`String "Maximum number of results to return"))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)));
                ("query",
-                 (`Assoc
-                    [("description", (`String "The search query to execute"));
-                    ("type", (`String "string"))]))]));
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("description",
+                            (`String "The search query to execute"))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)))]));
           ("required", (`List [`String "max_results"; `String "query"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -2642,13 +2503,18 @@ include
           ("properties",
             (`Assoc
                [("age",
-                  (`Assoc
-                     [("description", (`String "The user's age"));
-                     ("type", (`List [`String "integer"; `String "null"]))]));
+                  ((match option_jsonschema int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("description", (`String "The user's age"))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)));
                ("name",
-                 (`Assoc
-                    [("description", (`String "The user's full name"));
-                    ("type", (`String "string"))]))]));
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("description", (`String "The user's full name"))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)))]));
           ("required", (`List [`String "name"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -2678,9 +2544,12 @@ include
           ("properties",
             (`Assoc
                [("opt_int",
-                  (`Assoc
-                     [("description", (`String "An optional integer"));
-                     ("type", (`List [`String "integer"; `String "null"]))]))]));
+                  ((match option_jsonschema int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc
+                          (("description", (`String "An optional integer"))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)))]));
           ("required", (`List []));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -2722,7 +2591,7 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "With_int"))];
-                       `Assoc [("type", (`String "integer"))]]));
+                       int_jsonschema]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))];
@@ -2732,8 +2601,8 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "Pair"))];
-                       `Assoc [("type", (`String "string"))];
-                       `Assoc [("type", (`String "integer"))]]));
+                       string_jsonschema;
+                       int_jsonschema]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 3));
                   ("maxItems", (`Int 3))];
@@ -2742,9 +2611,12 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "Description_value"))];
-                       `Assoc
-                         [("description", (`String "A string value"));
-                         ("type", (`String "string"))]]));
+                       (match string_jsonschema with
+                        | `Assoc ppx_fields ->
+                            `Assoc
+                              (("description", (`String "A string value")) ::
+                              ppx_fields)
+                        | ppx_other -> ppx_other)]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
@@ -2781,10 +2653,7 @@ include
                           [("type", (`String "object"));
                           ("properties",
                             (`Assoc
-                               [("y",
-                                  (`Assoc [("type", (`String "integer"))]));
-                               ("x",
-                                 (`Assoc [("type", (`String "integer"))]))]));
+                               [("y", int_jsonschema); ("x", int_jsonschema)]));
                           ("required", (`List [`String "y"; `String "x"]));
                           ("additionalProperties", (`Bool false))]]));
                    ("unevaluatedItems", (`Bool false));
@@ -2847,13 +2716,18 @@ include
           ("properties",
             (`Assoc
                [("age",
-                  (`Assoc
-                     [("description", (`String "The user's age"));
-                     ("type", (`String "integer"))]));
+                  ((match int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("description", (`String "The user's age"))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)));
                ("name",
-                 (`Assoc
-                    [("description", (`String "The user's full name"));
-                    ("type", (`String "string"))]))]));
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("description", (`String "The user's full name"))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)))]));
           ("required", (`List [`String "age"; `String "name"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -2879,8 +2753,7 @@ include
       let ppx_result =
         `Assoc
           [("type", (`String "object"));
-          ("properties",
-            (`Assoc [("name", (`Assoc [("type", (`String "string"))]))]));
+          ("properties", (`Assoc [("name", string_jsonschema)]));
           ("required", (`List [`String "name"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -2909,9 +2782,11 @@ include
           ("properties",
             (`Assoc
                [("field",
-                  (`Assoc
-                     [("description", (`String "explicit wins"));
-                     ("type", (`String "string"))]))]));
+                  ((match string_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("description", (`String "explicit wins")) ::
+                          ppx_fields)
+                    | ppx_other -> ppx_other)))]));
           ("required", (`List [`String "field"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -2952,7 +2827,7 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "With_int"))];
-                       `Assoc [("type", (`String "integer"))]]));
+                       int_jsonschema]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
@@ -2974,9 +2849,11 @@ include
     let doc_comment_core_type_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("description", (`String "A string alias"));
-          ("type", (`String "string"))] in
+        match string_jsonschema with
+        | `Assoc ppx_fields ->
+            `Assoc (("description", (`String "A string alias")) ::
+              ppx_fields)
+        | ppx_other -> ppx_other in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -2996,9 +2873,11 @@ include
     let doc_attribute_alias_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("description", (`String "Alias fallback"));
-          ("type", (`String "string"))] in
+        match string_jsonschema with
+        | `Assoc ppx_fields ->
+            `Assoc (("description", (`String "Alias fallback")) ::
+              ppx_fields)
+        | ppx_other -> ppx_other in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -3027,11 +2906,14 @@ include
           ("properties",
             (`Assoc
                [("name",
-                  (`Assoc
-                     [("description",
-                        (`String
-                           "The user's full name.\n          Must be non-empty and under 100 characters."));
-                     ("type", (`String "string"))]))]));
+                  ((match string_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc
+                          (("description",
+                             (`String
+                                "The user's full name.\n          Must be non-empty and under 100 characters."))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)))]));
           ("required", (`List [`String "name"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -3073,7 +2955,7 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "With_int"))];
-                       `Assoc [("type", (`String "integer"))]]));
+                       int_jsonschema]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
@@ -3097,10 +2979,13 @@ include
     let doc_comment_multiple_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("description",
-             (`String "first block\n\nsecond block\n\nthird block"));
-          ("type", (`String "string"))] in
+        match string_jsonschema with
+        | `Assoc ppx_fields ->
+            `Assoc
+              (("description",
+                 (`String "first block\n\nsecond block\n\nthird block"))
+              :: ppx_fields)
+        | ppx_other -> ppx_other in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -3171,7 +3056,7 @@ include
                  ("prefixItems",
                    (`List
                       [`Assoc [("const", (`String "Err"))];
-                      `Assoc [("type", (`String "string"))]]));
+                      string_jsonschema]));
                  ("unevaluatedItems", (`Bool false));
                  ("minItems", (`Int 2));
                  ("maxItems", (`Int 2))]]))] in
@@ -3201,20 +3086,9 @@ include
           ("properties",
             (`Assoc
                [("drop_complex",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [`Assoc
-                              [("type", (`String "array"));
-                              ("items",
-                                (`Assoc [("type", (`String "integer"))]))];
-                           `Assoc [("type", (`String "null"))]]))]));
-               ("drop_simple",
-                 (`Assoc
-                    [("type", (`List [`String "string"; `String "null"]))]));
-               ("plain",
-                 (`Assoc
-                    [("type", (`List [`String "string"; `String "null"]))]))]));
+                  (option_jsonschema (list_jsonschema int_jsonschema)));
+               ("drop_simple", (option_jsonschema string_jsonschema));
+               ("plain", (option_jsonschema string_jsonschema))]));
           ("required", (`List [`String "plain"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -3249,29 +3123,35 @@ include
           ("properties",
             (`Assoc
                [("custom_drop_default",
-                  (`Assoc
-                     [("default", (((fun x -> `Float x)) 0.0));
-                     ("type", (`String "number"))]));
+                  ((match float_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("default", (((fun x -> `Float x)) 0.0)) ::
+                          ppx_fields)
+                    | ppx_other -> ppx_other)));
                ("dropped_default",
-                 (`Assoc
-                    [("default", (`List []));
-                    ("type", (`String "array"));
-                    ("items", (`Assoc [("type", (`String "integer"))]))]));
-               ("dropped_option",
-                 (`Assoc
-                    [("type", (`List [`String "integer"; `String "null"]))]));
+                 ((match list_jsonschema int_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (`List [])) :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("dropped_option", (option_jsonschema int_jsonschema));
                ("default_value",
-                 (`Assoc
-                    [("default", (((fun x -> `String x)) "-"));
-                    ("type", (`String "string"))]));
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (((fun x -> `String x)) "-")) ::
+                         ppx_fields)
+                   | ppx_other -> ppx_other)));
                ("default_none",
-                 (`Assoc [("default", `Null); ("type", (`String "string"))]));
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", `Null) :: ppx_fields)
+                   | ppx_other -> ppx_other)));
                ("option_default_none",
-                 (`Assoc [("default", `Null); ("type", (`String "string"))]));
-               ("option_value",
-                 (`Assoc
-                    [("type", (`List [`String "string"; `String "null"]))]));
-               ("required_value", (`Assoc [("type", (`String "integer"))]))]));
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", `Null) :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("option_value", (option_jsonschema string_jsonschema));
+               ("required_value", int_jsonschema)]));
           ("required", (`List [`String "required_value"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -3303,22 +3183,17 @@ include
           ("properties",
             (`Assoc
                [("composing_type",
-                  (`Assoc
-                     [("anyOf",
-                        (`List
-                           [(match composing_type_jsonschema with
-                             | `Assoc pairs when
-                                 Stdlib.List.mem_assoc "$defs" pairs ->
-                                 `Assoc
-                                   (("$id",
-                                      (`String "file://shared/cases.ml:361"))
-                                   ::
-                                   (Stdlib.List.filter
-                                      (fun (k, _) ->
-                                         not (Stdlib.String.equal k "$id"))
-                                      pairs))
-                             | other -> other);
-                           `Assoc [("type", (`String "null"))]]))]))]));
+                  (option_jsonschema
+                     (match composing_type_jsonschema with
+                      | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
+                          ->
+                          `Assoc
+                            (("$id", (`String "file://shared/cases.ml:361"))
+                            ::
+                            (Stdlib.List.filter
+                               (fun (k, _) ->
+                                  not (Stdlib.String.equal k "$id")) pairs))
+                      | other -> other)))]));
           ("required", (`List []));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -3339,8 +3214,10 @@ include
     let with_format_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("format", (`String "date-time")); ("type", (`String "string"))] in
+        match string_jsonschema with
+        | `Assoc ppx_fields ->
+            `Assoc (("format", (`String "date-time")) :: ppx_fields)
+        | ppx_other -> ppx_other in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -3366,9 +3243,11 @@ include
           ("properties",
             (`Assoc
                [("with_format",
-                  (`Assoc
-                     [("format", (`String "date-time"));
-                     ("type", (`String "string"))]))]));
+                  ((match string_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("format", (`String "date-time")) ::
+                          ppx_fields)
+                    | ppx_other -> ppx_other)))]));
           ("required", (`List [`String "with_format"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -3401,10 +3280,18 @@ include
                    ("prefixItems",
                      (`List
                         [`Assoc [("const", (`String "A"))];
-                        `Assoc
-                          [("format", (`String "date-time"));
-                          ("description", (`String "A date-time string"));
-                          ("type", (`String "string"))]]));
+                        (match match string_jsonschema with
+                               | `Assoc ppx_fields ->
+                                   `Assoc
+                                     (("description",
+                                        (`String "A date-time string"))
+                                     :: ppx_fields)
+                               | ppx_other -> ppx_other
+                         with
+                         | `Assoc ppx_fields ->
+                             `Assoc (("format", (`String "date-time")) ::
+                               ppx_fields)
+                         | ppx_other -> ppx_other)]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 2));
                    ("maxItems", (`Int 2))];
@@ -3489,10 +3376,8 @@ include
           ("properties",
             (`Assoc
                [("children",
-                  (`Assoc
-                     [("type", (`String "array"));
-                     ("items",
-                       (`Assoc [("$ref", (`String "#/$defs/self_ref"))]))]))]));
+                  (list_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/self_ref"))])))]));
           ("required", (`List [`String "children"]));
           ("additionalProperties", (`Bool false))] in
       `Assoc
@@ -3567,10 +3452,8 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "Group"))];
-                       `Assoc
-                         [("type", (`String "array"));
-                         ("items",
-                           (`Assoc [("$ref", (`String "#/$defs/filter"))]))];
+                       list_jsonschema
+                         (`Assoc [("$ref", (`String "#/$defs/filter"))]);
                        group_atom]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 3));
@@ -3615,11 +3498,8 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "BoolFilterGroup"))];
-                       `Assoc
-                         [("type", (`String "array"));
-                         ("items",
-                           (`Assoc
-                              [("$ref", (`String "#/$defs/bool_filter"))]))]]));
+                       list_jsonschema
+                         (`Assoc [("$ref", (`String "#/$defs/bool_filter"))])]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
@@ -3676,7 +3556,7 @@ include
                    ("prefixItems",
                      (`List
                         [`Assoc [("const", (`String "ORLeaf"))];
-                        `Assoc [("type", (`String "integer"))]]));
+                        int_jsonschema]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 2));
                    ("maxItems", (`Int 2))];
@@ -3721,7 +3601,9 @@ include
     let with_maximum_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc [("maximum", (`Int 100)); ("type", (`String "integer"))] in
+        match int_jsonschema with
+        | `Assoc ppx_fields -> `Assoc (("maximum", (`Int 100)) :: ppx_fields)
+        | ppx_other -> ppx_other in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -3745,8 +3627,10 @@ include
           ("properties",
             (`Assoc
                [("field",
-                  (`Assoc
-                     [("maximum", (`Int 100)); ("type", (`String "integer"))]))]));
+                  ((match int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("maximum", (`Int 100)) :: ppx_fields)
+                    | ppx_other -> ppx_other)))]));
           ("required", (`List [`String "field"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -3772,12 +3656,21 @@ include
     let attrs_core_type_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("description",
-             (`String "Integer percentage value (0-100 inclusive)"));
-          ("minimum", (`Int 0));
-          ("maximum", (`Int 100));
-          ("type", (`String "integer"))] in
+        match match match int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("maximum", (`Int 100)) :: ppx_fields)
+                    | ppx_other -> ppx_other
+              with
+              | `Assoc ppx_fields ->
+                  `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+              | ppx_other -> ppx_other
+        with
+        | `Assoc ppx_fields ->
+            `Assoc
+              (("description",
+                 (`String "Integer percentage value (0-100 inclusive)"))
+              :: ppx_fields)
+        | ppx_other -> ppx_other in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -3808,16 +3701,31 @@ include
           ("properties",
             (`Assoc
                [("label",
-                  (`Assoc
-                     [("description", (`String "An ISO date-time"));
-                     ("format", (`String "date-time"));
-                     ("type", (`String "string"))]));
+                  ((match match string_jsonschema with
+                          | `Assoc ppx_fields ->
+                              `Assoc (("format", (`String "date-time")) ::
+                                ppx_fields)
+                          | ppx_other -> ppx_other
+                    with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("description", (`String "An ISO date-time"))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)));
                ("score",
-                 (`Assoc
-                    [("description", (`String "Score out of 100"));
-                    ("minimum", (`Int 0));
-                    ("maximum", (`Int 100));
-                    ("type", (`String "integer"))]))]));
+                 ((match match match int_jsonschema with
+                               | `Assoc ppx_fields ->
+                                   `Assoc (("maximum", (`Int 100)) ::
+                                     ppx_fields)
+                               | ppx_other -> ppx_other
+                         with
+                         | `Assoc ppx_fields ->
+                             `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+                         | ppx_other -> ppx_other
+                   with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("description", (`String "Score out of 100"))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)))]));
           ("required", (`List [`String "label"; `String "score"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -3839,9 +3747,11 @@ include
     let attrs_type_decl_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("description", (`String "A plain integer"));
-          ("type", (`String "integer"))] in
+        match int_jsonschema with
+        | `Assoc ppx_fields ->
+            `Assoc (("description", (`String "A plain integer")) ::
+              ppx_fields)
+        | ppx_other -> ppx_other in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -3861,10 +3771,13 @@ include
     let minimum_core_type_int_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("minimum", (`Int 0));
-          ("maximum", (`Int 100));
-          ("type", (`String "integer"))] in
+        match match int_jsonschema with
+              | `Assoc ppx_fields ->
+                  `Assoc (("maximum", (`Int 100)) :: ppx_fields)
+              | ppx_other -> ppx_other
+        with
+        | `Assoc ppx_fields -> `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+        | ppx_other -> ppx_other in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -3884,10 +3797,14 @@ include
     let minimum_core_type_float_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("minimum", (`Float 0.0));
-          ("maximum", (`Float 1.0));
-          ("type", (`String "number"))] in
+        match match float_jsonschema with
+              | `Assoc ppx_fields ->
+                  `Assoc (("maximum", (`Float 1.0)) :: ppx_fields)
+              | ppx_other -> ppx_other
+        with
+        | `Assoc ppx_fields ->
+            `Assoc (("minimum", (`Float 0.0)) :: ppx_fields)
+        | ppx_other -> ppx_other in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -3914,15 +3831,24 @@ include
           ("properties",
             (`Assoc
                [("ratio",
-                  (`Assoc
-                     [("minimum", (`Float 0.0));
-                     ("maximum", (`Float 1.0));
-                     ("type", (`String "number"))]));
+                  ((match match float_jsonschema with
+                          | `Assoc ppx_fields ->
+                              `Assoc (("maximum", (`Float 1.0)) ::
+                                ppx_fields)
+                          | ppx_other -> ppx_other
+                    with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("minimum", (`Float 0.0)) :: ppx_fields)
+                    | ppx_other -> ppx_other)));
                ("score",
-                 (`Assoc
-                    [("minimum", (`Int 0));
-                    ("maximum", (`Int 100));
-                    ("type", (`String "integer"))]))]));
+                 ((match match int_jsonschema with
+                         | `Assoc ppx_fields ->
+                             `Assoc (("maximum", (`Int 100)) :: ppx_fields)
+                         | ppx_other -> ppx_other
+                   with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+                   | ppx_other -> ppx_other)))]));
           ("required", (`List [`String "ratio"; `String "score"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -3944,10 +3870,13 @@ include
     let minimum_maximum_type_decl_int_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("minimum", (`Int 0));
-          ("maximum", (`Int 255));
-          ("type", (`String "integer"))] in
+        match match int_jsonschema with
+              | `Assoc ppx_fields ->
+                  `Assoc (("maximum", (`Int 255)) :: ppx_fields)
+              | ppx_other -> ppx_other
+        with
+        | `Assoc ppx_fields -> `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+        | ppx_other -> ppx_other in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -3966,10 +3895,14 @@ include
     let minimum_maximum_type_decl_float_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
-        `Assoc
-          [("minimum", (`Float 0.0));
-          ("maximum", (`Float 1.0));
-          ("type", (`String "number"))] in
+        match match float_jsonschema with
+              | `Assoc ppx_fields ->
+                  `Assoc (("maximum", (`Float 1.0)) :: ppx_fields)
+              | ppx_other -> ppx_other
+        with
+        | `Assoc ppx_fields ->
+            `Assoc (("minimum", (`Float 0.0)) :: ppx_fields)
+        | ppx_other -> ppx_other in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -3998,10 +3931,15 @@ include
                    ("prefixItems",
                      (`List
                         [`Assoc [("const", (`String "Percentage"))];
-                        `Assoc
-                          [("minimum", (`Int 0));
-                          ("maximum", (`Int 100));
-                          ("type", (`String "integer"))]]));
+                        (match match int_jsonschema with
+                               | `Assoc ppx_fields ->
+                                   `Assoc (("maximum", (`Int 100)) ::
+                                     ppx_fields)
+                               | ppx_other -> ppx_other
+                         with
+                         | `Assoc ppx_fields ->
+                             `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+                         | ppx_other -> ppx_other)]));
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 2));
                    ("maxItems", (`Int 2))];
@@ -4010,10 +3948,15 @@ include
                   ("prefixItems",
                     (`List
                        [`Assoc [("const", (`String "Factor"))];
-                       `Assoc
-                         [("minimum", (`Float 0.0));
-                         ("maximum", (`Float 1.0));
-                         ("type", (`String "number"))]]));
+                       (match match float_jsonschema with
+                              | `Assoc ppx_fields ->
+                                  `Assoc (("maximum", (`Float 1.0)) ::
+                                    ppx_fields)
+                              | ppx_other -> ppx_other
+                        with
+                        | `Assoc ppx_fields ->
+                            `Assoc (("minimum", (`Float 0.0)) :: ppx_fields)
+                        | ppx_other -> ppx_other)]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
@@ -4098,10 +4041,7 @@ include
         `Assoc
           [("type", (`String "object"));
           ("properties",
-            (`Assoc
-               [("score",
-                  (`Assoc
-                     [("type", (`List [`String "integer"; `String "null"]))]))]));
+            (`Assoc [("score", (option_jsonschema int_jsonschema))]));
           ("required", (`List [`String "score"]));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -4138,18 +4078,20 @@ include
           ("properties",
             (`Assoc
                [("empty_list",
-                  (`Assoc
-                     [("default", (`List []));
-                     ("type", (`String "array"));
-                     ("items", (`Assoc [("type", (`String "integer"))]))]));
+                  ((match list_jsonschema int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("default", (`List [])) :: ppx_fields)
+                    | ppx_other -> ppx_other)));
                ("int_list",
-                 (`Assoc
-                    [("default",
-                       (((fun xs ->
-                            `List (Stdlib.List.map (fun x -> `Int x) xs)))
-                          [1; 2; 3]));
-                    ("type", (`String "array"));
-                    ("items", (`Assoc [("type", (`String "integer"))]))]));
+                 ((match list_jsonschema int_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("default",
+                            (((fun xs ->
+                                 `List (Stdlib.List.map (fun x -> `Int x) xs)))
+                               [1; 2; 3]))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)));
                ("record",
                  ((match match record_for_default_jsonschema with
                          | `Assoc pairs when
@@ -4191,34 +4133,36 @@ include
                          :: ppx_fields)
                    | ppx_other -> ppx_other)));
                ("pairs",
-                 (`Assoc
-                    [("default",
-                       (((fun xs ->
-                            `List
-                              (Stdlib.List.map
-                                 (fun (ppx_tuple_0, ppx_tuple_1) ->
-                                    `List
-                                      [((fun x -> `String x)) ppx_tuple_0;
-                                      ((fun x ->
-                                          match x with
-                                          | None -> `Null
-                                          | Some v ->
-                                              ((fun x -> `String x)) v))
-                                        ppx_tuple_1]) xs)))
-                          [("a", None); ("b", (Some "b"))]));
-                    ("type", (`String "array"));
-                    ("items",
-                      (`Assoc
-                         [("type", (`String "array"));
-                         ("prefixItems",
-                           (`List
-                              [`Assoc [("type", (`String "string"))];
-                              `Assoc
-                                [("type",
-                                   (`List [`String "string"; `String "null"]))]]));
-                         ("unevaluatedItems", (`Bool false));
-                         ("minItems", (`Int 2));
-                         ("maxItems", (`Int 2))]))]));
+                 ((match list_jsonschema
+                           (`Assoc
+                              [("type", (`String "array"));
+                              ("prefixItems",
+                                (`List
+                                   [string_jsonschema;
+                                   option_jsonschema string_jsonschema]));
+                              ("unevaluatedItems", (`Bool false));
+                              ("minItems", (`Int 2));
+                              ("maxItems", (`Int 2))])
+                   with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("default",
+                            (((fun xs ->
+                                 `List
+                                   (Stdlib.List.map
+                                      (fun (ppx_tuple_0, ppx_tuple_1) ->
+                                         `List
+                                           [((fun x -> `String x))
+                                              ppx_tuple_0;
+                                           ((fun x ->
+                                               match x with
+                                               | None -> `Null
+                                               | Some v ->
+                                                   ((fun x -> `String x)) v))
+                                             ppx_tuple_1]) xs)))
+                               [("a", None); ("b", (Some "b"))]))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)));
                ("pair",
                  (`Assoc
                     [("default",
@@ -4229,28 +4173,35 @@ include
                           (1, "hello")));
                     ("type", (`String "array"));
                     ("prefixItems",
-                      (`List
-                         [`Assoc [("type", (`String "integer"))];
-                         `Assoc [("type", (`String "string"))]]));
+                      (`List [int_jsonschema; string_jsonschema]));
                     ("unevaluatedItems", (`Bool false));
                     ("minItems", (`Int 2));
                     ("maxItems", (`Int 2))]));
                ("is_active",
-                 (`Assoc
-                    [("default", (((fun x -> `Bool x)) false));
-                    ("type", (`String "boolean"))]));
+                 ((match bool_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (((fun x -> `Bool x)) false)) ::
+                         ppx_fields)
+                   | ppx_other -> ppx_other)));
                ("speed",
-                 (`Assoc
-                    [("default", (((fun x -> `Float x)) 100.0));
-                    ("type", (`String "number"))]));
+                 ((match float_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (((fun x -> `Float x)) 100.0)) ::
+                         ppx_fields)
+                   | ppx_other -> ppx_other)));
                ("label",
-                 (`Assoc
-                    [("default", (((fun x -> `String x)) "default"));
-                    ("type", (`String "string"))]));
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("default", (((fun x -> `String x)) "default")) ::
+                         ppx_fields)
+                   | ppx_other -> ppx_other)));
                ("score",
-                 (`Assoc
-                    [("default", (((fun x -> `Int x)) 0));
-                    ("type", (`List [`String "integer"; `String "null"]))]))]));
+                 ((match option_jsonschema int_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (((fun x -> `Int x)) 0)) ::
+                         ppx_fields)
+                   | ppx_other -> ppx_other)))]));
           ("required", (`List []));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -4391,10 +4342,7 @@ include
         `Assoc
           [("type", (`String "object"));
           ("properties",
-            (`Assoc
-               [("foo",
-                  (`Assoc
-                     [("type", (`List [`String "integer"; `String "null"]))]))]));
+            (`Assoc [("foo", (option_jsonschema int_jsonschema))]));
           ("required", (`List []));
           ("additionalProperties", (`Bool false))] in
       match !ppx_eds with
@@ -4475,8 +4423,7 @@ include
                   [("type", (`String "array"));
                   ("prefixItems",
                     (`List
-                       [`Assoc [("const", (`String "C"))];
-                       `Assoc [("type", (`String "integer"))]]));
+                       [`Assoc [("const", (`String "C"))]; int_jsonschema]));
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
@@ -4588,7 +4535,7 @@ module Generated_code_must_qualify_stdlib =
                        ("prefixItems",
                          (`List
                             [`Assoc [("const", (`String "Leaf"))];
-                            `Assoc [("type", (`String "integer"))]]));
+                            int_jsonschema]));
                        ("unevaluatedItems", (`Bool false));
                        ("minItems", (`Int 2));
                        ("maxItems", (`Int 2))];
@@ -4651,27 +4598,34 @@ module Generated_code_must_qualify_stdlib =
               ("properties",
                 (`Assoc
                    [("name",
-                      (`Assoc
-                         [("default", (((fun x -> `String x)) "x"));
-                         ("type", (`String "string"))]));
+                      ((match string_jsonschema with
+                        | `Assoc ppx_fields ->
+                            `Assoc (("default", (((fun x -> `String x)) "x"))
+                              :: ppx_fields)
+                        | ppx_other -> ppx_other)));
                    ("items_a",
-                     (`Assoc
-                        [("default",
-                           (((fun xs ->
-                                `List
-                                  (Stdlib.Array.to_list
-                                     (Stdlib.Array.map (fun x -> `Int x) xs))))
-                              [|1;2|]));
-                        ("type", (`String "array"));
-                        ("items", (`Assoc [("type", (`String "integer"))]))]));
+                     ((match array_jsonschema int_jsonschema with
+                       | `Assoc ppx_fields ->
+                           `Assoc
+                             (("default",
+                                (((fun xs ->
+                                     `List
+                                       (Stdlib.Array.to_list
+                                          (Stdlib.Array.map (fun x -> `Int x)
+                                             xs)))) [|1;2|]))
+                             :: ppx_fields)
+                       | ppx_other -> ppx_other)));
                    ("items",
-                     (`Assoc
-                        [("default",
-                           (((fun xs ->
-                                `List (Stdlib.List.map (fun x -> `Int x) xs)))
-                              [1; 2]));
-                        ("type", (`String "array"));
-                        ("items", (`Assoc [("type", (`String "integer"))]))]))]));
+                     ((match list_jsonschema int_jsonschema with
+                       | `Assoc ppx_fields ->
+                           `Assoc
+                             (("default",
+                                (((fun xs ->
+                                     `List
+                                       (Stdlib.List.map (fun x -> `Int x) xs)))
+                                   [1; 2]))
+                             :: ppx_fields)
+                       | ppx_other -> ppx_other)))]));
               ("required", (`List []));
               ("additionalProperties", (`Bool false))] in
           match !ppx_eds with
@@ -4692,9 +4646,7 @@ module Generated_code_must_qualify_stdlib =
         let non_rec_using_wrapper_with_shadowed_stdlib_jsonschema =
           let ppx_eds = ref [] in
           let ppx_result =
-            match wrapper_with_shadowed_stdlib_jsonschema
-                    (`Assoc [("type", (`String "integer"))])
-            with
+            match wrapper_with_shadowed_stdlib_jsonschema int_jsonschema with
             | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
                 `Assoc (("$id", (`String "file://shared/cases.ml:499")) ::
                   (Stdlib.List.filter

--- a/test/test_schemas.expected.json
+++ b/test/test_schemas.expected.json
@@ -1927,10 +1927,8 @@
       "type": "object",
       "properties": {
         "composing_type": {
-          "anyOf": [
-            { "type": "string", "description": "A string" },
-            { "type": "null" }
-          ]
+          "type": [ "string", "null" ],
+          "description": "A string"
         }
       },
       "required": [],


### PR DESCRIPTION
## Summary

This PR introduces a `Primitives` module to the ppx runtime, externalizing primitive type schemas (`int`, `float`, `string`, `char`, `unit`, `option`, `list`, `array`, `int64`, `result`) away from being hardcoded inside the PPX rewriter.

That also allow us to have different behavior on Yojson and Melange-json

### Usage

```ocaml
open Ppx_deriving_jsonschema_runtime.Primitives.Melange_json

type t = {
  a: int;
  b: string;
} [@@deriving jsonschema]
```
