### PR TITLE
docs: document compact_variants and finish attrs example

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,34 @@ type t =
 { "anyOf": [ { "const": "type" }, { "const": "class" } ] }
 ```
 
+A `[@@jsonschema.compact_variants]` attribute offers a middle ground. Unlike `~variant_as_string`, it only collapses payload-free constructors to a bare `{ "const": "..." }`; constructors with arguments keep the standard array encoding. It therefore supports payloads.
+
+```ocaml
+type t =
+| A
+| B
+| C of int
+[@@deriving jsonschema] [@@jsonschema.compact_variants]
+```
+
+```json
+{
+  "anyOf": [
+    { "const": "A" },
+    { "const": "B" },
+    {
+      "type": "array",
+      "prefixItems": [ { "const": "C" }, { "type": "integer" } ],
+      "unevaluatedItems": false,
+      "minItems": 2,
+      "maxItems": 2
+    }
+  ]
+}
+```
+
+This attribute only affects regular variants. On polymorphic variants it is currently ignored, and the default array encoding is used.
+
 #### Records
 
 Records are converted to `{ "type": "object", "properties": {...}, "required": [...], "additionalProperties": false }`.
@@ -996,4 +1024,21 @@ It can also be applied directly to a core type in a variant payload:
 type t =
   | Score of (int [@jsonschema.attrs { maximum = 100; minimum = 0; description = "Percentage" }])
 [@@deriving jsonschema]
+```
+
+```json
+{
+  "anyOf": [
+    {
+      "type": "array",
+      "prefixItems": [
+        { "const": "Score" },
+        { "minimum": 0, "maximum": 100, "description": "Percentage", "type": "integer" }
+      ],
+      "unevaluatedItems": false,
+      "minItems": 2,
+      "maxItems": 2
+    }
+  ]
+}
 ```

--- a/README.md
+++ b/README.md
@@ -538,7 +538,32 @@ type t =
 }
 ```
 
-This attribute only affects regular variants. On polymorphic variants it is currently ignored, and the default array encoding is used.
+It works the same way on polymorphic variants: payload-free constructors collapse to `{ "const": "..." }`, while constructors with arguments keep the array encoding.
+
+```ocaml
+type t =
+[ `Aaa
+| `Bbb
+| `Ccc of int
+]
+[@@deriving jsonschema] [@@jsonschema.compact_variants]
+```
+
+```json
+{
+  "anyOf": [
+    { "const": "Aaa" },
+    { "const": "Bbb" },
+    {
+      "type": "array",
+      "prefixItems": [ { "const": "Ccc" }, { "type": "integer" } ],
+      "unevaluatedItems": false,
+      "minItems": 2,
+      "maxItems": 2
+    }
+  ]
+}
+```
 
 #### Records
 


### PR DESCRIPTION
The README fell behind recent changes. This adds the missing documentation:

- `[@@jsonschema.compact_variants]` (added in #42) had no docs at all. Adds a section with an example and its generated schema, contrasting it with `~variant_as_string` (it supports payloads).
- The `[@jsonschema.attrs]` variant-payload example was truncated: it showed OCaml input with no resulting schema. Adds the missing JSON block.
