### PR TITLE
Handle nonrec types

### DIFF
--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -300,11 +300,14 @@ let str_type_decl ~ctxt ast flag_variant_as_string flag_polymorphic_variant_tupl
   in
   match ast with
   (* Single type declaration *)
-  | _, [ type_decl ] ->
+  | rec_flag, [ type_decl ] ->
     let type_name = type_decl.ptype_name.txt in
-    let _, raw_schema, is_rec, params, params_prefix =
-      schema_of_type_decl ~loc ~config ~recursive_types:[ type_name ] type_decl
+    let recursive_types =
+      match rec_flag with
+      | Recursive -> [ type_name ]
+      | Nonrecursive -> []
     in
+    let _, raw_schema, is_rec, params, params_prefix = schema_of_type_decl ~loc ~config ~recursive_types type_decl in
     let raw_schema =
       raw_schema
       |> Schema.Annotation.add_description ~loc (Attrs.td_description ~ocaml_doc:config.Attrs.ocaml_doc type_decl)
@@ -331,8 +334,12 @@ let str_type_decl ~ctxt ast flag_variant_as_string flag_polymorphic_variant_tupl
     let schema = wrap_type_params ~loc ~prefix:params_prefix params schema in
     [ create_value ~loc type_name schema ]
   (* Multiple type declarations (mutually recursive types) *)
-  | _, type_decls when List.length type_decls > 1 ->
-    let recursive_types = List.map (fun td -> td.ptype_name.txt) type_decls in
+  | rec_flag, type_decls when List.length type_decls > 1 ->
+    let recursive_types =
+      match rec_flag with
+      | Recursive -> List.map (fun td -> td.ptype_name.txt) type_decls
+      | Nonrecursive -> []
+    in
     let raw_results = List.map (schema_of_type_decl ~loc ~config ~recursive_types) type_decls in
     let any_recursive = List.exists (fun (_, _, is_rec, _, _) -> is_rec) raw_results in
     if any_recursive then

--- a/test/shared/cases.ml
+++ b/test/shared/cases.ml
@@ -518,3 +518,27 @@ module Nonrec_type_alias = struct
     type nonrec foo = foo [@@deriving jsonschema]
   end
 end
+
+module Recursive_shapes = struct
+  type a = A of b
+  and b = int [@@deriving jsonschema]
+
+  type t =
+    | N
+    | S of t
+  [@@deriving jsonschema]
+
+  type 'a lst =
+    | Nil
+    | Cons of 'a * 'a lst
+  [@@deriving jsonschema]
+
+  type 'a tree =
+    | Leaf of 'a
+    | Node of 'a * 'a forest
+
+  and 'a forest =
+    | Empty
+    | Base of 'a tree * 'a forest
+  [@@deriving jsonschema]
+end

--- a/test/shared/cases.ml
+++ b/test/shared/cases.ml
@@ -507,3 +507,14 @@ module Generated_code_must_qualify_stdlib = struct
      exercises the [$id]-injection branch where the inner [$defs] gets a resource boundary. *)
   type non_rec_using_wrapper_with_shadowed_stdlib = int wrapper_with_shadowed_stdlib [@@deriving jsonschema]
 end
+
+module Nonrec_type_alias = struct
+  type foo =
+    | A
+    | B
+  [@@deriving jsonschema]
+
+  module X = struct
+    type nonrec foo = foo [@@deriving jsonschema]
+  end
+end

--- a/test/shared/generate_schemas_cases.ml
+++ b/test/shared/generate_schemas_cases.ml
@@ -115,6 +115,8 @@ let schemas =
     Ppx_deriving_jsonschema_runtime.json_schema default_with_module_type_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema outer_default_record_with_option_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema compact_variants_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema Nonrec_type_alias.foo_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema Nonrec_type_alias.X.foo_jsonschema;
   ]
 
 let snapshot = `Assoc [ "$schema", `String Ppx_deriving_jsonschema_runtime.schema_version; "oneOf", `List schemas ]

--- a/test/shared/generate_schemas_cases.ml
+++ b/test/shared/generate_schemas_cases.ml
@@ -117,6 +117,12 @@ let schemas =
     Ppx_deriving_jsonschema_runtime.json_schema compact_variants_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema Nonrec_type_alias.foo_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema Nonrec_type_alias.X.foo_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema Recursive_shapes.a_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema Recursive_shapes.b_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema Recursive_shapes.t_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema (Recursive_shapes.lst_jsonschema int_jsonschema);
+    Ppx_deriving_jsonschema_runtime.json_schema (Recursive_shapes.tree_jsonschema string_jsonschema);
+    Ppx_deriving_jsonschema_runtime.json_schema (Recursive_shapes.forest_jsonschema string_jsonschema);
   ]
 
 let snapshot = `Assoc [ "$schema", `String Ppx_deriving_jsonschema_runtime.schema_version; "oneOf", `List schemas ]

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -4741,10 +4741,25 @@ module Nonrec_type_alias =
           struct
             let foo_jsonschema =
               let ppx_eds = ref [] in
