### PR TITLE
Support compact_variants on polymorphic variants

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # 0.0.7
 
-- add `[@@jsonschema.compact_variants]` attribute on variant type declarations to render unit constructors as plain string constants (`{ "const": "Name" }`) instead of single-element tuple arrays; constructors with arguments keep the tuple array encoding
+- add `[@@jsonschema.compact_variants]` attribute on variant type declarations to render unit constructors as plain string constants (`{ "const": "Name" }`) instead of single-element tuple arrays; constructors with arguments keep the tuple array encoding; also supported on polymorphic variant type declarations
 - add `[@@jsonschema.format]` attribute to add a format to a type or a field; now also supported on core types (e.g. variant payloads: `A of (string[@jsonschema.format "date-time"])`); validated to only apply to `string` and `bytes` types
 - add `[@@jsonschema.description]` attribute to add a description to a type or a field; now also supported on core types (e.g. variant payloads and inline type annotations) and on polymorphic variant tags
 - add `~ocaml_doc` flag on `[@@deriving jsonschema]` to use `ocaml.doc` attributes (i.e. `(** ... *)` doc comments) as a fallback for `[@@jsonschema.description]` when the explicit annotation is absent; off by default

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
+# Unreleased
+
+- add `[@@jsonschema.compact_variants]` support on polymorphic variant type declarations
+
 # 0.0.7
 
-- add `[@@jsonschema.compact_variants]` attribute on variant type declarations to render unit constructors as plain string constants (`{ "const": "Name" }`) instead of single-element tuple arrays; constructors with arguments keep the tuple array encoding; also supported on polymorphic variant type declarations
+- add `[@@jsonschema.compact_variants]` attribute on variant type declarations to render unit constructors as plain string constants (`{ "const": "Name" }`) instead of single-element tuple arrays; constructors with arguments keep the tuple array encoding
 - add `[@@jsonschema.format]` attribute to add a format to a type or a field; now also supported on core types (e.g. variant payloads: `A of (string[@jsonschema.format "date-time"])`); validated to only apply to `string` and `bytes` types
 - add `[@@jsonschema.description]` attribute to add a description to a type or a field; now also supported on core types (e.g. variant payloads and inline type annotations) and on polymorphic variant tags
 - add `~ocaml_doc` flag on `[@@deriving jsonschema]` to use `ocaml.doc` attributes (i.e. `(** ... *)` doc comments) as a fallback for `[@@jsonschema.description]` when the explicit annotation is absent; off by default

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -18,7 +18,7 @@ let wrap_type_params ~loc ?(prefix = "") params body =
 
 (* schema_of_core_type and schema_of_poly_variant are mutually recursive.
    All other functions only call downward and use plain let. *)
-let rec schema_of_core_type ~(config : Attrs.config) ?(recursive_types = []) core_type =
+let rec schema_of_core_type ~(config : Attrs.config) ?(recursive_types = []) ?(compact_variants = false) core_type =
   let loc = core_type.ptyp_loc in
   let schema, is_rec =
     match core_type with
@@ -88,7 +88,7 @@ let rec schema_of_core_type ~(config : Attrs.config) ?(recursive_types = []) cor
       let ts = List.map fst results in
       let is_rec = List.exists snd results in
       Schema.tuple ~loc ts, is_rec
-    | Ptyp_variant (row_fields, _, _) -> schema_of_poly_variant ~loc ~config ~recursive_types row_fields
+    | Ptyp_variant (row_fields, _, _) -> schema_of_poly_variant ~loc ~config ~recursive_types ~compact_variants row_fields
     | _ ->
       let msg = Format.asprintf "ppx_deriving_jsonschema: unsupported type %a" Astlib.Pprintast.core_type core_type in
       [%expr [%ocaml.error [%e estring ~loc msg]]], false
@@ -103,7 +103,7 @@ let rec schema_of_core_type ~(config : Attrs.config) ?(recursive_types = []) cor
   in
   schema, is_rec
 
