### PR TITLE
Simplify default value serialization and add `declassify`

### DIFF
--- a/runtime/Ppx_deriving_jsonschema_runtime_classify.ml
+++ b/runtime/Ppx_deriving_jsonschema_runtime_classify.ml
@@ -33,8 +33,7 @@ let classify value =
         `Assoc
           (Array.fold_right
              (fun (k, v) acc -> if is_undefined v then acc else (k, decode v) :: acc)
-             (Js.Dict.entries dict)
-             [])
+             (Js.Dict.entries dict) [])
     in
     decode value
 

--- a/runtime/Ppx_deriving_jsonschema_runtime_classify.ml
+++ b/runtime/Ppx_deriving_jsonschema_runtime_classify.ml
@@ -8,9 +8,9 @@ type t =
   | `Assoc of (string * t) list
   ]
 
-let classify f x =
+let classify value =
   match%platform () with
-  | Server -> f x
+  | Server -> value
   | Client ->
     (* [Js.Json.classify] only checks for [=== null] when distinguishing null from object, so it
      mis-classifies [undefined] as [JSONObject]. melange-json's [@option] [@drop_default] codegen
@@ -31,7 +31,24 @@ let classify f x =
       | JSONObject dict ->
         let is_undefined json = Js.typeof json = "undefined" in
         `Assoc
-          (Js.Dict.entries dict
-          |> Array.fold_left (fun acc (k, v) -> if is_undefined v then acc else (k, decode v) :: acc) [])
+          (Array.fold_right
+             (fun (k, v) acc -> if is_undefined v then acc else (k, decode v) :: acc)
+             (Js.Dict.entries dict)
+             [])
     in
-    decode (f x)
+    decode value
+
+let declassify value =
+  match%platform () with
+  | Server -> value
+  | Client ->
+    let rec encode = function
+      | `Null -> Js.Json.null
+      | `String str -> Js.Json.string str
+      | `Float f -> Js.Json.number f
+      | `Int i -> Js.Json.number (Js.Int.toFloat i)
+      | `Bool b -> Js.Json.boolean b
+      | `List li -> Js.Json.array (Array.of_list (List.map encode li))
+      | `Assoc assoc -> Js.Json.object_ (Js.Dict.fromList (List.map (fun (k, v) -> k, encode v) assoc))
+    in
+    encode value

--- a/runtime/ppx_deriving_jsonschema_runtime.ml
+++ b/runtime/ppx_deriving_jsonschema_runtime.ml
@@ -3,6 +3,7 @@ let schema_version = "https://json-schema.org/draft/2020-12/schema"
 type t = Ppx_deriving_jsonschema_runtime_classify.t
 
 let classify = Ppx_deriving_jsonschema_runtime_classify.classify
+let declassify = Ppx_deriving_jsonschema_runtime_classify.declassify
 
 let json_schema ?id ?title ?description ?definitions types =
   let fields =

--- a/runtime/ppx_deriving_jsonschema_runtime.mli
+++ b/runtime/ppx_deriving_jsonschema_runtime.mli
@@ -2,8 +2,10 @@ val schema_version : string
 
 type t = Ppx_deriving_jsonschema_runtime_classify.t
 
-val classify : ('a -> t) -> 'a -> t [@@platform native]
-val classify : ('a -> Js.Json.t) -> 'a -> t [@@platform js]
+val classify : t -> t [@@platform native]
+val classify : Js.Json.t -> t [@@platform js]
+val declassify : t -> t [@@platform native]
+val declassify : t -> Js.Json.t [@@platform js]
 
 val json_schema : ?id:string -> ?title:string -> ?description:string -> ?definitions:(string * t) list -> t -> t
 

--- a/src/schema.ml
+++ b/src/schema.ml
@@ -101,38 +101,44 @@ module Annotation = struct
       | [%type: float], Pexp_constant (Pconst_float _) -> minimum ~loc [%expr `Float [%e expr]] schema
       | _ -> Location.raise_errorf ~loc:core_type.ptyp_loc "[@jsonschema.minimum] can only be applied to numeric types")
 
-  let rec serializer_of_core_type ~loc ct =
+  let rec serialize_expr ~loc ct default_value_expr =
     match ct with
-    | [%type: int] | [%type: int32] | [%type: nativeint] -> [%expr fun x -> `Int x]
-    | [%type: float] -> [%expr fun x -> `Float x]
-    | [%type: string] | [%type: bytes] -> [%expr fun x -> `String x]
-    | [%type: bool] -> [%expr fun x -> `Bool x]
+    | [%type: int] | [%type: int32] | [%type: nativeint] -> [%expr `Int [%e default_value_expr]]
+    | [%type: float] -> [%expr `Float [%e default_value_expr]]
+    | [%type: string] | [%type: bytes] -> [%expr `String [%e default_value_expr]]
+    | [%type: bool] -> [%expr `Bool [%e default_value_expr]]
     | [%type: [%t? t] option] ->
-      let s = serializer_of_core_type ~loc t in
       [%expr
-        fun x ->
-          match x with
-          | None -> `Null
-          | Some v -> [%e s] v]
+        match [%e default_value_expr] with
+        | None -> `Null
+        | Some ppx_opt_v -> [%e serialize_expr ~loc t [%expr ppx_opt_v]]]
     | [%type: [%t? t] list] ->
-      let s = serializer_of_core_type ~loc t in
-      [%expr fun xs -> `List (Stdlib.List.map [%e s] xs)]
+      [%expr
+        `List (Stdlib.List.map (fun ppx_item -> [%e serialize_expr ~loc t [%expr ppx_item]]) [%e default_value_expr])]
     | [%type: [%t? t] array] ->
-      let s = serializer_of_core_type ~loc t in
-      [%expr fun xs -> `List (Stdlib.Array.to_list (Stdlib.Array.map [%e s] xs))]
+      [%expr
+        `List
+          (Stdlib.Array.to_list
+             (Stdlib.Array.map (fun ppx_item -> [%e serialize_expr ~loc t [%expr ppx_item]]) [%e default_value_expr]))]
     | { ptyp_desc = Ptyp_tuple types; _ } ->
-      let serializers = List.map (serializer_of_core_type ~loc) types in
       let vars = List.mapi (fun i _ -> Printf.sprintf "ppx_tuple_%d" i) types in
       let pats = List.map (fun v -> ppat_var ~loc { txt = v; loc }) vars in
-      let exprs = List.map2 (fun s v -> [%expr [%e s] [%e evar ~loc v]]) serializers vars in
-      [%expr fun [%p ppat_tuple ~loc pats] -> `List [%e elist ~loc exprs]]
-    | { ptyp_desc = Ptyp_var name; _ } -> evar ~loc name
+      let exprs = List.map2 (fun t v -> serialize_expr ~loc t (evar ~loc v)) types vars in
+      [%expr
+        match [%e default_value_expr] with
+        | [%p ppat_tuple ~loc pats] -> `List [%e elist ~loc exprs]]
+    | { ptyp_desc = Ptyp_var name; _ } -> [%expr [%e evar ~loc name] [%e default_value_expr]]
     | { ptyp_desc = Ptyp_constr (id, args); _ } ->
-      let arg_serializers = List.map (serializer_of_core_type ~loc) args in
-      let exp =
+      let arg_serializers =
+        List.map
+          (fun arg ->
+            [%expr fun ppx_x -> Ppx_deriving_jsonschema_runtime.declassify [%e serialize_expr ~loc arg [%expr ppx_x]]])
+          args
+      in
+      let to_json_expr =
         type_constr_conv ~loc id ~f:(fun s -> if String.equal s "t" then "to_json" else s ^ "_to_json") arg_serializers
       in
-      [%expr Ppx_deriving_jsonschema_runtime.classify [%e exp]]
+      [%expr Ppx_deriving_jsonschema_runtime.classify ([%e to_json_expr] [%e default_value_expr])]
     | _ ->
       Location.raise_errorf ~loc:ct.ptyp_loc
         "[@jsonschema.default] cannot serialize this type. For non-primitive types, ensure a '<type>_to_json' function \
@@ -150,8 +156,7 @@ module Annotation = struct
             | [%type: [%t? t] option] -> t
             | t -> t
           in
-          let serializer = serializer_of_core_type ~loc base_type in
-          [%expr [%e serializer] [%e expr]]
+          serialize_expr ~loc base_type expr
       in
       match schema with
       | [%expr `Assoc [%e? fields]] -> [%expr `Assoc (("default", [%e json_value]) :: [%e fields])]

--- a/test/shared/cases.ml
+++ b/test/shared/cases.ml
@@ -426,7 +426,14 @@ type variant_for_default =
   | B
 [@@deriving to_json, jsonschema]
 
+type 'a range = {
+  from : 'a;
+  to_ : 'a; [@key "to"]
+}
+[@@deriving to_json, jsonschema]
+
 type record_for_default = { score : int option } [@@deriving to_json, jsonschema]
+
 type default_value = {
   score : int option; [@default 0]
   label : string; [@jsonschema.default "default"]
@@ -438,8 +445,10 @@ type default_value = {
   record : record_for_default; [@jsonschema.default { score = None }]
   int_list : int list; [@jsonschema.default [ 1; 2; 3 ]]
   empty_list : int list; [@jsonschema.default []]
+  range : int range; [@jsonschema.default { from = 0; to_ = 100 }]
 }
 [@@deriving jsonschema]
+
 module Status = struct
   type t =
     | Active

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -3125,8 +3125,7 @@ include
                [("custom_drop_default",
                   ((match float_jsonschema with
                     | `Assoc ppx_fields ->
-                        `Assoc (("default", (((fun x -> `Float x)) 0.0)) ::
-                          ppx_fields)
+                        `Assoc (("default", (`Float 0.0)) :: ppx_fields)
                     | ppx_other -> ppx_other)));
                ("dropped_default",
                  ((match list_jsonschema int_jsonschema with
@@ -3137,8 +3136,7 @@ include
                ("default_value",
                  ((match string_jsonschema with
                    | `Assoc ppx_fields ->
-                       `Assoc (("default", (((fun x -> `String x)) "-")) ::
-                         ppx_fields)
+                       `Assoc (("default", (`String "-")) :: ppx_fields)
                    | ppx_other -> ppx_other)));
                ("default_none",
                  ((match string_jsonschema with
@@ -4012,6 +4010,40 @@ include
                     ppx_pairs))
            | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type 'a range = {
+  from: 'a ;
+  to_: 'a [@key "to"]}[@@deriving (to_json, jsonschema)]
+include
+  struct
+    [@@@ocaml.warning "-39-11-27"]
+    let rec range_to_json a_to_json =
+      (fun x ->
+         match x with
+         | { from = x_from; to_ = x_to_ } ->
+             `Assoc
+               (let bnds__001_ = [] in
+                let bnds__001_ = ("to", (a_to_json x_to_)) :: bnds__001_ in
+                let bnds__001_ = ("from", (a_to_json x_from)) :: bnds__001_ in
+                bnds__001_) : 'a range -> Yojson.Basic.t)
+    let range_jsonschema a =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties", (`Assoc [("to", a); ("from", a)]));
+          ("required", (`List [`String "to"; `String "from"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type record_for_default = {
   score: int option }[@@deriving (to_json, jsonschema)]
 include
@@ -4022,11 +4054,11 @@ include
          match x with
          | { score = x_score } ->
              `Assoc
-               (let bnds__001_ = [] in
-                let bnds__001_ =
+               (let bnds__002_ = [] in
+                let bnds__002_ =
                   ("score", ((option_to_json int_to_json) x_score)) ::
-                  bnds__001_ in
-                bnds__001_) : record_for_default -> Yojson.Basic.t)
+                  bnds__002_ in
+                bnds__002_) : record_for_default -> Yojson.Basic.t)
     let record_for_default_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
@@ -4059,7 +4091,9 @@ type default_value =
   variant: variant_for_default [@jsonschema.default A];
   record: record_for_default [@jsonschema.default { score = None }];
   int_list: int list [@jsonschema.default [1; 2; 3]];
-  empty_list: int list [@jsonschema.default []]}[@@deriving jsonschema]
+  empty_list: int list [@jsonschema.default []];
+  range: int range [@jsonschema.default { from = 0; to_ = 100 }]}[@@deriving
+                                                                   jsonschema]
 include
   struct
     let default_value_jsonschema =
@@ -4069,19 +4103,44 @@ include
           [("type", (`String "object"));
           ("properties",
             (`Assoc
-               [("empty_list",
-                  ((match list_jsonschema int_jsonschema with
+               [("range",
+                  ((match match range_jsonschema int_jsonschema with
+                          | `Assoc pairs when
+                              Stdlib.List.mem_assoc "$defs" pairs ->
+                              `Assoc
+                                (("$id",
+                                   (`String "file://shared/cases.ml:448"))
+                                ::
+                                (Stdlib.List.filter
+                                   (fun (k, _) ->
+                                      not (Stdlib.String.equal k "$id"))
+                                   pairs))
+                          | other -> other
+                    with
                     | `Assoc ppx_fields ->
-                        `Assoc (("default", (`List [])) :: ppx_fields)
+                        `Assoc
+                          (("default",
+                             (Ppx_deriving_jsonschema_runtime.classify
+                                ((range_to_json
+                                    (fun ppx_x ->
+                                       Ppx_deriving_jsonschema_runtime.declassify
+                                         (`Int ppx_x)))
+                                   { from = 0; to_ = 100 })))
+                          :: ppx_fields)
                     | ppx_other -> ppx_other)));
+               ("empty_list",
+                 ((match list_jsonschema int_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (`List [])) :: ppx_fields)
+                   | ppx_other -> ppx_other)));
                ("int_list",
                  ((match list_jsonschema int_jsonschema with
                    | `Assoc ppx_fields ->
                        `Assoc
                          (("default",
-                            (((fun xs ->
-                                 `List (Stdlib.List.map (fun x -> `Int x) xs)))
-                               [1; 2; 3]))
+                            (`List
+                               (Stdlib.List.map
+                                  (fun ppx_item -> `Int ppx_item) [1; 2; 3])))
                          :: ppx_fields)
                    | ppx_other -> ppx_other)));
                ("record",
@@ -4090,7 +4149,7 @@ include
                              Stdlib.List.mem_assoc "$defs" pairs ->
                              `Assoc
                                (("$id",
-                                  (`String "file://shared/cases.ml:438"))
+                                  (`String "file://shared/cases.ml:445"))
                                ::
                                (Stdlib.List.filter
                                   (fun (k, _) ->
@@ -4100,8 +4159,8 @@ include
                    | `Assoc ppx_fields ->
                        `Assoc
                          (("default",
-                            ((Ppx_deriving_jsonschema_runtime.classify
-                                record_for_default_to_json) { score = None }))
+                            (Ppx_deriving_jsonschema_runtime.classify
+                               (record_for_default_to_json { score = None })))
                          :: ppx_fields)
                    | ppx_other -> ppx_other)));
                ("variant",
@@ -4110,7 +4169,7 @@ include
                              Stdlib.List.mem_assoc "$defs" pairs ->
                              `Assoc
                                (("$id",
-                                  (`String "file://shared/cases.ml:437"))
+                                  (`String "file://shared/cases.ml:444"))
                                ::
                                (Stdlib.List.filter
                                   (fun (k, _) ->
@@ -4120,8 +4179,8 @@ include
                    | `Assoc ppx_fields ->
                        `Assoc
                          (("default",
-                            ((Ppx_deriving_jsonschema_runtime.classify
-                                variant_for_default_to_json) A))
+                            (Ppx_deriving_jsonschema_runtime.classify
+                               (variant_for_default_to_json A)))
                          :: ppx_fields)
                    | ppx_other -> ppx_other)));
                ("pairs",
@@ -4139,30 +4198,26 @@ include
                    | `Assoc ppx_fields ->
                        `Assoc
                          (("default",
-                            (((fun xs ->
-                                 `List
-                                   (Stdlib.List.map
-                                      (fun (ppx_tuple_0, ppx_tuple_1) ->
+                            (`List
+                               (Stdlib.List.map
+                                  (fun ppx_item ->
+                                     match ppx_item with
+                                     | (ppx_tuple_0, ppx_tuple_1) ->
                                          `List
-                                           [((fun x -> `String x))
-                                              ppx_tuple_0;
-                                           ((fun x ->
-                                               match x with
-                                               | None -> `Null
-                                               | Some v ->
-                                                   ((fun x -> `String x)) v))
-                                             ppx_tuple_1]) xs)))
-                               [("a", None); ("b", (Some "b"))]))
+                                           [`String ppx_tuple_0;
+                                           (match ppx_tuple_1 with
+                                            | None -> `Null
+                                            | Some ppx_opt_v ->
+                                                `String ppx_opt_v)])
+                                  [("a", None); ("b", (Some "b"))])))
                          :: ppx_fields)
                    | ppx_other -> ppx_other)));
                ("pair",
                  (`Assoc
                     [("default",
-                       (((fun (ppx_tuple_0, ppx_tuple_1) ->
-                            `List
-                              [((fun x -> `Int x)) ppx_tuple_0;
-                              ((fun x -> `String x)) ppx_tuple_1]))
-                          (1, "hello")));
+                       ((match (1, "hello") with
+                         | (ppx_tuple_0, ppx_tuple_1) ->
+                             `List [`Int ppx_tuple_0; `String ppx_tuple_1])));
                     ("type", (`String "array"));
                     ("prefixItems",
                       (`List [int_jsonschema; string_jsonschema]));
@@ -4172,27 +4227,23 @@ include
                ("is_active",
                  ((match bool_jsonschema with
                    | `Assoc ppx_fields ->
-                       `Assoc (("default", (((fun x -> `Bool x)) false)) ::
-                         ppx_fields)
+                       `Assoc (("default", (`Bool false)) :: ppx_fields)
                    | ppx_other -> ppx_other)));
                ("speed",
                  ((match float_jsonschema with
                    | `Assoc ppx_fields ->
-                       `Assoc (("default", (((fun x -> `Float x)) 100.0)) ::
-                         ppx_fields)
+                       `Assoc (("default", (`Float 100.0)) :: ppx_fields)
                    | ppx_other -> ppx_other)));
                ("label",
                  ((match string_jsonschema with
                    | `Assoc ppx_fields ->
-                       `Assoc
-                         (("default", (((fun x -> `String x)) "default")) ::
+                       `Assoc (("default", (`String "default")) ::
                          ppx_fields)
                    | ppx_other -> ppx_other)));
                ("score",
                  ((match option_jsonschema int_jsonschema with
                    | `Assoc ppx_fields ->
-                       `Assoc (("default", (((fun x -> `Int x)) 0)) ::
-                         ppx_fields)
+                       `Assoc (("default", (`Int 0)) :: ppx_fields)
                    | ppx_other -> ppx_other)))]));
           ("required", (`List []));
           ("additionalProperties", (`Bool false))] in
@@ -4271,7 +4322,7 @@ include
                               Stdlib.List.mem_assoc "$defs" pairs ->
                               `Assoc
                                 (("$id",
-                                   (`String "file://shared/cases.ml:449"))
+                                   (`String "file://shared/cases.ml:458"))
                                 ::
                                 (Stdlib.List.filter
                                    (fun (k, _) ->
@@ -4282,8 +4333,8 @@ include
                     | `Assoc ppx_fields ->
                         `Assoc
                           (("default",
-                             ((Ppx_deriving_jsonschema_runtime.classify
-                                 Status.to_json) Status.Active))
+                             (Ppx_deriving_jsonschema_runtime.classify
+                                (Status.to_json Status.Active)))
                           :: ppx_fields)
                     | ppx_other -> ppx_other)))]));
           ("required", (`List []));
@@ -4310,14 +4361,14 @@ include
          match x with
          | { foo = x_foo } ->
              `Assoc
-               (let bnds__002_ = [] in
-                let bnds__002_ =
+               (let bnds__003_ = [] in
+                let bnds__003_ =
                   match x_foo with
-                  | Stdlib.Option.None -> bnds__002_
+                  | Stdlib.Option.None -> bnds__003_
                   | Stdlib.Option.Some _ ->
                       ("foo", ((option_to_json int_to_json) x_foo)) ::
-                      bnds__002_ in
-                bnds__002_) : inner_with_option_field -> Yojson.Basic.t)
+                      bnds__003_ in
+                bnds__003_) : inner_with_option_field -> Yojson.Basic.t)
     let inner_with_option_field_jsonschema =
       let ppx_eds = ref [] in
       let ppx_result =
@@ -4358,7 +4409,7 @@ include
                               Stdlib.List.mem_assoc "$defs" pairs ->
                               `Assoc
                                 (("$id",
-                                   (`String "file://shared/cases.ml:458"))
+                                   (`String "file://shared/cases.ml:467"))
                                 ::
                                 (Stdlib.List.filter
                                    (fun (k, _) ->
@@ -4369,9 +4420,9 @@ include
                     | `Assoc ppx_fields ->
                         `Assoc
                           (("default",
-                             ((Ppx_deriving_jsonschema_runtime.classify
-                                 inner_with_option_field_to_json)
-                                empty_inner_with_option_field))
+                             (Ppx_deriving_jsonschema_runtime.classify
+                                (inner_with_option_field_to_json
+                                   empty_inner_with_option_field)))
                           :: ppx_fields)
                     | ppx_other -> ppx_other)))]));
           ("required", (`List []));
@@ -4582,19 +4633,18 @@ module Generated_code_must_qualify_stdlib =
                    [("name",
                       ((match string_jsonschema with
                         | `Assoc ppx_fields ->
-                            `Assoc (("default", (((fun x -> `String x)) "x"))
-                              :: ppx_fields)
+                            `Assoc (("default", (`String "x")) :: ppx_fields)
                         | ppx_other -> ppx_other)));
                    ("items_a",
                      ((match array_jsonschema int_jsonschema with
                        | `Assoc ppx_fields ->
                            `Assoc
                              (("default",
-                                (((fun xs ->
-                                     `List
-                                       (Stdlib.Array.to_list
-                                          (Stdlib.Array.map (fun x -> `Int x)
-                                             xs)))) [|1;2|]))
+                                (`List
+                                   (Stdlib.Array.to_list
+                                      (Stdlib.Array.map
+                                         (fun ppx_item -> `Int ppx_item)
+                                         [|1;2|]))))
                              :: ppx_fields)
                        | ppx_other -> ppx_other)));
                    ("items",
@@ -4602,10 +4652,10 @@ module Generated_code_must_qualify_stdlib =
                        | `Assoc ppx_fields ->
                            `Assoc
                              (("default",
-                                (((fun xs ->
-                                     `List
-                                       (Stdlib.List.map (fun x -> `Int x) xs)))
-                                   [1; 2]))
+                                (`List
+                                   (Stdlib.List.map
+                                      (fun ppx_item -> `Int ppx_item) 
+                                      [1; 2])))
                              :: ppx_fields)
                        | ppx_other -> ppx_other)))]));
               ("required", (`List []));
@@ -4630,7 +4680,7 @@ module Generated_code_must_qualify_stdlib =
           let ppx_result =
             match wrapper_with_shadowed_stdlib_jsonschema int_jsonschema with
             | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                `Assoc (("$id", (`String "file://shared/cases.ml:499")) ::
+                `Assoc (("$id", (`String "file://shared/cases.ml:508")) ::
                   (Stdlib.List.filter
                      (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
             | other -> other in

--- a/test/test.melange.expected.ml
+++ b/test/test.melange.expected.ml
@@ -3125,8 +3125,7 @@ include
                [("custom_drop_default",
                   ((match float_jsonschema with
                     | `Assoc ppx_fields ->
-                        `Assoc (("default", (((fun x -> `Float x)) 0.0)) ::
-                          ppx_fields)
+                        `Assoc (("default", (`Float 0.0)) :: ppx_fields)
                     | ppx_other -> ppx_other)));
                ("dropped_default",
                  ((match list_jsonschema int_jsonschema with
@@ -3137,8 +3136,7 @@ include
                ("default_value",
                  ((match string_jsonschema with
                    | `Assoc ppx_fields ->
-                       `Assoc (("default", (((fun x -> `String x)) "-")) ::
-                         ppx_fields)
+                       `Assoc (("default", (`String "-")) :: ppx_fields)
                    | ppx_other -> ppx_other)));
                ("default_none",
                  ((match string_jsonschema with
@@ -4014,6 +4012,48 @@ include
                     ppx_pairs))
            | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type 'a range = {
+  from: 'a ;
+  to_: 'a [@key "to"]}[@@deriving (to_json, jsonschema)]
+include
+  struct
+    [@@@ocaml.warning "-39-11-27"]
+    let rec range_to_json a_to_json =
+      (fun x ->
+         match x with
+         | { from = x_from; to_ = x_to_ } ->
+             (Obj.magic
+                (let module J =
+                   struct
+                     external unsafe_expr :
+                       from:'a0 ->
+                         \#to:'a1 -> < from: 'a0  ;\#to: 'a1   >  Js.t = ""
+                         ""[@@ocaml.warning "-unboxable-type-in-prim-decl"]
+                     [@@mel.internal.ffi
+                       "\132\149\166\190\000\000\000\018\000\000\000\t\000\000\000\023\000\000\000\022\145\160\160A\144$from\160\160A\144\"to@"]
+                   end in
+                   J.unsafe_expr ~from:(a_to_json x_from)
+                     ~\#to:(a_to_json x_to_)) : Js.Json.t) : 'a range ->
+                                                               Js.Json.t)
+    let range_jsonschema a =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties", (`Assoc [("to", a); ("from", a)]));
+          ("required", (`List [`String "to"; `String "from"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type record_for_default = {
   score: int option }[@@deriving (to_json, jsonschema)]
 include
@@ -4067,7 +4107,9 @@ type default_value =
   variant: variant_for_default [@jsonschema.default A];
   record: record_for_default [@jsonschema.default { score = None }];
   int_list: int list [@jsonschema.default [1; 2; 3]];
-  empty_list: int list [@jsonschema.default []]}[@@deriving jsonschema]
+  empty_list: int list [@jsonschema.default []];
+  range: int range [@jsonschema.default { from = 0; to_ = 100 }]}[@@deriving
+                                                                   jsonschema]
 include
   struct
     let default_value_jsonschema =
@@ -4077,19 +4119,44 @@ include
           [("type", (`String "object"));
           ("properties",
             (`Assoc
-               [("empty_list",
-                  ((match list_jsonschema int_jsonschema with
+               [("range",
+                  ((match match range_jsonschema int_jsonschema with
+                          | `Assoc pairs when
+                              Stdlib.List.mem_assoc "$defs" pairs ->
+                              `Assoc
+                                (("$id",
+                                   (`String "file://shared/cases.ml:448"))
+                                ::
+                                (Stdlib.List.filter
+                                   (fun (k, _) ->
+                                      not (Stdlib.String.equal k "$id"))
+                                   pairs))
+                          | other -> other
+                    with
                     | `Assoc ppx_fields ->
-                        `Assoc (("default", (`List [])) :: ppx_fields)
+                        `Assoc
+                          (("default",
+                             (Ppx_deriving_jsonschema_runtime.classify
+                                ((range_to_json
+                                    (fun ppx_x ->
+                                       Ppx_deriving_jsonschema_runtime.declassify
+                                         (`Int ppx_x)))
+                                   { from = 0; to_ = 100 })))
+                          :: ppx_fields)
                     | ppx_other -> ppx_other)));
+               ("empty_list",
+                 ((match list_jsonschema int_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (`List [])) :: ppx_fields)
+                   | ppx_other -> ppx_other)));
                ("int_list",
                  ((match list_jsonschema int_jsonschema with
                    | `Assoc ppx_fields ->
                        `Assoc
                          (("default",
-                            (((fun xs ->
-                                 `List (Stdlib.List.map (fun x -> `Int x) xs)))
-                               [1; 2; 3]))
+                            (`List
+                               (Stdlib.List.map
+                                  (fun ppx_item -> `Int ppx_item) [1; 2; 3])))
                          :: ppx_fields)
                    | ppx_other -> ppx_other)));
                ("record",
@@ -4098,7 +4165,7 @@ include
                              Stdlib.List.mem_assoc "$defs" pairs ->
                              `Assoc
                                (("$id",
-                                  (`String "file://shared/cases.ml:438"))
+                                  (`String "file://shared/cases.ml:445"))
                                ::
                                (Stdlib.List.filter
                                   (fun (k, _) ->
@@ -4108,8 +4175,8 @@ include
                    | `Assoc ppx_fields ->
                        `Assoc
                          (("default",
-                            ((Ppx_deriving_jsonschema_runtime.classify
-                                record_for_default_to_json) { score = None }))
+                            (Ppx_deriving_jsonschema_runtime.classify
+                               (record_for_default_to_json { score = None })))
                          :: ppx_fields)
                    | ppx_other -> ppx_other)));
                ("variant",
@@ -4118,7 +4185,7 @@ include
                              Stdlib.List.mem_assoc "$defs" pairs ->
                              `Assoc
                                (("$id",
-                                  (`String "file://shared/cases.ml:437"))
+                                  (`String "file://shared/cases.ml:444"))
                                ::
                                (Stdlib.List.filter
                                   (fun (k, _) ->
@@ -4128,8 +4195,8 @@ include
                    | `Assoc ppx_fields ->
                        `Assoc
                          (("default",
-                            ((Ppx_deriving_jsonschema_runtime.classify
-                                variant_for_default_to_json) A))
+                            (Ppx_deriving_jsonschema_runtime.classify
+                               (variant_for_default_to_json A)))
                          :: ppx_fields)
                    | ppx_other -> ppx_other)));
                ("pairs",
@@ -4147,30 +4214,26 @@ include
                    | `Assoc ppx_fields ->
                        `Assoc
                          (("default",
-                            (((fun xs ->
-                                 `List
-                                   (Stdlib.List.map
-                                      (fun (ppx_tuple_0, ppx_tuple_1) ->
+                            (`List
+                               (Stdlib.List.map
+                                  (fun ppx_item ->
+                                     match ppx_item with
+                                     | (ppx_tuple_0, ppx_tuple_1) ->
                                          `List
-                                           [((fun x -> `String x))
-                                              ppx_tuple_0;
-                                           ((fun x ->
-                                               match x with
-                                               | None -> `Null
-                                               | Some v ->
-                                                   ((fun x -> `String x)) v))
-                                             ppx_tuple_1]) xs)))
-                               [("a", None); ("b", (Some "b"))]))
+                                           [`String ppx_tuple_0;
+                                           (match ppx_tuple_1 with
+                                            | None -> `Null
+                                            | Some ppx_opt_v ->
+                                                `String ppx_opt_v)])
+                                  [("a", None); ("b", (Some "b"))])))
                          :: ppx_fields)
                    | ppx_other -> ppx_other)));
                ("pair",
                  (`Assoc
                     [("default",
-                       (((fun (ppx_tuple_0, ppx_tuple_1) ->
-                            `List
-                              [((fun x -> `Int x)) ppx_tuple_0;
-                              ((fun x -> `String x)) ppx_tuple_1]))
-                          (1, "hello")));
+                       ((match (1, "hello") with
+                         | (ppx_tuple_0, ppx_tuple_1) ->
+                             `List [`Int ppx_tuple_0; `String ppx_tuple_1])));
                     ("type", (`String "array"));
                     ("prefixItems",
                       (`List [int_jsonschema; string_jsonschema]));
@@ -4180,27 +4243,23 @@ include
                ("is_active",
                  ((match bool_jsonschema with
                    | `Assoc ppx_fields ->
-                       `Assoc (("default", (((fun x -> `Bool x)) false)) ::
-                         ppx_fields)
+                       `Assoc (("default", (`Bool false)) :: ppx_fields)
                    | ppx_other -> ppx_other)));
                ("speed",
                  ((match float_jsonschema with
                    | `Assoc ppx_fields ->
-                       `Assoc (("default", (((fun x -> `Float x)) 100.0)) ::
-                         ppx_fields)
+                       `Assoc (("default", (`Float 100.0)) :: ppx_fields)
                    | ppx_other -> ppx_other)));
                ("label",
                  ((match string_jsonschema with
                    | `Assoc ppx_fields ->
-                       `Assoc
-                         (("default", (((fun x -> `String x)) "default")) ::
+                       `Assoc (("default", (`String "default")) ::
                          ppx_fields)
                    | ppx_other -> ppx_other)));
                ("score",
                  ((match option_jsonschema int_jsonschema with
                    | `Assoc ppx_fields ->
-                       `Assoc (("default", (((fun x -> `Int x)) 0)) ::
-                         ppx_fields)
+                       `Assoc (("default", (`Int 0)) :: ppx_fields)
                    | ppx_other -> ppx_other)))]));
           ("required", (`List []));
           ("additionalProperties", (`Bool false))] in
@@ -4282,7 +4341,7 @@ include
                               Stdlib.List.mem_assoc "$defs" pairs ->
                               `Assoc
                                 (("$id",
-                                   (`String "file://shared/cases.ml:449"))
+                                   (`String "file://shared/cases.ml:458"))
                                 ::
                                 (Stdlib.List.filter
                                    (fun (k, _) ->
@@ -4293,8 +4352,8 @@ include
                     | `Assoc ppx_fields ->
                         `Assoc
                           (("default",
-                             ((Ppx_deriving_jsonschema_runtime.classify
-                                 Status.to_json) Status.Active))
+                             (Ppx_deriving_jsonschema_runtime.classify
+                                (Status.to_json Status.Active)))
                           :: ppx_fields)
                     | ppx_other -> ppx_other)))]));
           ("required", (`List []));
@@ -4376,7 +4435,7 @@ include
                               Stdlib.List.mem_assoc "$defs" pairs ->
                               `Assoc
                                 (("$id",
-                                   (`String "file://shared/cases.ml:458"))
+                                   (`String "file://shared/cases.ml:467"))
                                 ::
                                 (Stdlib.List.filter
                                    (fun (k, _) ->
@@ -4387,9 +4446,9 @@ include
                     | `Assoc ppx_fields ->
                         `Assoc
                           (("default",
-                             ((Ppx_deriving_jsonschema_runtime.classify
-                                 inner_with_option_field_to_json)
-                                empty_inner_with_option_field))
+                             (Ppx_deriving_jsonschema_runtime.classify
+                                (inner_with_option_field_to_json
+                                   empty_inner_with_option_field)))
                           :: ppx_fields)
                     | ppx_other -> ppx_other)))]));
           ("required", (`List []));
@@ -4600,19 +4659,18 @@ module Generated_code_must_qualify_stdlib =
                    [("name",
                       ((match string_jsonschema with
                         | `Assoc ppx_fields ->
-                            `Assoc (("default", (((fun x -> `String x)) "x"))
-                              :: ppx_fields)
+                            `Assoc (("default", (`String "x")) :: ppx_fields)
                         | ppx_other -> ppx_other)));
                    ("items_a",
                      ((match array_jsonschema int_jsonschema with
                        | `Assoc ppx_fields ->
                            `Assoc
                              (("default",
-                                (((fun xs ->
-                                     `List
-                                       (Stdlib.Array.to_list
-                                          (Stdlib.Array.map (fun x -> `Int x)
-                                             xs)))) [|1;2|]))
+                                (`List
+                                   (Stdlib.Array.to_list
+                                      (Stdlib.Array.map
+                                         (fun ppx_item -> `Int ppx_item)
+                                         [|1;2|]))))
                              :: ppx_fields)
                        | ppx_other -> ppx_other)));
                    ("items",
@@ -4620,10 +4678,10 @@ module Generated_code_must_qualify_stdlib =
                        | `Assoc ppx_fields ->
                            `Assoc
                              (("default",
-                                (((fun xs ->
-                                     `List
-                                       (Stdlib.List.map (fun x -> `Int x) xs)))
-                                   [1; 2]))
+                                (`List
+                                   (Stdlib.List.map
+                                      (fun ppx_item -> `Int ppx_item) 
+                                      [1; 2])))
                              :: ppx_fields)
                        | ppx_other -> ppx_other)))]));
               ("required", (`List []));
@@ -4648,7 +4706,7 @@ module Generated_code_must_qualify_stdlib =
           let ppx_result =
             match wrapper_with_shadowed_stdlib_jsonschema int_jsonschema with
             | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                `Assoc (("$id", (`String "file://shared/cases.ml:499")) ::
+                `Assoc (("$id", (`String "file://shared/cases.ml:508")) ::
                   (Stdlib.List.filter
                      (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
             | other -> other in

--- a/test/test_schemas.expected.json
+++ b/test/test_schemas.expected.json
@@ -2305,6 +2305,16 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
+        "range": {
+          "default": { "from": 0, "to": 100 },
+          "type": "object",
+          "properties": {
+            "to": { "type": "integer" },
+            "from": { "type": "integer" }
+          },
+          "required": [ "to", "from" ],
+          "additionalProperties": false
+        },
         "empty_list": {
           "default": [],
           "type": "array",


### PR DESCRIPTION
## Simplify default value serialization and add `declassify`

### Summary

- **Simplify `classify`**:  previously accepted a function and a value (`f x`);
  it now accepts a pre-evaluated value directly. Call sites become `classify (foo_to_json v)` instead
  of `classify foo_to_json v`.
- **Add `declassify`**: The inverse of `classify` — converts the internal `t` type back to `Js.Json.t`
  on the client (no-op on the server). This is needed when passing serialized type-parameter values
  into polymorphic `_to_json` functions.
- **Refactor `serializer_of_core_type` → `serialize_expr`**: Instead of generating a standalone
  serializer function (`fun x -> ...`), the new approach builds the serialized expression inline given
  the value expression directly. This eliminates spurious lambda wrappers in the generated code
  (e.g. `(((fun x -> \`Int x)) 0)` becomes `` `Int 0 ``).
- **Support parametric types in `[@jsonschema.default]`**: 
  - That was not working on melange with parametric types, that's why the `declassify` was created
  - Adds a test case with `int range`
  (a parametric record type) as a `[@jsonschema.default]` field, exercising the `classify`/`declassify`
  round-trip for type-parameter serializers.