-              let ppx_body_foo = `Assoc [("$ref", (`String "#/$defs/foo"))] in
-              `Assoc
-                [("$defs", (`Assoc ([("foo", ppx_body_foo)] @ (!ppx_eds))));
-                ("$ref", (`String "#/$defs/foo"))][@@warning "-32-39"]
+              let ppx_result =
+                match foo_jsonschema with
+                | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                    `Assoc (("$id", (`String "file://shared/cases.ml:518"))
+                      ::
+                      (Stdlib.List.filter
+                         (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                         pairs))
+                | other -> other in
+              match !ppx_eds with
+              | [] -> ppx_result
+              | ppx_defs ->
+                  (match ppx_result with
+                   | `Assoc ppx_pairs ->
+                       `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                         (Stdlib.List.filter
+                            (fun (k, _) ->
+                               not (Stdlib.String.equal k "$defs")) ppx_pairs))
+                   | other -> other)[@@warning "-32-39"]
           end[@@ocaml.doc "@inline"][@@merlin.hide ]
       end
   end

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -4696,3 +4696,55 @@ module Generated_code_must_qualify_stdlib =
                | other -> other)[@@warning "-32-39"]
       end[@@ocaml.doc "@inline"][@@merlin.hide ]
   end
+module Nonrec_type_alias =
+  struct
+    type foo =
+      | A 
+      | B [@@deriving jsonschema]
+    include
+      struct
+        let foo_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_result =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "A"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List [`Assoc [("const", (`String "B"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 1));
+                      ("maxItems", (`Int 1))]]))] in
+          match !ppx_eds with
+          | [] -> ppx_result
+          | ppx_defs ->
+              (match ppx_result with
+               | `Assoc ppx_pairs ->
+                   `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                     (Stdlib.List.filter
+                        (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                        ppx_pairs))
+               | other -> other)[@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    module X =
+      struct
+        type nonrec foo = foo[@@deriving jsonschema]
+        include
+          struct
+            let foo_jsonschema =
+              let ppx_eds = ref [] in
+              let ppx_body_foo = `Assoc [("$ref", (`String "#/$defs/foo"))] in
+              `Assoc
+                [("$defs", (`Assoc ([("foo", ppx_body_foo)] @ (!ppx_eds))));
+                ("$ref", (`String "#/$defs/foo"))][@@warning "-32-39"]
+          end[@@ocaml.doc "@inline"][@@merlin.hide ]
+      end
+  end

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -4763,3 +4763,224 @@ module Nonrec_type_alias =
           end[@@ocaml.doc "@inline"][@@merlin.hide ]
       end
   end
+module Recursive_shapes =
+  struct
+    type a =
+      | A of b 
+    and b = int[@@deriving jsonschema]
+    include
+      struct
+        let a_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_body_a =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List
+                            [`Assoc [("const", (`String "A"))];
+                            `Assoc [("$ref", (`String "#/$defs/b"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 2));
+                       ("maxItems", (`Int 2))]]))] in
+          let ppx_body_b = int_jsonschema in
+          `Assoc
+            [("$defs",
+               (`Assoc ([("a", ppx_body_a); ("b", ppx_body_b)] @ (!ppx_eds))));
+            ("$ref", (`String "#/$defs/a"))][@@warning "-32-39"]
+        let b_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_body_a =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List
+                            [`Assoc [("const", (`String "A"))];
+                            `Assoc [("$ref", (`String "#/$defs/b"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 2));
+                       ("maxItems", (`Int 2))]]))] in
+          let ppx_body_b = int_jsonschema in
+          `Assoc
+            [("$defs",
+               (`Assoc ([("a", ppx_body_a); ("b", ppx_body_b)] @ (!ppx_eds))));
+            ("$ref", (`String "#/$defs/b"))][@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    type t =
+      | N 
+      | S of t [@@deriving jsonschema]
+    include
+      struct
+        let t_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_body_t =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "N"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "S"))];
+                           `Assoc [("$ref", (`String "#/$defs/t"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 2));
+                      ("maxItems", (`Int 2))]]))] in
+          `Assoc
+            [("$defs", (`Assoc ([("t", ppx_body_t)] @ (!ppx_eds))));
+            ("$ref", (`String "#/$defs/t"))][@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    type 'a lst =
+      | Nil 
+      | Cons of 'a * 'a lst [@@deriving jsonschema]
+    include
+      struct
+        let lst_jsonschema a =
+          let ppx_eds = ref [] in
+          let ppx_body_lst =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Nil"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Cons"))];
+                           a;
+                           `Assoc [("$ref", (`String "#/$defs/lst"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 3));
+                      ("maxItems", (`Int 3))]]))] in
+          `Assoc
+            [("$defs", (`Assoc ([("lst", ppx_body_lst)] @ (!ppx_eds))));
+            ("$ref", (`String "#/$defs/lst"))][@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    type 'a tree =
+      | Leaf of 'a 
+      | Node of 'a * 'a forest 
+    and 'a forest =
+      | Empty 
+      | Base of 'a tree * 'a forest [@@deriving jsonschema]
+    include
+      struct
+        let tree_jsonschema a =
+          let ppx_eds = ref [] in
+          let ppx_body_tree =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Leaf"))]; a]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 2));
+                       ("maxItems", (`Int 2))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Node"))];
+                           a;
+                           `Assoc [("$ref", (`String "#/$defs/forest"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 3));
+                      ("maxItems", (`Int 3))]]))] in
+          let ppx_body_forest =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Empty"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Base"))];
+                           `Assoc [("$ref", (`String "#/$defs/tree"))];
+                           `Assoc [("$ref", (`String "#/$defs/forest"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 3));
+                      ("maxItems", (`Int 3))]]))] in
+          `Assoc
+            [("$defs",
+               (`Assoc
+                  ([("tree", ppx_body_tree); ("forest", ppx_body_forest)] @
+                     (!ppx_eds))));
+            ("$ref", (`String "#/$defs/tree"))][@@warning "-32-39"]
+        let forest_jsonschema a =
+          let ppx_eds = ref [] in
+          let ppx_body_tree =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Leaf"))]; a]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 2));
+                       ("maxItems", (`Int 2))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Node"))];
+                           a;
+                           `Assoc [("$ref", (`String "#/$defs/forest"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 3));
+                      ("maxItems", (`Int 3))]]))] in
+          let ppx_body_forest =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Empty"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Base"))];
+                           `Assoc [("$ref", (`String "#/$defs/tree"))];
+                           `Assoc [("$ref", (`String "#/$defs/forest"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 3));
+                      ("maxItems", (`Int 3))]]))] in
+          `Assoc
+            [("$defs",
+               (`Assoc
+                  ([("tree", ppx_body_tree); ("forest", ppx_body_forest)] @
+                     (!ppx_eds))));
+            ("$ref", (`String "#/$defs/forest"))][@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+  end

--- a/test/test.melange.expected.ml
+++ b/test/test.melange.expected.ml
@@ -4767,10 +4767,25 @@ module Nonrec_type_alias =
           struct
             let foo_jsonschema =
               let ppx_eds = ref [] in
-              let ppx_body_foo = `Assoc [("$ref", (`String "#/$defs/foo"))] in
-              `Assoc
-                [("$defs", (`Assoc ([("foo", ppx_body_foo)] @ (!ppx_eds))));
-                ("$ref", (`String "#/$defs/foo"))][@@warning "-32-39"]
+              let ppx_result =
+                match foo_jsonschema with
+                | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                    `Assoc (("$id", (`String "file://shared/cases.ml:518"))
+                      ::
+                      (Stdlib.List.filter
+                         (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                         pairs))
+                | other -> other in
+              match !ppx_eds with
+              | [] -> ppx_result
+              | ppx_defs ->
+                  (match ppx_result with
+                   | `Assoc ppx_pairs ->
+                       `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                         (Stdlib.List.filter
+                            (fun (k, _) ->
+                               not (Stdlib.String.equal k "$defs")) ppx_pairs))
+                   | other -> other)[@@warning "-32-39"]
           end[@@ocaml.doc "@inline"][@@merlin.hide ]
       end
   end

--- a/test/test.melange.expected.ml
+++ b/test/test.melange.expected.ml
@@ -4722,3 +4722,55 @@ module Generated_code_must_qualify_stdlib =
                | other -> other)[@@warning "-32-39"]
       end[@@ocaml.doc "@inline"][@@merlin.hide ]
   end
+module Nonrec_type_alias =
+  struct
+    type foo =
+      | A 
+      | B [@@deriving jsonschema]
+    include
+      struct
+        let foo_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_result =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "A"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List [`Assoc [("const", (`String "B"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 1));
+                      ("maxItems", (`Int 1))]]))] in
+          match !ppx_eds with
+          | [] -> ppx_result
+          | ppx_defs ->
+              (match ppx_result with
+               | `Assoc ppx_pairs ->
+                   `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                     (Stdlib.List.filter
+                        (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                        ppx_pairs))
+               | other -> other)[@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    module X =
+      struct
+        type nonrec foo = foo[@@deriving jsonschema]
+        include
+          struct
+            let foo_jsonschema =
+              let ppx_eds = ref [] in
+              let ppx_body_foo = `Assoc [("$ref", (`String "#/$defs/foo"))] in
+              `Assoc
+                [("$defs", (`Assoc ([("foo", ppx_body_foo)] @ (!ppx_eds))));
+                ("$ref", (`String "#/$defs/foo"))][@@warning "-32-39"]
+          end[@@ocaml.doc "@inline"][@@merlin.hide ]
+      end
+  end

--- a/test/test.melange.expected.ml
+++ b/test/test.melange.expected.ml
@@ -4789,3 +4789,224 @@ module Nonrec_type_alias =
           end[@@ocaml.doc "@inline"][@@merlin.hide ]
       end
   end
+module Recursive_shapes =
+  struct
+    type a =
+      | A of b 
+    and b = int[@@deriving jsonschema]
+    include
+      struct
+        let a_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_body_a =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List
+                            [`Assoc [("const", (`String "A"))];
+                            `Assoc [("$ref", (`String "#/$defs/b"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 2));
+                       ("maxItems", (`Int 2))]]))] in
+          let ppx_body_b = int_jsonschema in
+          `Assoc
+            [("$defs",
+               (`Assoc ([("a", ppx_body_a); ("b", ppx_body_b)] @ (!ppx_eds))));
+            ("$ref", (`String "#/$defs/a"))][@@warning "-32-39"]
+        let b_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_body_a =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List
+                            [`Assoc [("const", (`String "A"))];
+                            `Assoc [("$ref", (`String "#/$defs/b"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 2));
+                       ("maxItems", (`Int 2))]]))] in
+          let ppx_body_b = int_jsonschema in
+          `Assoc
+            [("$defs",
+               (`Assoc ([("a", ppx_body_a); ("b", ppx_body_b)] @ (!ppx_eds))));
+            ("$ref", (`String "#/$defs/b"))][@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    type t =
+      | N 
+      | S of t [@@deriving jsonschema]
+    include
+      struct
+        let t_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_body_t =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "N"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "S"))];
+                           `Assoc [("$ref", (`String "#/$defs/t"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 2));
+                      ("maxItems", (`Int 2))]]))] in
+          `Assoc
+            [("$defs", (`Assoc ([("t", ppx_body_t)] @ (!ppx_eds))));
+            ("$ref", (`String "#/$defs/t"))][@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    type 'a lst =
+      | Nil 
+      | Cons of 'a * 'a lst [@@deriving jsonschema]
+    include
+      struct
+        let lst_jsonschema a =
+          let ppx_eds = ref [] in
+          let ppx_body_lst =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Nil"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Cons"))];
+                           a;
+                           `Assoc [("$ref", (`String "#/$defs/lst"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 3));
+                      ("maxItems", (`Int 3))]]))] in
+          `Assoc
+            [("$defs", (`Assoc ([("lst", ppx_body_lst)] @ (!ppx_eds))));
+            ("$ref", (`String "#/$defs/lst"))][@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    type 'a tree =
+      | Leaf of 'a 
+      | Node of 'a * 'a forest 
+    and 'a forest =
+      | Empty 
+      | Base of 'a tree * 'a forest [@@deriving jsonschema]
+    include
+      struct
+        let tree_jsonschema a =
+          let ppx_eds = ref [] in
+          let ppx_body_tree =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Leaf"))]; a]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 2));
+                       ("maxItems", (`Int 2))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Node"))];
+                           a;
+                           `Assoc [("$ref", (`String "#/$defs/forest"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 3));
+                      ("maxItems", (`Int 3))]]))] in
+          let ppx_body_forest =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Empty"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Base"))];
+                           `Assoc [("$ref", (`String "#/$defs/tree"))];
+                           `Assoc [("$ref", (`String "#/$defs/forest"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 3));
+                      ("maxItems", (`Int 3))]]))] in
+          `Assoc
+            [("$defs",
+               (`Assoc
+                  ([("tree", ppx_body_tree); ("forest", ppx_body_forest)] @
+                     (!ppx_eds))));
+            ("$ref", (`String "#/$defs/tree"))][@@warning "-32-39"]
+        let forest_jsonschema a =
+          let ppx_eds = ref [] in
+          let ppx_body_tree =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Leaf"))]; a]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 2));
+                       ("maxItems", (`Int 2))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Node"))];
+                           a;
+                           `Assoc [("$ref", (`String "#/$defs/forest"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 3));
+                      ("maxItems", (`Int 3))]]))] in
+          let ppx_body_forest =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Empty"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Base"))];
+                           `Assoc [("$ref", (`String "#/$defs/tree"))];
+                           `Assoc [("$ref", (`String "#/$defs/forest"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 3));
+                      ("maxItems", (`Int 3))]]))] in
+          `Assoc
+            [("$defs",
+               (`Assoc
+                  ([("tree", ppx_body_tree); ("forest", ppx_body_forest)] @
+                     (!ppx_eds))));
+            ("$ref", (`String "#/$defs/forest"))][@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+  end

--- a/test/test_schemas.expected.json
+++ b/test/test_schemas.expected.json
@@ -2457,8 +2457,22 @@
     },
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$defs": { "foo": { "$ref": "#/$defs/foo" } },
-      "$ref": "#/$defs/foo"
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "A" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "B" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        }
+      ]
     }
   ]
 }