-and schema_of_poly_variant ~loc ~(config : Attrs.config) ?(recursive_types = []) row_fields =
+and schema_of_poly_variant ~loc ~(config : Attrs.config) ?(recursive_types = []) ?(compact_variants = false) row_fields =
   let constrs, is_rec =
     List.fold_left
       (fun (constrs, is_rec) row_field ->
@@ -145,7 +145,7 @@ and schema_of_poly_variant ~loc ~(config : Attrs.config) ?(recursive_types = [])
       ([], false) row_fields
   in
   let constrs = List.rev constrs in
-  let v = Schema.variants ~loc ~as_string:config.Attrs.variant_as_string constrs in
+  let v = Schema.variants ~loc ~as_string:config.Attrs.variant_as_string ~compact_variants constrs in
   v, is_rec
 
 (* Returns (schema_expression, is_recursive) *)
@@ -248,7 +248,8 @@ let schema_of_type_decl ~loc ~(config : Attrs.config) ~recursive_types type_decl
   | Ptype_abstract ->
     (match type_decl.ptype_manifest with
     | Some core_type ->
-      let schema, is_rec = schema_of_core_type ~config ~recursive_types core_type in
+      let compact_variants = Attribute.has_flag Attrs.jsonschema_td_compact_variants type_decl in
+      let schema, is_rec = schema_of_core_type ~config ~recursive_types ~compact_variants core_type in
       type_name, schema, is_rec, params, ""
     | None ->
       let msg = "ppx_deriving_jsonschema: abstract type without manifest" in

--- a/src/ppx_deriving_jsonschema.ml
+++ b/src/ppx_deriving_jsonschema.ml
@@ -88,7 +88,8 @@ let rec schema_of_core_type ~(config : Attrs.config) ?(recursive_types = []) ?(c
       let ts = List.map fst results in
       let is_rec = List.exists snd results in
       Schema.tuple ~loc ts, is_rec
-    | Ptyp_variant (row_fields, _, _) -> schema_of_poly_variant ~loc ~config ~recursive_types ~compact_variants row_fields
+    | Ptyp_variant (row_fields, _, _) ->
+      schema_of_poly_variant ~loc ~config ~recursive_types ~compact_variants row_fields
     | _ ->
       let msg = Format.asprintf "ppx_deriving_jsonschema: unsupported type %a" Astlib.Pprintast.core_type core_type in
       [%expr [%ocaml.error [%e estring ~loc msg]]], false
@@ -103,7 +104,8 @@ let rec schema_of_core_type ~(config : Attrs.config) ?(recursive_types = []) ?(c
   in
   schema, is_rec
 
-and schema_of_poly_variant ~loc ~(config : Attrs.config) ?(recursive_types = []) ?(compact_variants = false) row_fields =
+and schema_of_poly_variant ~loc ~(config : Attrs.config) ?(recursive_types = []) ?(compact_variants = false) row_fields
+    =
   let constrs, is_rec =
     List.fold_left
       (fun (constrs, is_rec) row_field ->

--- a/test/shared/cases.ml
+++ b/test/shared/cases.ml
@@ -471,6 +471,12 @@ type compact_variants =
   | B
   | C of int
 [@@deriving jsonschema] [@@jsonschema.compact_variants]
+type compact_poly_variants =
+  [ `Aaa
+  | `Bbb
+  | `Ccc of int
+  ]
+[@@deriving jsonschema] [@@jsonschema.compact_variants]
 
 (* Regression test: PPX-generated code must not depend on user-scope [List]/[String]/[Array].
    Shadowing them with empty modules makes any unqualified reference (e.g. [List.filter])

--- a/test/shared/generate_schemas_cases.ml
+++ b/test/shared/generate_schemas_cases.ml
@@ -115,6 +115,7 @@ let schemas =
     Ppx_deriving_jsonschema_runtime.json_schema default_with_module_type_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema outer_default_record_with_option_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema compact_variants_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema compact_poly_variants_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema Nonrec_type_alias.foo_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema Nonrec_type_alias.X.foo_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema Recursive_shapes.a_jsonschema;

--- a/test/test.expected.ml
+++ b/test/test.expected.ml
@@ -4471,6 +4471,38 @@ include
                     ppx_pairs))
            | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type compact_poly_variants = [ `Aaa  | `Bbb  | `Ccc of int ][@@deriving
+                                                              jsonschema]
+[@@jsonschema.compact_variants ]
+include
+  struct
+    let compact_poly_variants_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "Aaa"))];
+                `Assoc [("const", (`String "Bbb"))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Ccc"))]; int_jsonschema]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 module Generated_code_must_qualify_stdlib =
   struct
     module List = struct  end