--- a/test/test_schemas.expected.json
+++ b/test/test_schemas.expected.json
@@ -2473,6 +2473,194 @@
           "maxItems": 1
         }
       ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "a": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "A" }, { "$ref": "#/$defs/b" } ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            }
+          ]
+        },
+        "b": { "type": "integer" }
+      },
+      "$ref": "#/$defs/a"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "a": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "A" }, { "$ref": "#/$defs/b" } ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            }
+          ]
+        },
+        "b": { "type": "integer" }
+      },
+      "$ref": "#/$defs/b"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "t": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "N" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "S" }, { "$ref": "#/$defs/t" } ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/t"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "lst": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Nil" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "Cons" },
+                { "type": "integer" },
+                { "$ref": "#/$defs/lst" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 3,
+              "maxItems": 3
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/lst"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "tree": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Leaf" }, { "type": "string" } ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "Node" },
+                { "type": "string" },
+                { "$ref": "#/$defs/forest" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 3,
+              "maxItems": 3
+            }
+          ]
+        },
+        "forest": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Empty" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "Base" },
+                { "$ref": "#/$defs/tree" },
+                { "$ref": "#/$defs/forest" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 3,
+              "maxItems": 3
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/tree"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "tree": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Leaf" }, { "type": "string" } ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "Node" },
+                { "type": "string" },
+                { "$ref": "#/$defs/forest" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 3,
+              "maxItems": 3
+            }
+          ]
+        },
+        "forest": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Empty" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "Base" },
+                { "$ref": "#/$defs/tree" },
+                { "$ref": "#/$defs/forest" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 3,
+              "maxItems": 3
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/forest"
     }
   ]
 }

--- a/test/test_schemas.expected.json
+++ b/test/test_schemas.expected.json
@@ -2435,6 +2435,30 @@
           "maxItems": 2
         }
       ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "A" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "B" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": { "foo": { "$ref": "#/$defs/foo" } },
+      "$ref": "#/$defs/foo"
     }
   ]
 }


### PR DESCRIPTION
`type nonrec foo = foo [@@deriving jsonschema]` inside a module should derive from the outer `foo`, not treat the alias as a recursive self-reference.

- Honor the OCaml `rec_flag` in the deriver when deciding which type names are recursive.
- Add native/Melange shared test cases for the nested `type nonrec` alias.

The first commit has a test with the original behavior. And the second commit a fix to respect `nonrec`