@@ -4680,7 +4712,7 @@ module Generated_code_must_qualify_stdlib =
           let ppx_result =
             match wrapper_with_shadowed_stdlib_jsonschema int_jsonschema with
             | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                `Assoc (("$id", (`String "file://shared/cases.ml:508")) ::
+                `Assoc (("$id", (`String "file://shared/cases.ml:514")) ::
                   (Stdlib.List.filter
                      (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
             | other -> other in
@@ -4744,7 +4776,7 @@ module Nonrec_type_alias =
               let ppx_result =
                 match foo_jsonschema with
                 | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                    `Assoc (("$id", (`String "file://shared/cases.ml:518"))
+                    `Assoc (("$id", (`String "file://shared/cases.ml:524"))
                       ::
                       (Stdlib.List.filter
                          (fun (k, _) -> not (Stdlib.String.equal k "$id"))

--- a/test/test.melange.expected.ml
+++ b/test/test.melange.expected.ml
@@ -4497,6 +4497,38 @@ include
                     ppx_pairs))
            | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type compact_poly_variants = [ `Aaa  | `Bbb  | `Ccc of int ][@@deriving
+                                                              jsonschema]
+[@@jsonschema.compact_variants ]
+include
+  struct
+    let compact_poly_variants_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "Aaa"))];
+                `Assoc [("const", (`String "Bbb"))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Ccc"))]; int_jsonschema]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 module Generated_code_must_qualify_stdlib =
   struct
     module List = struct  end
@@ -4706,7 +4738,7 @@ module Generated_code_must_qualify_stdlib =
           let ppx_result =
             match wrapper_with_shadowed_stdlib_jsonschema int_jsonschema with
             | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                `Assoc (("$id", (`String "file://shared/cases.ml:508")) ::
+                `Assoc (("$id", (`String "file://shared/cases.ml:514")) ::
                   (Stdlib.List.filter
                      (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
             | other -> other in
@@ -4770,7 +4802,7 @@ module Nonrec_type_alias =
               let ppx_result =
                 match foo_jsonschema with
                 | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                    `Assoc (("$id", (`String "file://shared/cases.ml:518"))
+                    `Assoc (("$id", (`String "file://shared/cases.ml:524"))
                       ::
                       (Stdlib.List.filter
                          (fun (k, _) -> not (Stdlib.String.equal k "$id"))

--- a/test/test_schemas.expected.json
+++ b/test/test_schemas.expected.json
@@ -2439,6 +2439,20 @@
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "anyOf": [
+        { "const": "Aaa" },
+        { "const": "Bbb" },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "Ccc" }, { "type": "integer" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
         {
           "type": "array",
           "prefixItems": [ { "const": "A" } ],


### PR DESCRIPTION
`[@@jsonschema.compact_variants]` was only honored for regular variant type declarations (`Ptype_variant`). Polymorphic variants are abstract types with a `Ptyp_variant` manifest, and `schema_of_poly_variant` never received the flag, so no-argument tags were always rendered as single-element tuple arrays even when the attribute was set.
